### PR TITLE
Passkeys client/endpoint setup

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -27,6 +27,8 @@ import com.stytch.sdk.consumer.oauth.OAuth
 import com.stytch.sdk.consumer.oauth.OAuthImpl
 import com.stytch.sdk.consumer.otp.OTP
 import com.stytch.sdk.consumer.otp.OTPImpl
+import com.stytch.sdk.consumer.passkeys.Passkeys
+import com.stytch.sdk.consumer.passkeys.PasskeysImpl
 import com.stytch.sdk.consumer.passwords.Passwords
 import com.stytch.sdk.consumer.passwords.PasswordsImpl
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
@@ -222,6 +224,24 @@ public object StytchClient {
         sessionStorage,
         StorageHelper,
         StytchApi.OAuth
+    )
+        get() {
+            assertInitialized()
+            return field
+        }
+        internal set
+
+    /**
+     * Exposes an instance of the [Passkeys] interface which provides methods for registering and authenticating
+     * with Passkeys.
+     *
+     * @throws [stytchError] if you attempt to access this property before calling StytchClient.configure()
+     */
+    public var passkeys: Passkeys = PasskeysImpl(
+        externalScope,
+        dispatchers,
+        sessionStorage,
+        StytchApi.WebAuthn
     )
         get() {
             assertInitialized()

--- a/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
@@ -12,6 +12,8 @@ import com.stytch.sdk.consumer.network.models.OAuthData
 import com.stytch.sdk.consumer.network.models.StrengthCheckResponse
 import com.stytch.sdk.consumer.network.models.UpdateUserResponseData
 import com.stytch.sdk.consumer.network.models.UserData
+import com.stytch.sdk.consumer.network.models.WebAuthnAuthenticateData
+import com.stytch.sdk.consumer.network.models.WebAuthnRegisterData
 
 /**
  * Type alias for StytchResult<IAuthData> used for authentication responses
@@ -67,3 +69,13 @@ public typealias PasswordsStrengthCheckResponse = StytchResult<StrengthCheckResp
  * Type alias for StytchResult<UpdateUserResponseData> used for UpdateUser responses
  */
 public typealias UpdateUserResponse = StytchResult<UpdateUserResponseData>
+
+/**
+ * Type alias for StytchResult<WebAuthnRegisterData> used for WebAuthn registration responses
+ */
+public typealias WebAuthnRegisterResponse = StytchResult<WebAuthnRegisterData>
+
+/**
+ * Type alias for StytchResult<WebAuthnAuthenticateData> used for WebAuthn authentication responses
+ */
+public typealias WebAuthnAuthenticateResponse = StytchResult<WebAuthnAuthenticateData>

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -21,8 +21,11 @@ import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.common.network.models.NameData
 import com.stytch.sdk.common.network.models.OTPSendResponseData
 import com.stytch.sdk.common.network.safeApiCall
+import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 import com.stytch.sdk.consumer.StytchClient
+import com.stytch.sdk.consumer.WebAuthnAuthenticateResponse
+import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.network.models.AuthData
 import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.ConsumerRequests
@@ -574,6 +577,52 @@ internal object StytchApi {
                     token = token,
                     sessionDurationMinutes = sessionDurationMinutes.toInt(),
                     codeVerifier = codeVerifier
+                )
+            )
+        }
+    }
+
+    internal object WebAuthn {
+        suspend fun registerStart(
+            userId: String,
+            domain: String,
+        ): WebAuthnRegisterResponse = safeConsumerApiCall {
+            apiService.webAuthnRegisterStart(
+                ConsumerRequests.WebAuthn.RegisterStartRequest(
+                    userId = userId,
+                    domain = domain
+                )
+            )
+        }
+
+        suspend fun register(
+            userId: String,
+            publicKeyCredential: String,
+        ) = safeConsumerApiCall {
+            apiService.webAuthnRegister(
+                ConsumerRequests.WebAuthn.RegisterRequest(
+                    userId = userId,
+                    publicKeyCredential = publicKeyCredential
+                )
+            )
+        }
+
+        suspend fun authenticateStart(
+            domain: String,
+        ): WebAuthnAuthenticateResponse = safeConsumerApiCall {
+            apiService.webAuthnAuthenticateStart(
+                ConsumerRequests.WebAuthn.AuthenticateStartRequest(
+                    domain = domain
+                )
+            )
+        }
+
+        suspend fun authenticate(
+            publicKeyCredential: Map<String, Any>,
+        ): AuthResponse = safeConsumerApiCall {
+            apiService.webAuthnAuthenticate(
+                ConsumerRequests.WebAuthn.AuthenticateRequest(
+                    publicKeyCredential = publicKeyCredential
                 )
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -197,4 +197,26 @@ internal interface StytchApiService : ApiService {
         @Path(value = "publicToken") publicToken: String
     ): CommonResponses.Bootstrap.BootstrapResponse
     //endregion Bootstrap
+
+    //region WebAuthn
+    @POST("webauthn/register/start")
+    suspend fun webAuthnRegisterStart(
+        @Body request: ConsumerRequests.WebAuthn.RegisterStartRequest
+    ): ConsumerResponses.WebAuthn.RegisterResponse
+
+    @POST("webauthn/register")
+    suspend fun webAuthnRegister(
+        @Body request: ConsumerRequests.WebAuthn.RegisterRequest
+    ): CommonResponses.BasicResponse
+
+    @POST("webauthn/authenticate/start")
+    suspend fun webAuthnAuthenticateStart(
+        @Body request: ConsumerRequests.WebAuthn.AuthenticateStartRequest
+    ): ConsumerResponses.WebAuthn.AuthenticateResponse
+
+    @POST("webauthn/authenticate")
+    suspend fun webAuthnAuthenticate(
+        @Body request: ConsumerRequests.WebAuthn.AuthenticateRequest
+    ): ConsumerResponses.AuthenticateResponse
+    //endregion WebAuthn
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -220,4 +220,50 @@ internal object ConsumerRequests {
             val untrustedMetadata: Map<String, Any?>? = null,
         )
     }
+
+    object WebAuthn {
+        @JsonClass(generateAdapter = true)
+        data class RegisterStartRequest(
+            @Json(name = "user_id")
+            val userId: String,
+            val domain: String,
+            @Json(name = "user_agent")
+            val userAgent: String? = null,
+            @Json(name = "authenticator_type")
+            val authenticatorType: String? = null,
+            @Json(name = "is_passkey")
+            val isPasskey: Boolean? = false
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class RegisterRequest(
+            @Json(name = "user_id")
+            val userId: String,
+            @Json(name = "public_key_credential")
+            val publicKeyCredential: String
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class AuthenticateStartRequest(
+            @Json(name = "user_id")
+            val userId: String? = null,
+            val domain: String,
+            @Json(name = "is_passkey")
+            val isPasskey: Boolean? = false
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class AuthenticateRequest(
+            @Json(name = "public_key_credential")
+            val publicKeyCredential: Map<String, Any>,
+            @Json(name = "session_duration_minutes")
+            val sessionDurationMinutes: Int? = null,
+            @Json(name = "session_custom_claims")
+            val sessionCustomClaims: Map<String, Any>? = null,
+            @Json(name = "session_jwt")
+            val sessionJwt: String? = null,
+            @Json(name = "session_token")
+            val sessionToken: String? = null,
+        )
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
@@ -46,6 +46,14 @@ internal object ConsumerResponses {
         class NativeOAuthAuthenticateResponse(data: NativeOAuthData) : StytchDataResponse<NativeOAuthData>(data)
     }
 
+    object WebAuthn {
+        @JsonClass(generateAdapter = true)
+        class RegisterResponse(data: WebAuthnRegisterData) : StytchDataResponse<WebAuthnRegisterData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class AuthenticateResponse(data: WebAuthnAuthenticateData) : StytchDataResponse<WebAuthnAuthenticateData>(data)
+    }
+
     @JsonClass(generateAdapter = true)
     class AuthenticateResponse(data: AuthData) : StytchDataResponse<AuthData>(data)
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
@@ -234,3 +234,17 @@ public data class UpdateUserResponseData(
     val requestId: String,
     val user: UserData
 )
+
+@JsonClass(generateAdapter = true)
+public data class WebAuthnRegisterData(
+    @Json(name = "user_id")
+    val userId: String,
+    @Json(name = "public_key_credential_creation_options")
+    val publicKeyCredentialCreationOptions: String,
+)
+
+@JsonClass(generateAdapter = true)
+public data class WebAuthnAuthenticateData(
+    @Json(name = "public_key_credential_creation_options")
+    val publicKeyCredentialCreationOptions: String,
+)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -3,29 +3,66 @@ package com.stytch.sdk.consumer.passkeys
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.consumer.AuthResponse
 
+/**
+ * The Passkeys interface provides methods for detecting Passkeys support, registering, and authenticating with
+ * Passkeys.
+ */
 public interface Passkeys {
 
+    /**
+     * Data class used for wrapping parameters used with Passkeys registration
+     * @property userId the user identifier of the Passkey registration
+     * @property domain the domain of the Passkey registration
+     * @property userAgent the user agent of the Passkey registration
+     */
     public data class RegisterParameters(
         val userId: String,
         val domain: String,
         val userAgent: String? = null,
     )
 
+    /**
+     * Data class used for wrapping parameters used with Passkeys authentication
+     * @property domain the domain of the Passkey registration
+     */
     public data class AuthenticateParameters(
         val domain: String,
     )
 
+    /**
+     * Indicates if Passkeys is supported on the device.
+     */
     public val isSupported: Boolean
 
+    /**
+     * Creates a new Passkey registration.
+     * @param parameters required to register a Passkey
+     * @return [BaseResponse]
+     */
     public suspend fun register(parameters: RegisterParameters): BaseResponse
 
+    /**
+     * Creates a new Passkey registration.
+     * @param parameters required to register a Passkey
+     * @param callback a callback that receives a [BaseResponse]
+     */
     public fun register(
         parameters: RegisterParameters,
         callback: (response: BaseResponse) -> Unit
     )
 
+    /**
+     * Authenticates a Passkey registration.
+     * @param parameters required to authenticate a Passkey registration
+     * @return [AuthResponse]
+     */
     public suspend fun authenticate(parameters: AuthenticateParameters): AuthResponse
 
+    /**
+     * Authenticates a Passkey registration.
+     * @param parameters required to authenticate a Passkey registration
+     * @param callback a callback that receives a [AuthResponse]
+     */
     public fun authenticate(
         parameters: AuthenticateParameters,
         callback: (response: AuthResponse) -> Unit,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -1,0 +1,33 @@
+package com.stytch.sdk.consumer.passkeys
+
+import com.stytch.sdk.common.BaseResponse
+import com.stytch.sdk.consumer.AuthResponse
+
+public interface Passkeys {
+
+    public data class RegisterParameters(
+        val userId: String,
+        val domain: String,
+        val userAgent: String? = null,
+    )
+
+    public data class AuthenticateParameters(
+        val domain: String,
+    )
+
+    public val isSupported: Boolean
+
+    public suspend fun register(parameters: RegisterParameters): BaseResponse
+
+    public fun register(
+        parameters: RegisterParameters,
+        callback: (response: BaseResponse) -> Unit
+    )
+
+    public suspend fun authenticate(parameters: AuthenticateParameters): AuthResponse
+
+    public fun authenticate(
+        parameters: AuthenticateParameters,
+        callback: (response: AuthResponse) -> Unit,
+    )
+}

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
@@ -1,0 +1,42 @@
+package com.stytch.sdk.consumer.passkeys
+
+import com.stytch.sdk.common.BaseResponse
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.network.StytchApi
+import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal class PasskeysImpl internal constructor(
+    private val externalScope: CoroutineScope,
+    private val dispatchers: StytchDispatchers,
+    private val sessionStorage: ConsumerSessionStorage,
+    private val api: StytchApi.WebAuthn,
+) : Passkeys {
+
+    override val isSupported: Boolean
+        get() = TODO("Not yet implemented")
+
+    override suspend fun register(parameters: Passkeys.RegisterParameters): BaseResponse {
+        TODO("Not yet implemented")
+    }
+
+    override fun register(parameters: Passkeys.RegisterParameters, callback: (response: BaseResponse) -> Unit) {
+        externalScope.launch(dispatchers.ui) {
+            val result = register(parameters)
+            callback(result)
+        }
+    }
+
+    override suspend fun authenticate(parameters: Passkeys.AuthenticateParameters): AuthResponse {
+        TODO("Not yet implemented")
+    }
+
+    override fun authenticate(parameters: Passkeys.AuthenticateParameters, callback: (response: AuthResponse) -> Unit) {
+        externalScope.launch(dispatchers.ui) {
+            val result = authenticate(parameters)
+            callback(result)
+        }
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1191](https://linear.app/stytch/issue/SDK-1191)

## Changes:

1. Add a new `Passkeys` interface to the `StytchClient`
2. Add data models for Passkeys requests + responses
3. Set up calls to the WebAuthn API

## Notes:

- As part of the lean MVP for Passkeys, we are reusing the WebAuthn API, instead of creating a new Passkeys API.
- TODOs are to be completed in [SDK-1190](https://linear.app/stytch/issue/SDK-1190)

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A