### PR TITLE
SDK-1197 Passkeys unit tests

### DIFF
--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -243,6 +243,18 @@ internal class StytchClientTest {
     }
 
     @Test(expected = IllegalStateException::class)
+    fun `accessing StytchClient passkeys throws IllegalStateException when not configured`() {
+        every { StytchApi.isInitialized } returns false
+        StytchClient.passkeys
+    }
+
+    @Test
+    fun `accessing StytchClient passkeys returns instance of Passkeys when configured`() {
+        every { StytchApi.isInitialized } returns true
+        StytchClient.passkeys
+    }
+
+    @Test(expected = IllegalStateException::class)
     fun `handle with coroutines throws IllegalStateException when not configured`() {
         runBlocking {
             every { StytchApi.isInitialized } returns false

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -739,6 +739,111 @@ internal class StytchApiServiceTests {
     }
     // endregion Bootstrap
 
+    //region Webauthn
+    @Test
+    fun `check webAuthnRegisterStart request`() {
+        val parameters = ConsumerRequests.WebAuthn.RegisterStartRequest(
+            domain = "test.domain.com",
+            userAgent = "My Test UserAgent",
+            authenticatorType = "platform",
+            isPasskey = true
+        )
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.webAuthnRegisterStart(parameters)
+            }.verifyPost(
+                expectedPath = "/webauthn/register/start",
+                expectedBody = mapOf(
+                    "domain" to parameters.domain,
+                    "user_agent" to parameters.userAgent,
+                    "authenticator_type" to parameters.authenticatorType,
+                    "return_passkey_credential_options" to parameters.isPasskey,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check webAuthnRegister request`() {
+        val parameters = ConsumerRequests.WebAuthn.RegisterRequest(
+            publicKeyCredential = "my-public-key-credential"
+        )
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.webAuthnRegister(parameters)
+            }.verifyPost(
+                expectedPath = "/webauthn/register",
+                expectedBody = mapOf(
+                    "public_key_credential" to parameters.publicKeyCredential,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check webAuthnAuthenticateStartPrimary request`() {
+        val parameters = ConsumerRequests.WebAuthn.AuthenticateStartRequest(
+            domain = "test.domain.com",
+            isPasskey = true,
+        )
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.webAuthnAuthenticateStartPrimary(parameters)
+            }.verifyPost(
+                expectedPath = "/webauthn/authenticate/start/primary",
+                expectedBody = mapOf(
+                    "domain" to parameters.domain,
+                    "return_passkey_credential_options" to parameters.isPasskey,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check webAuthnAuthenticateStartSecondary request`() {
+        val parameters = ConsumerRequests.WebAuthn.AuthenticateStartRequest(
+            domain = "test.domain.com",
+            isPasskey = true,
+        )
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.webAuthnAuthenticateStartSecondary(parameters)
+            }.verifyPost(
+                expectedPath = "/webauthn/authenticate/start/secondary",
+                expectedBody = mapOf(
+                    "domain" to parameters.domain,
+                    "return_passkey_credential_options" to parameters.isPasskey,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check webAuthnAuthenticate request`() {
+        val parameters = ConsumerRequests.WebAuthn.AuthenticateRequest(
+            publicKeyCredential = "my-public-key-credential",
+            sessionDurationMinutes = 30,
+            sessionCustomClaims = mapOf("test" to true),
+            sessionJwt = "my-session-jwt",
+            sessionToken = "my-session-token",
+        )
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.webAuthnAuthenticate(parameters)
+            }.verifyPost(
+                expectedPath = "/webauthn/authenticate",
+                expectedBody = mapOf(
+                    "public_key_credential" to parameters.publicKeyCredential,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
+                    "session_custom_claims" to parameters.sessionCustomClaims,
+                    "session_jwt" to parameters.sessionJwt,
+                    "session_token" to parameters.sessionToken,
+                )
+            )
+        }
+    }
+    //endregion
+
     private suspend fun requestIgnoringResponseException(block: suspend () -> Unit): RecordedRequest {
         try {
             block()

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -374,6 +374,50 @@ internal class StytchApiTest {
         coVerify { StytchApi.apiService.getBootstrapData("mock-public-token") }
     }
 
+    @Test
+    fun `StytchApi Webauthn registerStart calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        coEvery { StytchApi.apiService.webAuthnRegisterStart(mockk(relaxed = true)) } returns mockk(relaxed = true)
+        StytchApi.WebAuthn.registerStart("")
+        coVerify { StytchApi.apiService.webAuthnRegisterStart(any()) }
+    }
+
+    @Test
+    fun `StytchApi Webauthn register calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        coEvery { StytchApi.apiService.webAuthnRegister(mockk(relaxed = true)) } returns mockk(relaxed = true)
+        StytchApi.WebAuthn.register("")
+        coVerify { StytchApi.apiService.webAuthnRegister(any()) }
+    }
+
+    @Test
+    fun `StytchApi Webauthn webAuthnAuthenticateStartPrimary calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        coEvery {
+            StytchApi.apiService.webAuthnAuthenticateStartPrimary(mockk(relaxed = true))
+        } returns mockk(relaxed = true)
+        StytchApi.WebAuthn.authenticateStartPrimary("", false)
+        coVerify { StytchApi.apiService.webAuthnAuthenticateStartPrimary(any()) }
+    }
+
+    @Test
+    fun `StytchApi Webauthn webAuthnAuthenticateStartSecondary calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        coEvery {
+            StytchApi.apiService.webAuthnAuthenticateStartSecondary(mockk(relaxed = true))
+        } returns mockk(relaxed = true)
+        StytchApi.WebAuthn.authenticateStartSecondary("", true)
+        coVerify { StytchApi.apiService.webAuthnAuthenticateStartSecondary(any()) }
+    }
+
+    @Test
+    fun `StytchApi Webauthn webAuthnAuthenticate calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        coEvery { StytchApi.apiService.webAuthnAuthenticate(mockk(relaxed = true)) } returns mockk(relaxed = true)
+        StytchApi.WebAuthn.authenticate("", 30U)
+        coVerify { StytchApi.apiService.webAuthnAuthenticate(any()) }
+    }
+
     @Test(expected = IllegalStateException::class)
     fun `safeApiCall throws exception when StytchClient is not initialized`() = runTest {
         every { StytchApi.isInitialized } returns false

--- a/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
@@ -1,0 +1,236 @@
+package com.stytch.sdk.consumer.passkeys
+
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.StytchExceptions
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.sessions.SessionAutoUpdater
+import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.WebAuthnRegisterResponse
+import com.stytch.sdk.consumer.extensions.launchSessionUpdater
+import com.stytch.sdk.consumer.network.StytchApi
+import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.security.KeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class PasskeysImplTest {
+    @MockK
+    private lateinit var mockApi: StytchApi.WebAuthn
+
+    @MockK
+    private lateinit var mockSessionStorage: ConsumerSessionStorage
+
+    @MockK
+    private lateinit var mockPasskeysProvider: PasskeysProvider
+
+    private lateinit var impl: PasskeysImpl
+    private val dispatcher = Dispatchers.Unconfined
+
+    @Before
+    fun before() {
+        mockkStatic(KeyStore::class)
+        mockkStatic(
+            "com.stytch.sdk.consumer.extensions.StytchResultExtKt"
+        )
+        MockKAnnotations.init(this, true, true)
+        mockkObject(SessionAutoUpdater)
+        every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        impl = spyk(
+            PasskeysImpl(
+                externalScope = TestScope(),
+                dispatchers = StytchDispatchers(dispatcher, dispatcher),
+                sessionStorage = mockSessionStorage,
+                api = mockApi,
+                provider = mockPasskeysProvider,
+            ),
+            recordPrivateCalls = true
+        )
+    }
+
+    @After
+    fun after() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `register returns error if passkeys are unsupported`() = runTest {
+        every { impl.isSupported } returns false
+        val result = impl.register(mockk(relaxed = true))
+        require(result is StytchResult.Error)
+        require(result.exception is StytchExceptions.Input)
+        assert(result.exception.reason == "Passkeys are not supported")
+    }
+
+    @Test
+    fun `register returns error if registerStart api call fails`() = runTest {
+        every { impl.isSupported } returns true
+        coEvery { mockApi.registerStart(any(), any(), any(), any()) } returns StytchResult.Error(mockk())
+        val result = impl.register(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 0) { mockApi.register(any()) }
+    }
+
+    @Test
+    fun `register returns error if createPublicKeyCredential call fails`() = runTest {
+        every { impl.isSupported } returns true
+        coEvery {
+            mockApi.registerStart(any(), any(), any(), any())
+        } returns StytchResult.Success(mockk(relaxed = true))
+        coEvery { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) } throws Exception()
+        val result = impl.register(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 0) { mockApi.register(any()) }
+    }
+
+    @Test
+    fun `register returns error if register api call fails`() = runTest {
+        every { impl.isSupported } returns true
+        coEvery {
+            mockApi.registerStart(any(), any(), any(), any())
+        } returns StytchResult.Success(mockk(relaxed = true))
+        coEvery { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
+        coEvery { mockApi.register(any()) } returns StytchResult.Error(mockk(relaxed = true))
+        val result = impl.register(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 1) { mockApi.register(any()) }
+    }
+
+    @Test
+    fun `register calls launchSessionUpdater and returns success if registration flow succeeds`() = runTest {
+        every { impl.isSupported } returns true
+        coEvery {
+            mockApi.registerStart(any(), any(), any(), any())
+        } returns StytchResult.Success(mockk(relaxed = true))
+        coEvery { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
+        val mockSuccessResponse = mockk<WebAuthnRegisterResponse>(relaxed = true)
+        coEvery { mockApi.register(any()) } returns mockSuccessResponse
+        every { mockSuccessResponse.launchSessionUpdater(any(), any()) } just runs
+        impl.register(mockk(relaxed = true))
+        coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 1) { mockApi.register(any()) }
+        verify(exactly = 1) { mockSuccessResponse.launchSessionUpdater(any(), any()) }
+    }
+
+    @Test
+    fun `register with callback calls callback method`() {
+        // short circuit on the first internal check, since we just care that the callback method is called
+        val mockCallback = spyk<(WebAuthnRegisterResponse) -> Unit>()
+        impl.register(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `authenticate returns error if passkeys are unsupported`() = runTest {
+        every { impl.isSupported } returns false
+        val result = impl.authenticate(mockk())
+        require(result is StytchResult.Error)
+        require(result.exception is StytchExceptions.Input)
+        assert(result.exception.reason == "Passkeys are not supported")
+    }
+
+    @Test
+    fun `authenticate returns error if authenticateStartSecondary api call fails`() = runTest {
+        every { impl.isSupported } returns true
+        every { mockSessionStorage.activeSessionExists } returns true
+        coEvery { mockApi.authenticateStartSecondary(any(), any()) } returns StytchResult.Error(mockk())
+        val result = impl.authenticate(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 1) { mockApi.authenticateStartSecondary(any(), any()) }
+        coVerify(exactly = 0) { mockApi.authenticateStartPrimary(any(), any()) }
+        coVerify(exactly = 0) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 0) { mockApi.authenticate(any(), any()) }
+    }
+
+    @Test
+    fun `authenticate returns error if authenticateStartPrimary api call fails`() = runTest {
+        every { impl.isSupported } returns true
+        every { mockSessionStorage.activeSessionExists } returns false
+        coEvery { mockApi.authenticateStartPrimary(any(), any()) } returns StytchResult.Error(mockk())
+        val result = impl.authenticate(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
+        coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
+        coVerify(exactly = 0) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 0) { mockApi.authenticate(any(), any()) }
+    }
+
+    @Test
+    fun `authenticate returns error if getPublicKeyCredential call fails`() = runTest {
+        every { impl.isSupported } returns true
+        every { mockSessionStorage.activeSessionExists } returns false
+        coEvery { mockApi.authenticateStartPrimary(any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
+        coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } throws Exception()
+        val result = impl.authenticate(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
+        coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
+        coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 0) { mockApi.authenticate(any(), any()) }
+    }
+
+    @Test
+    fun `authenticate returns error if authenticate api call fails`() = runTest {
+        every { impl.isSupported } returns true
+        every { mockSessionStorage.activeSessionExists } returns false
+        coEvery { mockApi.authenticateStartPrimary(any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
+        coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
+        coEvery { mockApi.authenticate(any(), any()) } returns StytchResult.Error(mockk(relaxed = true))
+        val result = impl.authenticate(mockk(relaxed = true))
+        assert(result is StytchResult.Error)
+        coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
+        coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
+        coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 1) { mockApi.authenticate(any(), any()) }
+    }
+
+    @Test
+    fun `authenticate calls launchSessionUpdater and returns success if authentication flow succeeds`() = runTest {
+        every { impl.isSupported } returns true
+        every { mockSessionStorage.activeSessionExists } returns false
+        coEvery { mockApi.authenticateStartPrimary(any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
+        coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
+        val mockSuccessResponse = mockk<AuthResponse>(relaxed = true)
+        coEvery { mockApi.authenticate(any(), any()) } returns mockSuccessResponse
+        every { mockSuccessResponse.launchSessionUpdater(any(), any()) } just runs
+        impl.authenticate(mockk(relaxed = true))
+        coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
+        coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
+        coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+        coVerify(exactly = 1) { mockApi.authenticate(any(), any()) }
+        verify(exactly = 1) { mockSuccessResponse.launchSessionUpdater(any(), any()) }
+    }
+
+    @Test
+    fun `authenticate with callback calls callback method`() {
+        // short circuit on the first internal check, since we just care that the callback method is called
+        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        impl.authenticate(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysTest.kt
@@ -1,0 +1,23 @@
+package com.stytch.sdk.consumer.passkeys
+
+import android.app.Activity
+import com.stytch.sdk.common.Constants
+import io.mockk.mockk
+import org.junit.Test
+
+internal class PasskeysTest {
+    @Test
+    fun `Passkeys AuthenticateParameters have correct default values`() {
+        val mockActivity: Activity = mockk()
+        val params = Passkeys.AuthenticateParameters(
+            activity = mockActivity,
+            domain = "test.domain.com"
+        )
+        val expected = Passkeys.AuthenticateParameters(
+            activity = mockActivity,
+            domain = "test.domain.com",
+            sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
+        )
+        assert(params == expected)
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1197](https://linear.app/stytch/issue/SDK-1197)

## Changes:

1. Moves Android specific credential provider stuff to a provider class for easier testing (same as we do for Biometrics)
2. Adds tests for all of the Passkeys changes

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A