### PR TITLE
Add sessionDurationMinutes to passwordresetbysession

### DIFF
--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/PasswordsViewModel.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/PasswordsViewModel.kt
@@ -7,8 +7,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.stytch.sdk.consumer.passwords.Passwords
 import com.stytch.sdk.consumer.StytchClient
+import com.stytch.sdk.consumer.passwords.Passwords
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -124,6 +124,21 @@ class PasswordsViewModel(application: Application) : AndroidViewModel(applicatio
             }
         } else {
             showTokenError = true
+        }
+    }
+
+    fun resetPasswordBySession() {
+        viewModelScope.launch {
+            _loadingState.value = true
+            val result = StytchClient.passwords.resetBySession(
+                Passwords.ResetBySessionParameters(
+                    passwordTextState.text,
+                    5U
+                )
+            )
+            _currentResponse.value = result.toFriendlyDisplay()
+        }.invokeOnCompletion {
+            _loadingState.value = false
         }
     }
 }

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/ui/PasswordsScreen.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/ui/PasswordsScreen.kt
@@ -99,6 +99,11 @@ fun PasswordsScreen(navController: NavController) {
             text = stringResource(id = R.string.passwords_reset_by_email),
             onClick = { viewModel.resetPasswordByEmail() }
         )
+        StytchButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(id = R.string.passwords_reset_by_session),
+            onClick = { viewModel.resetPasswordBySession() }
+        )
         if (loading.value) {
             CircularProgressIndicator()
         } else {

--- a/consumerExampleApp/src/main/res/values/strings.xml
+++ b/consumerExampleApp/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="passwords_create">Create account</string>
     <string name="passwords_reset_by_email_start">Reset by email start</string>
     <string name="passwords_reset_by_email">Reset by email (needs token)</string>
+    <string name="passwords_reset_by_session">Reset by session</string>
     <string name="deep_link_title">Deep links</string>
     <string name="host">exampleapp.com</string>
     <string name="deeplink_received_toast">Deeplink received</string>

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.13.2'
+  PUBLISH_VERSION = '0.13.3'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -56,6 +56,7 @@ public object StytchClient {
             val deviceInfo = context.getDeviceInfo()
             StytchApi.configure(publicToken, deviceInfo)
             StorageHelper.initialize(context)
+            maybeClearBadSessionToken()
         } catch (ex: Exception) {
             throw StytchExceptions.Critical(ex)
         }
@@ -289,4 +290,12 @@ public object StytchClient {
      */
     public fun canHandle(uri: Uri): Boolean =
         ConsumerTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE)) != ConsumerTokenType.UNKNOWN
