### PR TITLE
SDK-1201 update otp send response

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.14.0'
+  PUBLISH_VERSION = '0.14.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -141,6 +141,16 @@ public data class LoginOrCreateOTPData(
 )
 
 @JsonClass(generateAdapter = true)
+public data class OTPSendResponseData(
+    @Json(name = "status_code")
+    val statusCode: Int,
+    @Json(name = "request_id")
+    val requestId: String,
+    @Json(name = "method_id")
+    val methodId: String,
+)
+
+@JsonClass(generateAdapter = true)
 public data class AuthenticationFactor(
     @Json(name = "delivery_method")
     val deliveryMethod: String,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer
 
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
+import com.stytch.sdk.common.network.models.OTPSendResponseData
 import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.CreateResponse
 import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
@@ -51,6 +52,11 @@ public typealias OAuthAuthenticatedResponse = StytchResult<OAuthData>
  * Type alias for StytchResult<LoginOrCreateOTPData> used for loginOrCreateOTP responses
  */
 public typealias LoginOrCreateOTPResponse = StytchResult<LoginOrCreateOTPData>
+
+/**
+ * Type alias for StytchResult<OTPSendResponseData> used for OTPSend responses
+ */
+public typealias OTPSendResponse = StytchResult<OTPSendResponseData>
 
 /**
  * Type alias for StytchResult<StrengthCheckResponse> used for PasswordsStrengthCheck responses

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -19,6 +19,7 @@ import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.common.network.models.NameData
+import com.stytch.sdk.common.network.models.OTPSendResponseData
 import com.stytch.sdk.common.network.safeApiCall
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 import com.stytch.sdk.consumer.StytchClient
@@ -216,7 +217,7 @@ internal object StytchApi {
         suspend fun sendOTPWithSMSPrimary(
             phoneNumber: String,
             expirationMinutes: UInt?,
-        ): StytchResult<BasicData> = safeConsumerApiCall {
+        ): StytchResult<OTPSendResponseData> = safeConsumerApiCall {
             apiService.sendOTPWithSMSPrimary(
                 ConsumerRequests.OTP.SMS(
                     phoneNumber = phoneNumber,
@@ -229,7 +230,7 @@ internal object StytchApi {
         suspend fun sendOTPWithSMSSecondary(
             phoneNumber: String,
             expirationMinutes: UInt?,
-        ): StytchResult<BasicData> = safeConsumerApiCall {
+        ): StytchResult<OTPSendResponseData> = safeConsumerApiCall {
             apiService.sendOTPWithSMSSecondary(
                 ConsumerRequests.OTP.SMS(
                     phoneNumber = phoneNumber,
@@ -254,7 +255,7 @@ internal object StytchApi {
         suspend fun sendOTPWithWhatsAppPrimary(
             phoneNumber: String,
             expirationMinutes: UInt?,
-        ): StytchResult<BasicData> = safeConsumerApiCall {
+        ): StytchResult<OTPSendResponseData> = safeConsumerApiCall {
             apiService.sendOTPWithWhatsAppPrimary(
                 ConsumerRequests.OTP.WhatsApp(
                     phoneNumber = phoneNumber,
@@ -267,7 +268,7 @@ internal object StytchApi {
         suspend fun sendOTPWithWhatsAppSecondary(
             phoneNumber: String,
             expirationMinutes: UInt?,
-        ): StytchResult<BasicData> = safeConsumerApiCall {
+        ): StytchResult<OTPSendResponseData> = safeConsumerApiCall {
             apiService.sendOTPWithWhatsAppSecondary(
                 ConsumerRequests.OTP.WhatsApp(
                     phoneNumber = phoneNumber,
@@ -298,7 +299,7 @@ internal object StytchApi {
             expirationMinutes: UInt?,
             loginTemplateId: String?,
             signupTemplateId: String?,
-        ): StytchResult<BasicData> = safeConsumerApiCall {
+        ): StytchResult<OTPSendResponseData> = safeConsumerApiCall {
             apiService.sendOTPWithEmailPrimary(
                 ConsumerRequests.OTP.Email(
                     email = email,
@@ -315,7 +316,7 @@ internal object StytchApi {
             expirationMinutes: UInt?,
             loginTemplateId: String?,
             signupTemplateId: String?,
-        ): StytchResult<BasicData> = safeConsumerApiCall {
+        ): StytchResult<OTPSendResponseData> = safeConsumerApiCall {
             apiService.sendOTPWithEmailSecondary(
                 ConsumerRequests.OTP.Email(
                     email = email,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -56,12 +56,12 @@ internal interface StytchApiService : ApiService {
     @POST("otps/sms/send/primary")
     suspend fun sendOTPWithSMSPrimary(
         @Body request: ConsumerRequests.OTP.SMS
-    ): CommonResponses.SendResponse
+    ): ConsumerResponses.OTPSendResponse
 
     @POST("otps/sms/send/secondary")
     suspend fun sendOTPWithSMSSecondary(
         @Body request: ConsumerRequests.OTP.SMS
-    ): CommonResponses.SendResponse
+    ): ConsumerResponses.OTPSendResponse
 
     @POST("otps/whatsapp/login_or_create")
     suspend fun loginOrCreateUserByOTPWithWhatsApp(
@@ -71,12 +71,12 @@ internal interface StytchApiService : ApiService {
     @POST("otps/whatsapp/send/primary")
     suspend fun sendOTPWithWhatsAppPrimary(
         @Body request: ConsumerRequests.OTP.WhatsApp
-    ): CommonResponses.SendResponse
+    ): ConsumerResponses.OTPSendResponse
 
     @POST("otps/whatsapp/send/secondary")
     suspend fun sendOTPWithWhatsAppSecondary(
         @Body request: ConsumerRequests.OTP.WhatsApp
-    ): CommonResponses.SendResponse
+    ): ConsumerResponses.OTPSendResponse
 
     @POST("otps/email/login_or_create")
     suspend fun loginOrCreateUserByOTPWithEmail(
@@ -86,12 +86,12 @@ internal interface StytchApiService : ApiService {
     @POST("otps/email/send/primary")
     suspend fun sendOTPWithEmailPrimary(
         @Body request: ConsumerRequests.OTP.Email
-    ): CommonResponses.SendResponse
+    ): ConsumerResponses.OTPSendResponse
 
     @POST("otps/email/send/secondary")
     suspend fun sendOTPWithEmailSecondary(
         @Body request: ConsumerRequests.OTP.Email
-    ): CommonResponses.SendResponse
+    ): ConsumerResponses.OTPSendResponse
 
     @POST("otps/authenticate") // TODO Need to create a proper name to differentiate fom magiclinks authenticate
     suspend fun authenticateWithOTP(

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.network.models
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.StytchDataResponse
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
+import com.stytch.sdk.common.network.models.OTPSendResponseData
 
 internal object ConsumerResponses {
     object Passwords {
@@ -50,4 +51,7 @@ internal object ConsumerResponses {
 
     @JsonClass(generateAdapter = true)
     class LoginOrCreateOTPResponse(data: LoginOrCreateOTPData) : StytchDataResponse<LoginOrCreateOTPData>(data)
+
+    @JsonClass(generateAdapter = true)
+    class OTPSendResponse(data: OTPSendResponseData) : StytchDataResponse<OTPSendResponseData>(data)
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.common.Constants.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
 import com.stytch.sdk.common.Constants.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
+import com.stytch.sdk.consumer.OTPSendResponse
 
 /**
  * The OTP interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS, WhatsApp, and
@@ -100,17 +101,17 @@ public interface OTP {
          * Send a one-time passcode (OTP) to a user's phone number via SMS. If you'd like to create a user and send them
          * a passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
-         * @return [BaseResponse]
+         * @return [OTPSendResponse]
          */
-        public suspend fun send(parameters: Parameters): BaseResponse
+        public suspend fun send(parameters: Parameters): OTPSendResponse
 
         /**
          * Send a one-time passcode (OTP) to a user's phone number via SMS. If you'd like to create a user and send them
          * a passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
-         * @param callback a callback that receives a [BaseResponse]
+         * @param callback a callback that receives a [OTPSendResponse]
          */
-        public fun send(parameters: Parameters, callback: (response: BaseResponse) -> Unit)
+        public fun send(parameters: Parameters, callback: (response: OTPSendResponse) -> Unit)
     }
 
     /**
@@ -152,17 +153,17 @@ public interface OTP {
          * Send a one-time passcode (OTP) to a user's phone number via WhatsApp. If you'd like to create a user and send
          * them a passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
-         * @return [BaseResponse]
+         * @return [OTPSendResponse]
          */
