### PR TITLE
Fix syntax issue in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
-      with:
-        java-version: 8
+        with:
+          java-version: 8
 
       - name: Release build
         run: ./gradlew :sdk:assembleRelease

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.4.0'
+  PUBLISH_VERSION = '0.4.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 


### PR DESCRIPTION
There was a syntax/indentation issue in my workflow file that prevented GitHub Actions release integration from working. This fixes that, and updates the version to 0.4.1.