### PR TITLE
DFP Updates

### DIFF
--- a/sdk/src/main/assets/dfp.html
+++ b/sdk/src/main/assets/dfp.html
@@ -6,7 +6,7 @@
     <body>
         <script>
             function fetchTelemetryId(publicToken) {
-                window.GetTelemetryID(publicToken)
+                window.GetTelemetryID({ publicToken: publicToken, platform: "Android" })
                     .then((telemetryId) => StytchDFP.reportTelemetryId(telemetryId))
                     .catch((error) => StytchDFP.reportTelemetryId(error.message));
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -28,6 +28,9 @@ import com.stytch.sdk.common.StytchExceptions
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.ActivityProvider
 import com.stytch.sdk.common.dfp.CaptchaProviderImpl
+import com.stytch.sdk.common.dfp.DFP
+import com.stytch.sdk.common.dfp.DFPImpl
+import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.dfp.DFPProviderImpl
 import com.stytch.sdk.common.extensions.getDeviceInfo
 import com.stytch.sdk.common.network.StytchErrorType
@@ -49,6 +52,8 @@ public object StytchB2BClient {
     public var bootstrapData: BootstrapData = BootstrapData()
         internal set
 
+    internal lateinit var dfpProvider: DFPProvider
+
     /**
      * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
      * across app launches.
@@ -63,13 +68,14 @@ public object StytchB2BClient {
             StorageHelper.initialize(context)
             StytchB2BApi.configure(publicToken, deviceInfo)
             val activityProvider = ActivityProvider(context.applicationContext as Application)
+            dfpProvider = DFPProviderImpl(publicToken, activityProvider)
             externalScope.launch(dispatchers.io) {
                 bootstrapData = when (val res = StytchB2BApi.getBootstrapData()) {
                     is StytchResult.Success -> res.value
                     else -> BootstrapData()
                 }
                 StytchB2BApi.configureDFP(
-                    dfpProvider = DFPProviderImpl(publicToken, activityProvider),
+                    dfpProvider = dfpProvider,
                     captchaProvider = CaptchaProviderImpl(
                         context.applicationContext as Application,
                         externalScope,
@@ -217,6 +223,17 @@ public object StytchB2BClient {
             return field
         }
         internal set
+
+    /**
+     * Exposes an instance of the [DFP] interface which provides a method for retrieving a dfp_telemetry_id for use
+     * in DFP lookups on your backend server
+     *
+     * @throws [stytchError] if you attempt to access this property before calling StytchB2BClient.configure()
+     */
+    public val dfp: DFP by lazy {
+        assertInitialized()
+        DFPImpl(dfpProvider, dispatchers, externalScope)
+    }
 
     /**
      * Call this method to parse out and authenticate deeplinks that your application receives. The currently supported

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/DFP.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/DFP.kt
@@ -1,0 +1,15 @@
+package com.stytch.sdk.common.dfp
+
+public interface DFP {
+    /**
+     * Fetches a DFP Telemetry ID for use in backend lookup calls
+     * @return String a dpf_telemetry_id
+     */
+    public suspend fun getTelemetryId(): String
+
+    /**
+     * Fetches a DFP Telemetry ID for use in backend lookup calls
+     * @param callback  a callback that receives a dpf_telemetry_id
+     */
+    public fun getTelemetryId(callback: (String) -> Unit)
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPImpl.kt
@@ -1,0 +1,22 @@
+package com.stytch.sdk.common.dfp
+
+import com.stytch.sdk.common.StytchDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal class DFPImpl(
+    private val dfpProvider: DFPProvider,
+    private val dispatchers: StytchDispatchers,
+    private val externalScope: CoroutineScope,
+) : DFP {
+    override suspend fun getTelemetryId(): String = withContext(dispatchers.io) {
+        dfpProvider.getTelemetryId()
+    }
+
+    override fun getTelemetryId(callback: (String) -> Unit) {
+        externalScope.launch(dispatchers.ui) {
+            callback(getTelemetryId())
+        }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -77,6 +77,7 @@ internal class StytchB2BClientTest {
         StytchB2BClient.magicLinks = mockMagicLinks
         StytchB2BClient.externalScope = TestScope()
         StytchB2BClient.dispatchers = StytchDispatchers(dispatcher, dispatcher)
+        StytchB2BClient.dfpProvider = mockk()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -220,6 +221,18 @@ internal class StytchB2BClientTest {
     fun `accessing StytchB2BClient sso returns instance of SSO when configured`() {
         every { StytchB2BApi.isInitialized } returns true
         StytchB2BClient.sso
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `accessing StytchB2BClient dfp throws IllegalStateException when not configured`() {
+        every { StytchB2BApi.isInitialized } returns false
+        StytchB2BClient.dfp
+    }
+
+    @Test
+    fun `accessing StytchB2BClient dfp returns instance of OAuth when configured`() {
+        every { StytchB2BApi.isInitialized } returns true
+        StytchB2BClient.dfp
     }
 
     @Test(expected = IllegalStateException::class)

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -230,7 +230,7 @@ internal class StytchB2BClientTest {
     }
 
     @Test
-    fun `accessing StytchB2BClient dfp returns instance of OAuth when configured`() {
+    fun `accessing StytchB2BClient dfp returns instance of DFP when configured`() {
         every { StytchB2BApi.isInitialized } returns true
         StytchB2BClient.dfp
     }

--- a/sdk/src/test/java/com/stytch/sdk/common/dfp/DFPImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/dfp/DFPImplTest.kt
@@ -1,0 +1,54 @@
+package com.stytch.sdk.common.dfp
+
+import com.stytch.sdk.common.StytchDispatchers
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class DFPImplTest {
+    @MockK
+    private lateinit var dfpProvider: DFPProvider
+
+    private lateinit var impl: DFPImpl
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this, true, true)
+        coEvery { dfpProvider.getTelemetryId() } returns "dfp-telemetry-id"
+        impl = DFPImpl(
+            dfpProvider = dfpProvider,
+            dispatchers = StytchDispatchers(Dispatchers.Unconfined, Dispatchers.Unconfined),
+            externalScope = TestScope(),
+        )
+    }
+
+    @After
+    fun after() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `getTelemetryId delegates to provider`() = runTest {
+        impl.getTelemetryId()
+        coVerify(exactly = 1) { dfpProvider.getTelemetryId() }
+    }
+
+    @Test
+    fun `getTelemetryId with callback calls callback`() {
+        val callback = spyk<(String) -> Unit>()
+        impl.getTelemetryId(callback)
+        verify(exactly = 1) { callback.invoke("dfp-telemetry-id") }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -75,13 +75,14 @@ internal class StytchClientTest {
         mockkObject(StorageHelper)
         mockkObject(StytchApi)
         every { StorageHelper.initialize(any()) } just runs
-        every { StorageHelper.loadValue(any()) } returns ""
+        every { StorageHelper.loadValue(any()) } returns "some-value"
         every { StorageHelper.generateHashedCodeChallenge() } returns Pair("", "")
         MockKAnnotations.init(this, true, true)
         StytchClient.oauth = mockOAuth
         StytchClient.magicLinks = mockMagicLinks
         StytchClient.externalScope = TestScope()
         StytchClient.dispatchers = StytchDispatchers(dispatcher, dispatcher)
+        StytchClient.dfpProvider = mockk()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -225,6 +226,18 @@ internal class StytchClientTest {
     fun `accessing StytchClient oauth returns instance of OAuth when configured`() {
         every { StytchApi.isInitialized } returns true
         StytchClient.oauth
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `accessing StytchClient dfp throws IllegalStateException when not configured`() {
+        every { StytchApi.isInitialized } returns false
+        StytchClient.dfp
+    }
+
+    @Test
+    fun `accessing StytchClient dfp returns instance of OAuth when configured`() {
+        every { StytchApi.isInitialized } returns true
+        StytchClient.dfp
     }
 
     @Test(expected = IllegalStateException::class)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -235,7 +235,7 @@ internal class StytchClientTest {
     }
 
     @Test
-    fun `accessing StytchClient dfp returns instance of OAuth when configured`() {
+    fun `accessing StytchClient dfp returns instance of DFP when configured`() {
         every { StytchApi.isInitialized } returns true
         StytchClient.dfp
     }


### PR DESCRIPTION
Linear Ticket:
[SDK-1223](https://linear.app/stytch/issue/SDK-1223)
[SDK-1224](https://linear.app/stytch/issue/SDK-1224)

## Changes:

1. Updates the GetTelemetryID call to pass an object with the platform
2. Adds a top-level DFP object that exposes a getTelemetryId method that delegates to the existing DFPProvider

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A