### PR TITLE
DFP: Unit tests

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -133,4 +133,5 @@ dependencies {
     testImplementation "io.mockk:mockk:1.12.5"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
     testImplementation("com.squareup.okhttp3:mockwebserver:4.7.2")
+    testImplementation("org.json:json:20230227")
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
@@ -6,10 +6,10 @@ import android.view.ViewGroup
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
 
 internal interface DFPProvider {
     suspend fun getTelemetryId(): String

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
@@ -9,6 +9,7 @@ import android.webkit.WebViewClient
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 internal interface DFPProvider {
     suspend fun getTelemetryId(): String
@@ -60,6 +61,9 @@ internal class DFPProviderImpl(
                 webview = createWebView(it)
                 it.addContentView(webview, ViewGroup.LayoutParams(0, 0))
             }
+        } ?: run {
+            // Couldn't inject webview, return empty string
+            continuation.resume("")
         }
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
@@ -9,7 +9,7 @@ internal fun Context.getDeviceInfo(): DeviceInfo {
     deviceInfo.applicationPackageName = applicationContext.packageName
     deviceInfo.osVersion = Build.VERSION.SDK_INT.toString()
     deviceInfo.deviceName = Build.MODEL
-    deviceInfo.osName = Build.VERSION.CODENAME
+    deviceInfo.osName = "Android"
 
     try {
         // throw exceptions if packageName not found

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/RequestBodyExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/RequestBodyExt.kt
@@ -1,0 +1,18 @@
+package com.stytch.sdk.common.extensions
+
+import okhttp3.RequestBody
+import okio.Buffer
+
+internal fun RequestBody?.asJsonString(): String {
+    if (this == null) return "{}"
+    val buffer = Buffer()
+    writeTo(buffer)
+    var bodyAsString: String
+    buffer.use {
+        bodyAsString = it.readUtf8()
+    }
+    if (bodyAsString.isBlank()) {
+        bodyAsString = "{}"
+    }
+    return bodyAsString
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/RequestExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/RequestExt.kt
@@ -1,0 +1,16 @@
+package com.stytch.sdk.common.extensions
+
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+internal fun Request.toNewRequest(params: Map<String, String>): Request {
+    val bodyAsString = body.asJsonString()
+    val updatedBody = JSONObject(bodyAsString).apply {
+        params.forEach {
+            put(it.key, it.value)
+        }
+    }.toString()
+    val newBody = updatedBody.toRequestBody(body?.contentType())
+    return newBuilder().method(method, newBody).build()
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ResponseExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ResponseExt.kt
@@ -1,0 +1,9 @@
+package com.stytch.sdk.common.extensions
+
+import okhttp3.Response
+
+private const val HTTP_UNAUTHORIZED = 403
+
+internal fun Response.requiresCaptcha(): Boolean {
+    return code == HTTP_UNAUTHORIZED
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
@@ -2,19 +2,14 @@ package com.stytch.sdk.common.network
 
 import com.stytch.sdk.common.dfp.CaptchaProvider
 import com.stytch.sdk.common.dfp.DFPProvider
+import com.stytch.sdk.common.extensions.requiresCaptcha
+import com.stytch.sdk.common.extensions.toNewRequest
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okio.Buffer
-import org.json.JSONObject
 
 private const val DFP_TELEMETRY_ID_KEY = "dfp_telemetry_id"
 private const val CAPTCHA_TOKEN_KEY = "captcha_token"
-private const val HTTP_UNAUTHORIZED = 403
-
 internal class StytchDFPInterceptor(
     private val dfpProvider: DFPProvider,
     private val captchaProvider: CaptchaProvider
@@ -22,57 +17,25 @@ internal class StytchDFPInterceptor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         if (request.method == "GET" || request.method == "DELETE") return chain.proceed(request)
-        val response = chain.proceed(request.addDfpTelemetryIdToRequest())
+        val response = chain.proceed(
+            request.toNewRequest(
+                mapOf(
+                    DFP_TELEMETRY_ID_KEY to runBlocking { dfpProvider.getTelemetryId() }
+                )
+            )
+        )
         return if (response.requiresCaptcha()) {
             response.close()
-            chain.proceed(request.addDfpTelemetryIdAndCaptchaTokenToRequest())
+            chain.proceed(
+                request.toNewRequest(
+                    mapOf(
+                        DFP_TELEMETRY_ID_KEY to runBlocking { dfpProvider.getTelemetryId() },
+                        CAPTCHA_TOKEN_KEY to runBlocking { captchaProvider.executeRecaptcha() }
+                    )
+                )
+            )
         } else {
             response
         }
-    }
-
-    private fun Response.requiresCaptcha(): Boolean {
-        return code == HTTP_UNAUTHORIZED && message.contains("Captcha required")
-    }
-
-    private fun Request.addDfpTelemetryIdToRequest(): Request {
-        val dfpTelemetryId = runBlocking { dfpProvider.getTelemetryId() }
-        return toNewRequest(mapOf(DFP_TELEMETRY_ID_KEY to dfpTelemetryId))
-    }
-
-    private fun Request.addDfpTelemetryIdAndCaptchaTokenToRequest(): Request {
-        val dfpTelemetryId = runBlocking { dfpProvider.getTelemetryId() }
-        val dfpCaptchaToken = runBlocking { captchaProvider.executeRecaptcha() }
-        return toNewRequest(
-            mapOf(
-                DFP_TELEMETRY_ID_KEY to dfpTelemetryId,
-                CAPTCHA_TOKEN_KEY to dfpCaptchaToken
-            )
-        )
-    }
-
-    private fun Request.toNewRequest(params: Map<String, String>): Request {
-        val bodyAsString = body.asJsonString()
-        val updatedBody = JSONObject(bodyAsString).apply {
-            params.forEach {
-                put(it.key, it.value)
-            }
-        }.toString()
-        val newBody = updatedBody.toRequestBody(body?.contentType())
-        return newBuilder().method(method, newBody).build()
-    }
-
-    private fun RequestBody?.asJsonString(): String {
-        if (this == null) return "{}"
-        val buffer = Buffer()
-        writeTo(buffer)
-        var bodyAsString: String
-        buffer.use {
-            bodyAsString = it.readUtf8()
-        }
-        if (bodyAsString.isBlank()) {
-            bodyAsString = "{}"
-        }
-        return bodyAsString
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
 
-private const val DFP_TELEMETRY_ID_KEY = "dfp_telemetry_id"
-private const val CAPTCHA_TOKEN_KEY = "captcha_token"
+internal const val DFP_TELEMETRY_ID_KEY = "dfp_telemetry_id"
+internal const val CAPTCHA_TOKEN_KEY = "captcha_token"
 internal class StytchDFPInterceptor(
     private val dfpProvider: DFPProvider,
     private val captchaProvider: CaptchaProvider

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b
 
+import android.app.Application
 import android.content.Context
 import android.net.Uri
 import com.stytch.sdk.b2b.magicLinks.B2BMagicLinks
@@ -59,7 +60,13 @@ internal class StytchB2BClientTest {
         mockkStatic("com.stytch.sdk.common.extensions.ContextExtKt")
         mockkObject(EncryptionManager)
         every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
-        mContextMock = mockk(relaxed = true)
+        val mockApplication: Application = mockk {
+            every { registerActivityLifecycleCallbacks(any()) } just runs
+            every { packageName } returns "Stytch"
+        }
+        mContextMock = mockk(relaxed = true) {
+            every { applicationContext } returns mockApplication
+        }
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         mockkObject(StytchB2BApi)

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -36,6 +36,7 @@ internal class StytchB2BApiServiceTest {
         apiService = ApiService.createApiService(
             mockWebServer.url("/").toString(),
             null,
+            null,
             {},
             StytchB2BApiService::class.java
         )

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.network
 
+import android.app.Application
 import android.content.Context
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
@@ -18,9 +19,11 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.runs
 import io.mockk.unmockkAll
 import java.security.KeyStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,6 +39,13 @@ internal class StytchB2BApiTest {
 
     @Before
     fun before() {
+        val mockApplication: Application = mockk {
+            every { registerActivityLifecycleCallbacks(any()) } just runs
+            every { packageName } returns "Stytch"
+        }
+        mContextMock = mockk(relaxed = true) {
+            every { applicationContext } returns mockApplication
+        }
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
         mockkObject(StytchB2BApi)

--- a/sdk/src/test/java/com/stytch/sdk/common/extensions/RequestBodyExtTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/extensions/RequestBodyExtTest.kt
@@ -1,0 +1,26 @@
+package com.stytch.sdk.common.extensions
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.junit.Test
+
+internal class RequestBodyExtTest {
+    @Test
+    fun `null requestBody returns empty JSON string`() {
+        val rb: RequestBody? = null
+        assert(rb.asJsonString() == "{}")
+    }
+
+    @Test
+    fun `blank requestBody returns empty JSON string`() {
+        val rb = "".toRequestBody("application/json".toMediaTypeOrNull())
+        assert(rb.asJsonString() == "{}")
+    }
+
+    @Test
+    fun `a body is read into a string`() {
+        val rb = """{"a": true}""".toRequestBody("application/json".toMediaTypeOrNull())
+        assert(rb.asJsonString() == """{"a": true}""")
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/common/extensions/RequestExtTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/extensions/RequestExtTest.kt
@@ -1,0 +1,24 @@
+package com.stytch.sdk.common.extensions
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import org.junit.Test
+
+internal class RequestExtTest {
+    @Test
+    fun `toNewRequest adds appropriate items to body`() {
+        val originalBody = """{"a": true}""".toRequestBody("application/json".toMediaTypeOrNull())
+        val originalRequest = Request.Builder().url("http://stytch.com/").post(originalBody).build()
+        val newParams = mapOf(
+            "telemetry_id" to "telemetry-id",
+            "captcha_token" to "captcha-token"
+        )
+        val newRequest = originalRequest.toNewRequest(newParams)
+        val newRequestBodyAsJson = JSONObject(newRequest.body.asJsonString())
+        assert(newRequestBodyAsJson.getBoolean("a"))
+        assert(newRequestBodyAsJson.getString("telemetry_id") == "telemetry-id")
+        assert(newRequestBodyAsJson.getString("captcha_token") == "captcha-token")
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/common/extensions/ResponseExtTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/extensions/ResponseExtTest.kt
@@ -1,0 +1,24 @@
+package com.stytch.sdk.common.extensions
+
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.Response
+import org.junit.Test
+
+internal class ResponseExtTest {
+    @Test
+    fun `non-403 codes return false`() {
+        val response: Response = mockk {
+            every { code } returns 200
+        }
+        assert(!response.requiresCaptcha())
+    }
+
+    @Test
+    fun `403 code returns true`() {
+        val response: Response = mockk {
+            every { code } returns 403
+        }
+        assert(response.requiresCaptcha())
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/common/network/StytchDFPInterceptorTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/network/StytchDFPInterceptorTest.kt
@@ -1,5 +1,109 @@
 package com.stytch.sdk.common.network
 
-internal class StytchDFPInterceptorTest {
+import com.stytch.sdk.common.dfp.CaptchaProvider
+import com.stytch.sdk.common.dfp.DFPProvider
+import com.stytch.sdk.common.extensions.toNewRequest
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.junit.Before
+import org.junit.Test
 
+internal class StytchDFPInterceptorTest {
+    @MockK
+    private lateinit var dfpProvider: DFPProvider
+
+    @MockK
+    private lateinit var captchaProvider: CaptchaProvider
+
+    private lateinit var interceptor: StytchDFPInterceptor
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this, true, true)
+        mockkStatic("com.stytch.sdk.common.extensions.RequestExtKt")
+        interceptor = StytchDFPInterceptor(dfpProvider, captchaProvider)
+    }
+
+    @Test
+    fun `get requests do not inject DFP`() {
+        val request: Request = mockk {
+            every { method } returns "GET"
+        }
+        val chain: Interceptor.Chain = mockk {
+            every { request() } returns request
+            every { proceed(any()) } returns mockk()
+        }
+        interceptor.intercept(chain)
+        verify(exactly = 0) { request.toNewRequest(any()) }
+    }
+
+    @Test
+    fun `delete requests do not inject DFP`() {
+        val request: Request = mockk {
+            every { method } returns "DELETE"
+        }
+        val chain: Interceptor.Chain = mockk {
+            every { request() } returns request
+            every { proceed(any()) } returns mockk()
+        }
+        interceptor.intercept(chain)
+        verify(exactly = 0) { request.toNewRequest(any()) }
+    }
+
+    @Test
+    fun `dfp requests inject DFP, but not captcha, if not required`() {
+        val request: Request = mockk {
+            every { method } returns "POST"
+            every { body } returns "".toRequestBody("application/json".toMediaTypeOrNull())
+            every { toNewRequest(any()) } returns this
+        }
+        val chain: Interceptor.Chain = mockk {
+            every { request() } returns request
+            every { proceed(any()) } returns mockk {
+                every { code } returns 200
+            }
+        }
+        coEvery { dfpProvider.getTelemetryId() } returns "dfp-telemetry-id"
+        interceptor.intercept(chain)
+        verify(exactly = 1) { request.toNewRequest(any()) }
+    }
+
+    @Test
+    fun `dfp requests inject DFP and captcha, if required`() {
+        val request: Request = mockk {
+            every { method } returns "POST"
+            every { body } returns "".toRequestBody("application/json".toMediaTypeOrNull())
+            every { toNewRequest(any()) } returns this
+        }
+        val chain: Interceptor.Chain = mockk {
+            every { request() } returns request
+            every { proceed(any()) } returns mockk {
+                every { code } returns 403
+                every { close() } just runs
+            }
+        }
+        coEvery { dfpProvider.getTelemetryId() } returns "dfp-telemetry-id"
+        coEvery { captchaProvider.executeRecaptcha() } returns "captcha-token"
+        interceptor.intercept(chain)
+        verify(exactly = 1) { request.toNewRequest(mapOf(DFP_TELEMETRY_ID_KEY to "dfp-telemetry-id")) }
+        verify(exactly = 1) {
+            request.toNewRequest(
+                mapOf(
+                    DFP_TELEMETRY_ID_KEY to "dfp-telemetry-id",
+                    CAPTCHA_TOKEN_KEY to "captcha-token",
+                )
+            )
+        }
+    }
 }

--- a/sdk/src/test/java/com/stytch/sdk/common/network/StytchDFPInterceptorTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/network/StytchDFPInterceptorTest.kt
@@ -1,0 +1,5 @@
+package com.stytch.sdk.common.network
+
+internal class StytchDFPInterceptorTest {
+
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.consumer
 
+import android.app.Application
 import android.content.Context
 import android.net.Uri
 import com.stytch.sdk.common.DeeplinkHandledStatus
@@ -63,7 +64,13 @@ internal class StytchClientTest {
         mockkStatic("com.stytch.sdk.common.extensions.ContextExtKt")
         mockkObject(EncryptionManager)
         every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
-        mContextMock = mockk(relaxed = true)
+        val mockApplication: Application = mockk {
+            every { registerActivityLifecycleCallbacks(any()) } just runs
+            every { packageName } returns "Stytch"
+        }
+        mContextMock = mockk(relaxed = true) {
+            every { applicationContext } returns mockApplication
+        }
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         mockkObject(StytchApi)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -34,6 +34,7 @@ internal class StytchApiServiceTests {
         apiService = ApiService.createApiService(
             mockWebServer.url("/").toString(),
             null,
+            null,
             {},
             StytchApiService::class.java
         )

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.consumer.network
 
+import android.app.Application
 import android.content.Context
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
@@ -13,9 +14,11 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.runs
 import io.mockk.unmockkAll
 import java.security.KeyStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,6 +34,13 @@ internal class StytchApiTest {
 
     @Before
     fun before() {
+        val mockApplication: Application = mockk {
+            every { registerActivityLifecycleCallbacks(any()) } just runs
+            every { packageName } returns "Stytch"
+        }
+        mContextMock = mockk(relaxed = true) {
+            every { applicationContext } returns mockApplication
+        }
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
         mockkObject(StytchApi)


### PR DESCRIPTION
Linear Ticket: [SDK-1130](https://linear.app/stytch/issue/SDK-1130)

## Changes:

1. Adds unit tests for DFP/Captcha request modifications
2. Updates DeviceInfo to always return `Android` as the platform, instead of the codename (IDK why it was like this to begin with?)
3. Fixes some tests that were broken in earlier DFP work (oops)

## Notes:

- This does not have tests for the DFP or Captcha provider themselves, since it relies on Android stuff and would need to be run as instrumented tests, of which we don't have any yet

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A