### PR TITLE
Add alternate configuration method using Uri instead of scheme+host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 .idea/*
 !.idea/codeStyles
+!.idea/inspectionProfiles
 .DS_Store
 build
 captures

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="MemberVisibilityCanBePrivate" enabled="true" level="INFO" enabled_by_default="true">
+      <scope name="Project Source Files" level="INFORMATION" enabled="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/sdk/src/main/java/com/stytch/sdk/Stytch.kt
+++ b/sdk/src/main/java/com/stytch/sdk/Stytch.kt
@@ -14,12 +14,19 @@ public class Stytch private constructor() {
     public var listener: StytchListener? = null
 
     public fun configure(projectID: String, secret: String, scheme: String, host: String) {
-        config = StytchConfig.Builder()
-            .withAuth(projectID, secret)
-            .withDeepLinkScheme(scheme)
-            .withDeepLinkHost(host)
-            .build()
+        config = StytchConfig(
+            projectID = projectID,
+            secret = secret,
+            deeplinkScheme = scheme,
+            deeplinkHost = host,
+        )
         flowManager = StytchFlowManager()
+    }
+
+    public fun configure(projectID: String, secret: String, deeplink: Uri) {
+        val scheme = deeplink.scheme ?: throw Exception("Provided deeplink Uri has a null scheme")
+        val host = deeplink.host ?: throw Exception("Provided deeplink Uri has a null host")
+        configure(projectID, secret, scheme, host)
     }
 
     public fun login(email: String) {
@@ -38,7 +45,7 @@ public class Stytch private constructor() {
 
     public fun handleDeepLink(uri: Uri): Boolean {
         checkIfConfigured()
-        if (uri.scheme == config?.deepLinkScheme && uri.host == config?.deepLinkHost) {
+        if (uri.scheme == config?.deeplinkScheme && uri.host == config?.deeplinkHost) {
             uri.path?.let { path ->
 //                TODO: handle different deep link paths
                 when {
@@ -82,63 +89,14 @@ public class Stytch private constructor() {
 
 }
 
-internal class StytchConfig private constructor(
-    val projectID: String,
-    val secret: String,
-    val deepLinkScheme: String,
-    val deepLinkHost: String,
-    val verifyEmail: Boolean,
-    var uiCustomization: StytchUICustomization,
-) {
-
-    public class Builder {
-
-        private var deepLinkScheme: String = "app"
-        private var deepLinkHost: String = "stytch.com"
-        private var uiCustomization: StytchUICustomization = StytchUICustomization()
-        private var verifyEmail: Boolean = false
-        private var projectID: String = ""
-        private var secret: String = ""
-
-        fun withDeepLinkScheme(scheme: String): Builder {
-            deepLinkScheme = scheme
-            return this
-        }
-
-        fun withDeepLinkHost(host: String): Builder {
-            deepLinkHost = host
-            return this
-        }
-
-        fun withCustomization(UICustomization: StytchUICustomization): Builder {
-            this.uiCustomization = UICustomization
-            return this
-        }
-
-        fun withVerifyEmail(verifyEmail: Boolean): Builder {
-            this.verifyEmail = verifyEmail
-            return this
-        }
-
-        fun withAuth(projectID: String, secret: String): Builder {
-            this.projectID = projectID
-            this.secret = secret
-            return this
-        }
-
-        fun build(): StytchConfig {
-            return StytchConfig(
-                projectID,
-                secret,
-                deepLinkScheme,
-                deepLinkHost,
-                verifyEmail,
-                uiCustomization,
-            )
-        }
-    }
-
-}
+internal class StytchConfig(
+    val projectID: String = "",
+    val secret: String = "",
+    val deeplinkScheme: String = "https",
+    val deeplinkHost: String = "test.stytch.com",
+    val verifyEmail: Boolean = false,
+    var uiCustomization: StytchUICustomization = StytchUICustomization(),
+)
 
 public enum class StytchEnvironment {
     LIVE,

--- a/sdk/src/main/java/com/stytch/sdk/api/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/api/StytchApi.kt
@@ -29,7 +29,7 @@ internal class StytchApi {
         return service.sendMagicLink(
             SendMagicLinkRequest(
                 email,
-                "${Stytch.instance.config?.deepLinkScheme}://${Stytch.instance.config?.deepLinkHost}/magic_link",
+                "${Stytch.instance.config?.deeplinkScheme}://${Stytch.instance.config?.deeplinkHost}/magic_link",
                 60
             )
         ).execute()
@@ -202,5 +202,5 @@ internal object ServiceGenerator {
 }
 
 internal fun String.deepLink(): String {
-    return "${Stytch.instance.config?.deepLinkScheme}://${Stytch.instance.config?.deepLinkHost}/$this"
+    return "${Stytch.instance.config?.deeplinkScheme}://${Stytch.instance.config?.deeplinkHost}/$this"
 }


### PR DESCRIPTION
Linear Ticket: [MOB-20](https://linear.app/stytch/issue/MOB-20)

## Changes:

1. Add alternate configuration method using Uri object instead of scheme string + host string

1. Removed unneeded Builder class for `StytchConfig`

1. Added project-level inspection profile settings for Android Studio (to not warn about 'unused' elements of the public interface)
