### PR TITLE
Condense and simplify biometric availability checks

### DIFF
--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/ui/BiometricsScreen.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/ui/BiometricsScreen.kt
@@ -21,8 +21,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.stytch.exampleapp.BiometricsViewModel
 import com.stytch.exampleapp.R
-import com.stytch.sdk.consumer.biometrics.BiometricAvailability
 import com.stytch.sdk.consumer.StytchClient
+import com.stytch.sdk.consumer.biometrics.BiometricAvailability
 
 @Composable
 fun BiometricsScreen(navController: NavController) {
@@ -31,7 +31,7 @@ fun BiometricsScreen(navController: NavController) {
     val responseState = viewModel.currentResponse.collectAsState()
     val context = LocalContext.current as FragmentActivity
     val biometricAvailability = StytchClient.biometrics.areBiometricsAvailable(context, true)
-    val biometricsAreAvailable = biometricAvailability == BiometricAvailability.BIOMETRIC_SUCCESS
+    val biometricsAreAvailable = biometricAvailability !is BiometricAvailability.Unavailable
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -60,12 +60,13 @@ fun BiometricsScreen(navController: NavController) {
                 onClick = { viewModel.removeRegistration() }
             )
         } else {
+            val unavailable = biometricAvailability as BiometricAvailability.Unavailable
             Text(
-                text = stringResource(id = R.string.biometrics_unavailable, biometricAvailability.message),
+                text = stringResource(id = R.string.biometrics_unavailable, unavailable.reason.message),
                 modifier = Modifier.padding(8.dp)
             )
             if (
-                (biometricAvailability == BiometricAvailability.BIOMETRIC_ERROR_NONE_ENROLLED) &&
+                (unavailable.reason == BiometricAvailability.Unavailable.Reason.BIOMETRIC_ERROR_NONE_ENROLLED) &&
                 (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
             ) {
                 StytchButton(

--- a/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
@@ -1,55 +1,97 @@
 package com.stytch.sdk.consumer.biometrics
 
+import androidx.biometric.BiometricManager
+
 /**
  * Wrapper around BiometricManager results to provide friendly messaging for developers
  * @property message A string explaining the BiometricAvailability status
  */
-public enum class BiometricAvailability(public val message: String) {
-    /**
-     * Status indicating that the biometric key failed to generate. Biometrics cannot proceed.
-     */
-    BIOMETRIC_KEY_GENERATION_FAILED("Biometric key generation failed."),
+public sealed class BiometricAvailability {
 
     /**
-     * Status indicating that all biometrics checks have passed, and you can proceed.
+     * Status indicating that biometrics are not available on this device for some reason
+     * @param reason a reason why biometrics are unavailable
      */
-    BIOMETRIC_SUCCESS("Biometrics are ready to be used."),
+    public data class Unavailable(public val reason: Reason) : BiometricAvailability() {
+        /**
+         * An enum describing why biometrics are unavailable on this device
+         */
+        public enum class Reason(public val message: String) {
+            /**
+             * Status indicating that the biometric key failed to generate. Biometrics cannot proceed.
+             */
+            BIOMETRIC_KEY_GENERATION_FAILED("Biometric key generation failed."),
+
+            /**
+             * Status indicating that this device has no biometric hardware.
+             */
+            BIOMETRIC_ERROR_NO_HARDWARE("No biometric features available on this device."),
+
+            /**
+             * Status indicating that biometric hardware features are currently unavailable.
+             */
+            BIOMETRIC_ERROR_HW_UNAVAILABLE("Biometric features are currently unavailable."),
+
+            /**
+             * Status indicating that there are no biometrics currently enrolled on device.
+             */
+            BIOMETRIC_ERROR_NONE_ENROLLED("No biometrics currently enrolled on device."),
+
+            /**
+             * Status indicating that a security vulnerability has been discovered with one or more hardware sensors.
+             */
+            BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED(
+                "A security vulnerability has been discovered with one or more hardware sensors."
+            ),
+
+            /**
+             * Status indicating that the requested options are incompatible with the current Android version.
+             */
+            BIOMETRIC_ERROR_UNSUPPORTED(
+                "The requested biometrics options are incompatible with the current Android version."
+            ),
+
+            /**
+             * Status indicating that we do not know if biometrics are supported on this device.
+             */
+            BIOMETRIC_STATUS_UNKNOWN("Unable to determine whether the user can authenticate."),
+        }
+
+        internal companion object {
+            fun fromReason(reason: Int) = Unavailable(
+                when (reason) {
+                    BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
+                        Reason.BIOMETRIC_ERROR_NO_HARDWARE
+                    BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE ->
+                        Reason.BIOMETRIC_ERROR_HW_UNAVAILABLE
+                    BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+                        Reason.BIOMETRIC_ERROR_NONE_ENROLLED
+                    BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+                        Reason.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED
+                    BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED ->
+                        Reason.BIOMETRIC_ERROR_UNSUPPORTED
+                    BiometricManager.BIOMETRIC_STATUS_UNKNOWN ->
+                        Reason.BIOMETRIC_STATUS_UNKNOWN
+                    else ->
+                        Reason.BIOMETRIC_STATUS_UNKNOWN
+                }
+            )
+        }
+    }
 
     /**
-     * Status indicating that this device has no biometric hardware.
+     * Status indicating that the biometric key has been revoked. Usually this means the user has added a new
+     * biometric or deleted all existing biometrics.
      */
-    BIOMETRIC_ERROR_NO_HARDWARE("No biometric features available on this device."),
+    public object RegistrationRevoked : BiometricAvailability()
 
     /**
-     * Status indicating that biometric hardware features are currently unavailable.
+     * Status indicating that biometrics are available, but no registrations have been made yet
      */
-    BIOMETRIC_ERROR_HW_UNAVAILABLE("Biometric features are currently unavailable."),
+    public object AvailableNoRegistrations : BiometricAvailability()
 
     /**
-     * Status indicating that there are no biometrics currently enrolled on device.
+     * Status indicating that biometrics are available and there is already a biometric registration on device
      */
-    BIOMETRIC_ERROR_NONE_ENROLLED("No biometrics currently enrolled on device."),
-
-    /**
-     * Status indicating that a security vulnerability has been discovered with one or more hardware sensors.
-     */
-    BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED(
-        "A security vulnerability has been discovered with one or more hardware sensors."
-    ),
-
-    /**
-     * Status indicating that the requested options are incompatible with the current Android version.
-     */
-    BIOMETRIC_ERROR_UNSUPPORTED("The requested biometrics options are incompatible with the current Android version."),
-
-    /**
-     * Status indicating that we do not know if biometrics are supported on this device.
-     */
-    BIOMETRIC_STATUS_UNKNOWN("Unable to determine whether the user can authenticate."),
-
-    /**
-     * Status indicating that the biometric key has been revoked. Usually this means the user has added a new biometric
-     * or deleted all existing biometrics.
-     */
-    BIOMETRICS_REVOKED("Biometric key was revoked. Must re-register a biometric authentication.")
+    public object AvailableRegistered : BiometricAvailability()
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProvider.kt
@@ -17,7 +17,7 @@ internal interface BiometricsProvider {
         allowedAuthenticators: Int,
     ): Cipher
 
-    fun areBiometricsAvailable(context: FragmentActivity, allowedAuthenticators: Int): BiometricAvailability
+    fun areBiometricsAvailable(context: FragmentActivity, allowedAuthenticators: Int): Int
 
     fun deleteSecretKey()
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProviderImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProviderImpl.kt
@@ -126,19 +126,8 @@ internal class BiometricsProviderImpl : BiometricsProvider {
         return showBiometricPrompt(context, promptData, cipher, allowedAuthenticators)
     }
 
-    override fun areBiometricsAvailable(context: FragmentActivity, allowedAuthenticators: Int): BiometricAvailability {
-        val biometricManager = BiometricManager.from(context)
-        return when (biometricManager.canAuthenticate(allowedAuthenticators)) {
-            BiometricManager.BIOMETRIC_SUCCESS -> BiometricAvailability.BIOMETRIC_SUCCESS
-            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> BiometricAvailability.BIOMETRIC_ERROR_NO_HARDWARE
-            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> BiometricAvailability.BIOMETRIC_ERROR_HW_UNAVAILABLE
-            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> BiometricAvailability.BIOMETRIC_ERROR_NONE_ENROLLED
-            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
-                BiometricAvailability.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED
-            BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> BiometricAvailability.BIOMETRIC_ERROR_UNSUPPORTED
-            BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> BiometricAvailability.BIOMETRIC_STATUS_UNKNOWN
-            else -> BiometricAvailability.BIOMETRIC_STATUS_UNKNOWN
-        }
+    override fun areBiometricsAvailable(context: FragmentActivity, allowedAuthenticators: Int): Int {
+        return BiometricManager.from(context).canAuthenticate(allowedAuthenticators)
     }
 
     override fun deleteSecretKey() {

--- a/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.consumer.biometrics
 
+import androidx.biometric.BiometricManager
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
@@ -133,7 +134,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         every { mockStorageHelper.deletePreference(any()) } returns true
         every { mockSessionStorage.ensureSessionIsValidOrThrow() } just runs
         coEvery {
@@ -306,7 +307,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any(), any())
@@ -322,7 +323,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any(), any())
@@ -341,7 +342,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any(), any())
@@ -364,7 +365,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any(), any())
@@ -393,7 +394,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any(), any())
@@ -432,7 +433,7 @@ internal class BiometricsImplTest {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        } returns BiometricManager.BIOMETRIC_SUCCESS
         assert(impl.isRegistrationAvailable(mockk(relaxed = true)))
         verify { mockStorageHelper.preferenceExists(LAST_USED_BIOMETRIC_REGISTRATION_ID) }
         verify { mockStorageHelper.preferenceExists(PRIVATE_KEY_KEY) }
@@ -470,13 +471,19 @@ internal class BiometricsImplTest {
     }
 
     @Test
-    fun `areBiometricsAvailable delegates to BiometricsProvider`() {
+    fun `areBiometricsAvailable delegates to BiometricsProvider and produces correct registration result`() {
         every { mockBiometricsProvider.ensureSecretKeyIsAvailable(any()) } just runs
         every {
             mockBiometricsProvider.areBiometricsAvailable(any(), any())
-        } returns BiometricAvailability.BIOMETRIC_SUCCESS
-        val available = impl.areBiometricsAvailable(mockk())
-        assert(available == BiometricAvailability.BIOMETRIC_SUCCESS)
+        } returns BiometricManager.BIOMETRIC_SUCCESS
+        every { mockStorageHelper.preferenceExists(any()) } returns false // no registration data
+        var available = impl.areBiometricsAvailable(mockk())
+        assert(available == BiometricAvailability.AvailableNoRegistrations)
+        verify { mockBiometricsProvider.areBiometricsAvailable(any(), any()) }
+
+        every { mockStorageHelper.preferenceExists(any()) } returns true // assume registration data
+        available = impl.areBiometricsAvailable(mockk())
+        assert(available == BiometricAvailability.AvailableRegistered)
         verify { mockBiometricsProvider.areBiometricsAvailable(any(), any()) }
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1036](https://linear.app/stytch/issue/SDK-1036)

## Changes:

1. Condense the biometrics availability status into 4 statuses

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A