-        public suspend fun send(parameters: Parameters): BaseResponse
+        public suspend fun send(parameters: Parameters): OTPSendResponse
 
         /**
          * Send a one-time passcode (OTP) to a user's phone number via WhatsApp. If you'd like to create a user and send
          * them a passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
-         * @param callback a callback that receives a [BaseResponse]
+         * @param callback a callback that receives a [OTPSendResponse]
          */
-        public fun send(parameters: Parameters, callback: (response: BaseResponse) -> Unit)
+        public fun send(parameters: Parameters, callback: (response: OTPSendResponse) -> Unit)
     }
 
     /**
@@ -211,16 +212,16 @@ public interface OTP {
          * Send a one-time passcode (OTP) to a user's email address. If you'd like to create a user and send them a
          * passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
-         * @return [BaseResponse] response from backend
+         * @return [OTPSendResponse] response from backend
          */
-        public suspend fun send(parameters: Parameters): BaseResponse
+        public suspend fun send(parameters: Parameters): OTPSendResponse
 
         /**
          * Send a one-time passcode (OTP) to a user's email address. If you'd like to create a user and send them a
          * passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
-         * @param callback a callback that receives a [BaseResponse]
+         * @param callback a callback that receives a [OTPSendResponse]
          */
-        public fun send(parameters: Parameters, callback: (response: BaseResponse) -> Unit)
+        public fun send(parameters: Parameters, callback: (response: OTPSendResponse) -> Unit)
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.consumer.otp
 
