### PR TITLE
Remove user created from login or create response

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This SDK supports Android API level 21 and above ([distribution stats](https://d
 
 Add the Stytch dependency to your app/build.gradle file:
 
-`implementation 'com.stytch.sdk:sdk:0.3.0'`
+`implementation 'com.stytch.sdk:sdk:0.4.2'`
 
 ## Getting Started
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.4.1'
+  PUBLISH_VERSION = '0.4.2'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchApi.kt
@@ -198,7 +198,6 @@ public object StytchResponseTypes {
         val request_id: String,
         val user_id: String,
         val email_id: String,
-        val user_created: Boolean,
     )
 
     @JsonClass(generateAdapter = true)


### PR DESCRIPTION
Grace is removing the `user_created` parameter from the login_or_create endpoint response. I don't use this, however, I realized I still need to remove it from the response data structure for it to deserialize correctly. This PR makes that change and updates the patch version number.