### PR TITLE
Add resetBySession method to consumer StytchClient

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.13.1'
+  PUBLISH_VERSION = '0.13.2'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -381,6 +381,16 @@ internal object StytchApi {
             )
         }
 
+        suspend fun resetBySession(
+            password: String,
+        ): StytchResult<AuthData> = safeConsumerApiCall {
+            apiService.resetBySession(
+                ConsumerRequests.Passwords.ResetBySessionRequest(
+                    password = password,
+                )
+            )
+        }
+
         suspend fun strengthCheck(
             email: String?,
             password: String

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -120,6 +120,11 @@ internal interface StytchApiService : ApiService {
         @Body request: ConsumerRequests.Passwords.ResetByEmailRequest,
     ): ConsumerResponses.AuthenticateResponse
 
+    @POST("passwords/session/reset")
+    suspend fun resetBySession(
+        @Body request: ConsumerRequests.Passwords.ResetBySessionRequest,
+    ): ConsumerResponses.AuthenticateResponse
+
     @POST("passwords/strength_check")
     suspend fun strengthCheck(
         @Body request: ConsumerRequests.Passwords.StrengthCheckRequest

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -100,6 +100,11 @@ internal object ConsumerRequests {
         )
 
         @JsonClass(generateAdapter = true)
+        data class ResetBySessionRequest(
+            val password: String,
+        )
+
+        @JsonClass(generateAdapter = true)
         data class StrengthCheckRequest(
             val email: String?,
             val password: String,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -107,7 +107,6 @@ public interface Passwords {
      */
     public fun resetBySession(parameters: ResetBySessionParameters, callback: (AuthResponse) -> Unit)
 
-
     /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
      * @property email is the account identifier for the account in the form of an Email address that you wish to use to

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -81,6 +81,35 @@ public interface Passwords {
 
     /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
+     * @property password is the new password to set
+     */
+    public data class ResetBySessionParameters(
+        val password: String,
+    )
+
+    /**
+     * Reset the user’s password and authenticate them. This endpoint checks that the session is valid and hasn’t
+     * expired or been revoked. The provided password needs to meet our password strength requirements, which can be
+     * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
+     * the password is securely stored for future authentication and the user is authenticated.
+     * @param parameters required to reset a user's password
+     * @return [AuthResponse]
+     */
+    public suspend fun resetBySession(parameters: ResetBySessionParameters): AuthResponse
+
+    /**
+     * Reset the user’s password and authenticate them. This endpoint checks that the session is valid and hasn’t
+     * expired or been revoked. The provided password needs to meet our password strength requirements, which can be
+     * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
+     * the password is securely stored for future authentication and the user is authenticated.
+     * @param parameters required to reset a user's password
+     * @param callback a callback that receives an [AuthResponse]
+     */
+    public fun resetBySession(parameters: ResetBySessionParameters, callback: (AuthResponse) -> Unit)
+
+
+    /**
+     * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
      * @property email is the account identifier for the account in the form of an Email address that you wish to use to
      * initiate a password strength check
      * @property password is the private sequence of characters you wish to check to get advice on improving it

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -149,6 +149,23 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override suspend fun resetBySession(parameters: Passwords.ResetBySessionParameters): AuthResponse {
+        return withContext(dispatchers.io) {
+            api.resetBySession(
+                password = parameters.password,
+            )
+        }
+    }
+
+    override fun resetBySession(parameters: Passwords.ResetBySessionParameters,
+        callback: (AuthResponse) -> Unit
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            val result = resetBySession(parameters)
+            callback(result)
+        }
+    }
+
     override suspend fun strengthCheck(parameters: Passwords.StrengthCheckParameters): PasswordsStrengthCheckResponse {
         val result: PasswordsStrengthCheckResponse
         withContext(dispatchers.io) {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -157,7 +157,8 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
-    override fun resetBySession(parameters: Passwords.ResetBySessionParameters,
+    override fun resetBySession(
+        parameters: Passwords.ResetBySessionParameters,
         callback: (AuthResponse) -> Unit
     ) {
         externalScope.launch(dispatchers.ui) {

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -462,6 +462,23 @@ internal class StytchApiServiceTests {
     }
 
     @Test
+    fun `check Passwords resetPasswordBySession request`() {
+        runBlocking {
+            val parameters = ConsumerRequests.Passwords.ResetBySessionRequest(
+                password = "my-password",
+            )
+            requestIgnoringResponseException {
+                apiService.resetBySession(parameters)
+            }.verifyPost(
+                expectedPath = "/passwords/session/reset",
+                expectedBody = mapOf(
+                    "password" to parameters.password,
+                )
+            )
+        }
+    }
+
+    @Test
     fun `check Passwords authenticate request`() {
         runBlocking {
             val parameters = ConsumerRequests.Passwords.AuthenticateRequest(

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -210,6 +210,14 @@ internal class StytchApiTest {
     }
 
     @Test
+    fun `StytchApi Passwords resetBySession calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        coEvery { StytchApi.apiService.resetBySession(any()) } returns mockk(relaxed = true)
+        StytchApi.Passwords.resetBySession(password = "")
+        coVerify { StytchApi.apiService.resetBySession(any()) }
+    }
+
+    @Test
     fun `StytchApi Passwords strengthCheck calls appropriate apiService method`() = runTest {
         every { StytchApi.isInitialized } returns true
         coEvery { StytchApi.apiService.strengthCheck(any()) } returns mockk(relaxed = true)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -64,6 +64,7 @@ internal class PasswordsImplTest {
         resetPasswordTemplateId = null,
     )
     private val resetByEmailParameters = mockk<Passwords.ResetByEmailParameters>(relaxed = true)
+    private val resetBySessionParameters = mockk<Passwords.ResetBySessionParameters>(relaxed = true)
     private val strengthCheckParameters = mockk<Passwords.StrengthCheckParameters>(relaxed = true)
 
     @Before
@@ -172,6 +173,21 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl resetByEmail with callback calls callback method`() {
         val mockCallback = spyk<(AuthResponse) -> Unit>()
         impl.resetByEmail(resetByEmailParameters, mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `PasswordsImpl resetBySession delegates to api`() = runTest {
+        coEvery { mockApi.resetBySession(any()) } returns mockk()
+        impl.resetBySession(resetBySessionParameters)
+        coVerify { mockApi.resetBySession(any()) }
+    }
+
+    @Test
+    fun `PasswordsImpl resetBySession with callback calls callback method`() {
+        coEvery { mockApi.resetBySession(any()) } returns mockk()
+        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        impl.resetBySession(resetBySessionParameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 


### PR DESCRIPTION
Linear Ticket: [LINEAR_NUMBER](https://linear.app/stytch/issue/YOUR_TICKET)

## Changes:

1. Adds resetBySession method to consumer StytchClient

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A