+
+    private fun maybeClearBadSessionToken() {
+        if (sessionStorage.sessionToken?.isBlank() == true) {
+            // We accidentally saved a blank session token instead of a null session token. Clear it all out.
+            // This fixes a bug introduced with the original PasswordsResetBySession implementation
+            sessionStorage.revoke()
+        }
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -383,10 +383,12 @@ internal object StytchApi {
 
         suspend fun resetBySession(
             password: String,
+            sessionDurationMinutes: UInt,
         ): StytchResult<AuthData> = safeConsumerApiCall {
             apiService.resetBySession(
                 ConsumerRequests.Passwords.ResetBySessionRequest(
                     password = password,
+                    sessionDurationMinutes = sessionDurationMinutes.toInt()
                 )
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -102,6 +102,8 @@ internal object ConsumerRequests {
         @JsonClass(generateAdapter = true)
         data class ResetBySessionRequest(
             val password: String,
+            @Json(name = "session_duration_minutes")
+            val sessionDurationMinutes: Int,
         )
 
         @JsonClass(generateAdapter = true)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -85,6 +85,7 @@ public interface Passwords {
      */
     public data class ResetBySessionParameters(
         val password: String,
+        val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -82,6 +82,7 @@ public interface Passwords {
     /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
      * @property password is the new password to set
+     * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
     public data class ResetBySessionParameters(
         val password: String,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -153,6 +153,7 @@ internal class PasswordsImpl internal constructor(
         return withContext(dispatchers.io) {
             api.resetBySession(
                 password = parameters.password,
+                sessionDurationMinutes = parameters.sessionDurationMinutes
             )
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -154,7 +154,9 @@ internal class PasswordsImpl internal constructor(
             api.resetBySession(
                 password = parameters.password,
                 sessionDurationMinutes = parameters.sessionDurationMinutes
-            )
+            ).apply {
+                launchSessionUpdater(dispatchers, sessionStorage)
+            }
         }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
@@ -11,6 +11,8 @@ Call the `StytchClient.passwords.authenticate()` method to authenticate a user w
 
 Call the `StytchClient.passwords.resetByEmailStart()` method to initiate a password reset for the email address provided. This will trigger an email to be sent to the address, containing a magic link that will allow them to set a new password and authenticate.
 
+Call the `StytchClient.passwords.resetBySession()` method to reset the user’s password using their existing session. The endpoint will error if the session does not have a password, email magic link, or email OTP authentication factor that has been issued within the last 5 minutes.
+
 If you have connected your deeplink handler with `StytchClient`, the resulting magic link should be detected by your application and automatically parsed (via the `StytchClient.handle()` method). See the instructions in the [top-level README](/README.md) for information on handling deeplink intents. You should get a `DeeplinkHandledStatus.ManualHandlingRequired` result, which includes the necessary token for resetting the user's password. If you are not using our deeplink handler, you must parse out the token from the deeplink yourself.
 
 Once you have a password reset token, and have collected the user's new desired password, you can call the `StytchClient.passwords.resetByEmail()` method to finish resetting their password.

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -466,6 +466,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             val parameters = ConsumerRequests.Passwords.ResetBySessionRequest(
                 password = "my-password",
+                sessionDurationMinutes = 10
             )
             requestIgnoringResponseException {
                 apiService.resetBySession(parameters)
@@ -473,6 +474,7 @@ internal class StytchApiServiceTests {
                 expectedPath = "/passwords/session/reset",
                 expectedBody = mapOf(
                     "password" to parameters.password,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
                 )
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -213,7 +213,7 @@ internal class StytchApiTest {
     fun `StytchApi Passwords resetBySession calls appropriate apiService method`() = runTest {
         every { StytchApi.isInitialized } returns true
         coEvery { StytchApi.apiService.resetBySession(any()) } returns mockk(relaxed = true)
-        StytchApi.Passwords.resetBySession(password = "")
+        StytchApi.Passwords.resetBySession(password = "", sessionDurationMinutes = 30U)
         coVerify { StytchApi.apiService.resetBySession(any()) }
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -178,14 +178,14 @@ internal class PasswordsImplTest {
 
     @Test
     fun `PasswordsImpl resetBySession delegates to api`() = runTest {
-        coEvery { mockApi.resetBySession(any()) } returns mockk()
+        coEvery { mockApi.resetBySession(any(), any()) } returns mockk()
         impl.resetBySession(resetBySessionParameters)
-        coVerify { mockApi.resetBySession(any()) }
+        coVerify { mockApi.resetBySession(any(), any()) }
     }
 
     @Test
     fun `PasswordsImpl resetBySession with callback calls callback method`() {
-        coEvery { mockApi.resetBySession(any()) } returns mockk()
+        coEvery { mockApi.resetBySession(any(), any()) } returns mockk()
         val mockCallback = spyk<(AuthResponse) -> Unit>()
         impl.resetBySession(resetBySessionParameters, mockCallback)
         verify { mockCallback.invoke(any()) }


### PR DESCRIPTION
Linear Ticket: [SDK-1172](https://linear.app/stytch/issue/SDK-1172)

## Changes:

1. Adds sessionDurationMinutes to password resetBySession

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A