-import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse

--- a/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
+import com.stytch.sdk.consumer.OTPSendResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
@@ -70,7 +71,7 @@ internal class OTPImpl internal constructor(
             }
         }
 
-        override suspend fun send(parameters: OTP.SmsOTP.Parameters): BaseResponse =
+        override suspend fun send(parameters: OTP.SmsOTP.Parameters): OTPSendResponse =
             withContext(dispatchers.io) {
                 if (sessionStorage.activeSessionExists) {
                     api.sendOTPWithSMSSecondary(
@@ -85,7 +86,7 @@ internal class OTPImpl internal constructor(
                 }
             }
 
-        override fun send(parameters: OTP.SmsOTP.Parameters, callback: (response: BaseResponse) -> Unit) {
+        override fun send(parameters: OTP.SmsOTP.Parameters, callback: (response: OTPSendResponse) -> Unit) {
             externalScope.launch(dispatchers.ui) {
                 val result = send(parameters)
                 callback(result)
@@ -118,7 +119,7 @@ internal class OTPImpl internal constructor(
             }
         }
 
-        override suspend fun send(parameters: OTP.WhatsAppOTP.Parameters): BaseResponse =
+        override suspend fun send(parameters: OTP.WhatsAppOTP.Parameters): OTPSendResponse =
             withContext(dispatchers.io) {
                 if (sessionStorage.activeSessionExists) {
                     api.sendOTPWithWhatsAppSecondary(
@@ -133,7 +134,7 @@ internal class OTPImpl internal constructor(
                 }
             }
 
-        override fun send(parameters: OTP.WhatsAppOTP.Parameters, callback: (response: BaseResponse) -> Unit) {
+        override fun send(parameters: OTP.WhatsAppOTP.Parameters, callback: (response: OTPSendResponse) -> Unit) {
             externalScope.launch(dispatchers.ui) {
                 val result = send(parameters)
                 callback(result)
@@ -166,7 +167,7 @@ internal class OTPImpl internal constructor(
             }
         }
 
-        override suspend fun send(parameters: OTP.EmailOTP.Parameters): BaseResponse = withContext(dispatchers.io) {
+        override suspend fun send(parameters: OTP.EmailOTP.Parameters): OTPSendResponse = withContext(dispatchers.io) {
             if (sessionStorage.activeSessionExists) {
                 api.sendOTPWithEmailSecondary(
                     email = parameters.email,
@@ -184,7 +185,7 @@ internal class OTPImpl internal constructor(
             }
         }
 
-        override fun send(parameters: OTP.EmailOTP.Parameters, callback: (response: BaseResponse) -> Unit) {
+        override fun send(parameters: OTP.EmailOTP.Parameters, callback: (response: OTPSendResponse) -> Unit) {
             externalScope.launch(dispatchers.ui) {
                 val result = send(parameters)
                 callback(result)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
@@ -1,12 +1,12 @@
 package com.stytch.sdk.consumer.otp
 
-import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
+import com.stytch.sdk.consumer.OTPSendResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.network.models.AuthData
@@ -134,7 +134,7 @@ internal class OTPImplTest {
     fun `OTPImpl sms send with callback calls callback method`() {
         every { mockSessionStorage.activeSessionExists } returns false
         coEvery { mockApi.sendOTPWithSMSPrimary(any(), any()) } returns mockk(relaxed = true)
-        val mockCallback = spyk<(BaseResponse) -> Unit>()
+        val mockCallback = spyk<(OTPSendResponse) -> Unit>()
         impl.sms.send(
             OTP.SmsOTP.Parameters(
                 phoneNumber = "phoneNumber",
@@ -190,7 +190,7 @@ internal class OTPImplTest {
     fun `OTPImpl whatsapp send with callback calls callback method`() {
         every { mockSessionStorage.activeSessionExists } returns false
         coEvery { mockApi.sendOTPWithWhatsAppPrimary(any(), any()) } returns mockk(relaxed = true)
-        val mockCallback = spyk<(BaseResponse) -> Unit>()
+        val mockCallback = spyk<(OTPSendResponse) -> Unit>()
         impl.whatsapp.send(
             OTP.WhatsAppOTP.Parameters(
                 phoneNumber = "phoneNumber",
@@ -250,7 +250,7 @@ internal class OTPImplTest {
     fun `OTPImpl email send with callback calls callback method`() {
         every { mockSessionStorage.activeSessionExists } returns false
         coEvery { mockApi.sendOTPWithEmailPrimary(any(), any(), any(), any()) } returns mockk(relaxed = true)
-        val mockCallback = spyk<(BaseResponse) -> Unit>()
+        val mockCallback = spyk<(OTPSendResponse) -> Unit>()
         impl.email.send(
             OTP.EmailOTP.Parameters(
                 email = "emailAddress",


### PR DESCRIPTION
Linear Ticket: [SDK-1201](https://linear.app/stytch/issue/SDK-1201)

## Changes:

1. Updates OTP Send methods to return a new response type that includes `method_id` (it's literally the same response type as LoginOrCreate returns)

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A