### PR TITLE
MOB-38 Update to use create_user_as_pending flag instead of deprecated login_or_invite endpoint

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/Stytch.kt
+++ b/sdk/src/main/java/com/stytch/sdk/Stytch.kt
@@ -9,8 +9,6 @@ public class Stytch private constructor() {
 
     public var environment: StytchEnvironment = StytchEnvironment.LIVE
 
-    public var loginMethod: StytchLoginMethod = StytchLoginMethod.LoginOrSignUp
-
     public var listener: StytchListener? = null
 
     public fun configure(projectID: String, secret: String, scheme: String, host: String) {
@@ -22,13 +20,13 @@ public class Stytch private constructor() {
         flowManager = StytchFlowManager()
     }
 
-    public fun login(email: String) {
+    public fun login(email: String, createUserAsPending: Boolean = true) {
         checkIfConfigured()
         if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
             listener?.onFailure(StytchError.InvalidEmail)
             return
         }
-        flowManager.login(email)
+        flowManager.login(email, createUserAsPending)
     }
 
     private fun resendEmailVerification() {
@@ -170,11 +168,6 @@ public class StytchEvent private constructor(
             return StytchEvent(USER_EVENT, false, userId)
         }
     }
-}
-
-public enum class StytchLoginMethod {
-    LoginOrSignUp,
-    LoginOrInvite,
 }
 
 public data class StytchResult(

--- a/sdk/src/main/java/com/stytch/sdk/StytchFlowManager.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchFlowManager.kt
@@ -12,12 +12,14 @@ internal class StytchFlowManager {
     private var email: String = ""
     private var emailId: String = ""
     private var userId: String = ""
+    private var createUserAsPending: Boolean = true
 
     private var newUserCreated: Boolean = false
 
-    fun login(email: String) {
+    fun login(email: String, createUserAsPending: Boolean) {
         newUserCreated = false
         this.email = email
+        this.createUserAsPending = createUserAsPending
         GlobalScope.launch(Dispatchers.IO) {
             login()
         }
@@ -57,10 +59,7 @@ internal class StytchFlowManager {
     private suspend fun login() {
         try {
 
-            val response = when (Stytch.instance.loginMethod) {
-                StytchLoginMethod.LoginOrSignUp -> StytchApi.instance.loginOrSignUp(email)
-                StytchLoginMethod.LoginOrInvite -> StytchApi.instance.loginOrInvite(email)
-            }
+            val response = StytchApi.instance.loginOrSignUp(email, createUserAsPending)
 
             if (response.body() == null)
                 throw UnknownException()

--- a/sdk/src/main/java/com/stytch/sdk/api/Requests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/api/Requests.kt
@@ -22,20 +22,13 @@ public class CreateUserRequest(
 
 public class DeleteUserRequest : BasicRequest()
 
-public class LoginOrInviteRequest(
-    @SerializedName("email") public val email: String,
-    @SerializedName("login_magic_link_url") public val login_magic_link_url: String,
-    @SerializedName("invite_magic_link_url") public val invite_magic_link_url: String,
-    @SerializedName("login_expiration_minutes") public val login_expiration_minutes: Long,
-    @SerializedName("invite_expiration_minutes") public val invite_expiration_minutes: Long,
-) : BasicRequest()
-
 public class LoginOrSignUpRequest(
     @SerializedName("email") public val email: String,
     @SerializedName("login_magic_link_url") public val login_magic_link_url: String,
     @SerializedName("signup_magic_link_url") public val signup_magic_link_url: String,
     @SerializedName("login_expiration_minutes") public val login_expiration_minutes: Long,
     @SerializedName("signup_expiration_minutes") public val signup_expiration_minutes: Long,
+    @SerializedName("create_user_as_pending") public val create_user_as_pending: Boolean,
 ) : BasicRequest()
 
 public class SendEmailVerificationRequest() : BasicRequest()

--- a/sdk/src/main/java/com/stytch/sdk/api/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/api/StytchApi.kt
@@ -35,22 +35,9 @@ internal class StytchApi {
         ).execute()
     }
 
-    fun loginOrInvite(
-        email: String,
-    ): Response<SendMagicLingResponse> {
-        return service.loginOrInvite(
-            LoginOrInviteRequest(
-                email,
-                Constants.LOGIN_PATH.deepLink(),
-                Constants.INVITE_PATH.deepLink(),
-                Constants.LOGIN_EXPIRATION,
-                Constants.INVITE_EXPIRATION
-            )
-        ).execute()
-    }
-
     fun loginOrSignUp(
         email: String,
+        createUserAsPending: Boolean,
     ): Response<SendMagicLingResponse> {
         return service.loginOrSignUp(
             LoginOrSignUpRequest(
@@ -58,7 +45,8 @@ internal class StytchApi {
                 Constants.LOGIN_PATH.deepLink(),
                 Constants.SIGN_UP_PATH.deepLink(),
                 Constants.LOGIN_EXPIRATION,
-                Constants.SIGNUP_EXPIRATION
+                Constants.SIGNUP_EXPIRATION,
+                createUserAsPending,
             )
         ).execute()
     }

--- a/sdk/src/main/java/com/stytch/sdk/api/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/api/StytchApiService.kt
@@ -12,11 +12,6 @@ internal interface StytchApiService {
         @Body request: SendMagicLinkRequest,
     ): Call<SendMagicLingResponse>
 
-    @POST("magic_links/login_or_invite")
-    fun loginOrInvite(
-        @Body request: LoginOrInviteRequest,
-    ): Call<SendMagicLingResponse>
-
     @POST("magic_links/login_or_create")
     fun loginOrSignUp(
         @Body request: LoginOrSignUpRequest,


### PR DESCRIPTION
Linear Ticket: [MOB-38](https://linear.app/stytch/issue/MOB-38)
