### PR TITLE
SDK-1129 Integrate reCAPTCHA

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
     implementation 'com.google.crypto.tink:tink-android:1.7.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.72'
-    implementation 'com.google.android.recaptcha:recaptcha:18.3.0'
+    implementation 'com.google.android.recaptcha:recaptcha:18.2.1'
 
 
     testImplementation 'junit:junit:4.13.2'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
     implementation 'com.google.crypto.tink:tink-android:1.7.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.72'
+    implementation 'com.google.android.recaptcha:recaptcha:18.3.0'
 
 
     testImplementation 'junit:junit:4.13.2'

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
@@ -4,29 +4,28 @@ import android.app.Application
 import com.google.android.recaptcha.Recaptcha
 import com.google.android.recaptcha.RecaptchaAction
 import com.google.android.recaptcha.RecaptchaClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 internal interface CaptchaProvider {
-    suspend fun initializeRecaptchaClient(siteKey: String)
     suspend fun executeRecaptcha(): String
 }
 
 internal class CaptchaProviderImpl(
-    private val application: Application
-): CaptchaProvider {
+    application: Application,
+    scope: CoroutineScope,
+    siteKey: String,
+) : CaptchaProvider {
 
     private lateinit var recaptchaClient: RecaptchaClient
 
-    override suspend fun initializeRecaptchaClient(siteKey: String) {
-        recaptchaClient = Recaptcha.getClient(application, siteKey).getOrElse { exception ->
-            // TODO: handle errors
-            return
+    init {
+        scope.launch(Dispatchers.Main) {
+            recaptchaClient = Recaptcha.getClient(application, siteKey).getOrThrow()
         }
     }
 
-    override suspend fun executeRecaptcha(): String {
-        return recaptchaClient.execute(RecaptchaAction.LOGIN).getOrElse { exception ->
-            // TODO: handle errors
-            return ""
-        }
-    }
+    override suspend fun executeRecaptcha(): String =
+        recaptchaClient.execute(RecaptchaAction.LOGIN).getOrThrow()
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
@@ -6,22 +6,27 @@ import com.google.android.recaptcha.RecaptchaAction
 import com.google.android.recaptcha.RecaptchaClient
 
 internal interface CaptchaProvider {
-    suspend fun initializeRecaptchaClient()
+    suspend fun initializeRecaptchaClient(siteKey: String)
     suspend fun executeRecaptcha(): String
 }
 
 internal class CaptchaProviderImpl(
-    private val application: Application,
-    private val siteKey: String
+    private val application: Application
 ): CaptchaProvider {
 
     private lateinit var recaptchaClient: RecaptchaClient
 
-    override suspend fun initializeRecaptchaClient() {
-        recaptchaClient = Recaptcha.getClient(application, siteKey).getOrThrow()
+    override suspend fun initializeRecaptchaClient(siteKey: String) {
+        recaptchaClient = Recaptcha.getClient(application, siteKey).getOrElse { exception ->
+            // TODO: handle errors
+            return
+        }
     }
 
     override suspend fun executeRecaptcha(): String {
-        return recaptchaClient.execute(RecaptchaAction.LOGIN).getOrThrow()
+        return recaptchaClient.execute(RecaptchaAction.LOGIN).getOrElse { exception ->
+            // TODO: handle errors
+            return ""
+        }
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
@@ -1,0 +1,27 @@
+package com.stytch.sdk.common.dfp
+
+import android.app.Application
+import com.google.android.recaptcha.Recaptcha
+import com.google.android.recaptcha.RecaptchaAction
+import com.google.android.recaptcha.RecaptchaClient
+
+internal interface CaptchaProvider {
+    suspend fun initializeRecaptchaClient()
+    suspend fun executeRecaptcha(): String
+}
+
+internal class CaptchaProviderImpl(
+    private val application: Application,
+    private val siteKey: String
+): CaptchaProvider {
+
+    private lateinit var recaptchaClient: RecaptchaClient
+
+    override suspend fun initializeRecaptchaClient() {
+        recaptchaClient = Recaptcha.getClient(application, siteKey).getOrThrow()
+    }
+
+    override suspend fun executeRecaptcha(): String {
+        return recaptchaClient.execute(RecaptchaAction.LOGIN).getOrThrow()
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
@@ -22,10 +22,16 @@ internal class CaptchaProviderImpl(
 
     init {
         scope.launch(Dispatchers.Main) {
-            recaptchaClient = Recaptcha.getClient(application, siteKey).getOrThrow()
+            Recaptcha.getClient(application, siteKey).onSuccess {
+                recaptchaClient = it
+            }
         }
     }
 
     override suspend fun executeRecaptcha(): String =
-        recaptchaClient.execute(RecaptchaAction.LOGIN).getOrThrow()
+        if (::recaptchaClient.isInitialized) {
+            recaptchaClient.execute(RecaptchaAction.LOGIN).getOrElse { "" }
+        } else {
+            ""
+        }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.common.network
 
+import com.stytch.sdk.common.dfp.CaptchaProvider
 import com.stytch.sdk.common.dfp.DFPProvider
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -15,7 +16,8 @@ private const val CAPTCHA_TOKEN_KEY = "captcha_token"
 private const val HTTP_UNAUTHORIZED = 403
 
 internal class StytchDFPInterceptor(
-    private val dfpProvider: DFPProvider
+    private val dfpProvider: DFPProvider,
+    private val captchaProvider: CaptchaProvider
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
@@ -40,8 +42,7 @@ internal class StytchDFPInterceptor(
 
     private fun Request.addDfpTelemetryIdAndCaptchaTokenToRequest(): Request {
         val dfpTelemetryId = runBlocking { dfpProvider.getTelemetryId() }
-        // TODO: fetch the captcha token (SDK-1129)
-        val dfpCaptchaToken = "dfp-captcha-token"
+        val dfpCaptchaToken = runBlocking { captchaProvider.executeRecaptcha() }
         return toNewRequest(
             mapOf(
                 DFP_TELEMETRY_ID_KEY to dfpTelemetryId,

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -296,5 +296,6 @@ public data class BootstrapData(
 
 @JsonClass(generateAdapter = true)
 public data class CaptchaSettings(
-    val enabled: Boolean = false
+    val enabled: Boolean = false,
+    val siteKey: String? = null
 )

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -291,11 +291,11 @@ public data class BootstrapData(
     @Json(name = "create_organization_enabled")
     val createOrganizationEnabled: Boolean = false,
     @Json(name = "dfp_protected_auth_enabled")
-    val dfpProtectedAuthEnabled: Boolean = true, // TODO: Disabled by default, this is just for testing
+    val dfpProtectedAuthEnabled: Boolean = false,
 )
 
 @JsonClass(generateAdapter = true)
 public data class CaptchaSettings(
     val enabled: Boolean = false,
-    val siteKey: String? = null
+    val siteKey: String = ""
 )

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -11,6 +11,7 @@ import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchExceptions
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.ActivityProvider
+import com.stytch.sdk.common.dfp.CaptchaProviderImpl
 import com.stytch.sdk.common.dfp.DFPProviderImpl
 import com.stytch.sdk.common.extensions.getDeviceInfo
 import com.stytch.sdk.common.network.StytchErrorType
@@ -64,7 +65,8 @@ public object StytchClient {
             StytchApi.configure(
                 publicToken,
                 deviceInfo,
-                DFPProviderImpl(publicToken, ActivityProvider(context.applicationContext as Application))
+                DFPProviderImpl(publicToken, ActivityProvider(context.applicationContext as Application)),
+                CaptchaProviderImpl(context.applicationContext as Application)
             )
             StorageHelper.initialize(context)
             externalScope.launch(dispatchers.io) {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.Constants.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.StytchExceptions
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.dfp.CaptchaProvider
 import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.network.ApiService
 import com.stytch.sdk.common.network.StytchAuthHeaderInterceptor
@@ -29,13 +30,13 @@ import com.stytch.sdk.consumer.network.models.NativeOAuthData
 import com.stytch.sdk.consumer.network.models.StrengthCheckResponse
 import com.stytch.sdk.consumer.network.models.UpdateUserResponseData
 import com.stytch.sdk.consumer.network.models.UserData
-import java.lang.RuntimeException
 
 internal object StytchApi {
 
     internal lateinit var publicToken: String
     private lateinit var deviceInfo: DeviceInfo
     private lateinit var dfpProvider: DFPProvider
+    private lateinit var captchaProvider: CaptchaProvider
 
     // save reference for changing auth header
     // make sure api is configured before accessing this variable
@@ -58,16 +59,17 @@ internal object StytchApi {
     @VisibleForTesting
     internal val dfpInterceptor: StytchDFPInterceptor? by lazy {
         if (StytchClient.bootstrapData.dfpProtectedAuthEnabled || true) { // TODO: remove short circuit
-            StytchDFPInterceptor(this.dfpProvider)
+            StytchDFPInterceptor(this.dfpProvider, this.captchaProvider)
         } else {
             null
         }
     }
 
-    internal fun configure(publicToken: String, deviceInfo: DeviceInfo, dfpProvider: DFPProvider) {
+    internal fun configure(publicToken: String, deviceInfo: DeviceInfo, dfpProvider: DFPProvider, captchaProvider: CaptchaProvider) {
         this.publicToken = publicToken
         this.deviceInfo = deviceInfo
         this.dfpProvider = dfpProvider
+        this.captchaProvider = captchaProvider
     }
 
     internal val isInitialized: Boolean


### PR DESCRIPTION
Linear Ticket: [SDK-1129](https://linear.app/stytch/issue/SDK-1129)

## Changes:

1. Adds the captcha flow to the DFP interceptor
2. Removes shortcircuit now that we're getting the DFP settings from bootstrap data

## Notes:

- Our plan to move API configuration after the bootstrap call wasn't workable, because the API needs to be configured _before_ making the bootstrap call (obviously!) So now configuration and _DFP_ configuration are split into two methods, and the second one creates a new APIService (if applicable) that can be conditionally used (otherwise it falls back to the non-DFP APIService)

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A