### PR TITLE
SDK-1307 Add new error classes

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
@@ -1,0 +1,10 @@
+package com.stytch.sdk.common.errors
+
+/**
+ * An error class representing non-schema error that occurs in Stytch API
+ */
+public class StytchAPIError(description: String, url: String? = null) : StytchError(
+    name = "StytchAPIError",
+    description = description,
+    url = url
+)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
@@ -1,0 +1,10 @@
+package com.stytch.sdk.common.errors
+
+/**
+ * An error class representing a schema error that occurs in Stytch API
+ */
+public class StytchAPISchemaError(description: String, url: String? = null) : StytchError(
+    name = "StytchAPISchemaError",
+    description = description,
+    url = url
+)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
@@ -1,0 +1,10 @@
+package com.stytch.sdk.common.errors
+
+/**
+ * An error class that occurs when Stytch SDK cannot reach the API
+ */
+public class StytchAPIUnreachableError(description: String, url: String? = null) : StytchError(
+    name = "StytchAPIUnreachableError",
+    description = description,
+    url = url
+)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
@@ -1,0 +1,11 @@
+package com.stytch.sdk.common.errors
+
+/**
+ * A base error class for all errors returned by the Stytch SDK
+ */
+public sealed class StytchError(
+    public val name: String,
+    public val description: String,
+    public val url: String? = null,
+    public val exception: Throwable? = null,
+) : Exception()

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -1,0 +1,17 @@
+package com.stytch.sdk.common.errors
+
+/**
+ * A base class representing SDK specific errors or exceptions that may occur. This class should not be used directly,
+ * rather we should be creating implementations for each of the known/expected errors we return.
+ */
+public sealed class StytchSDKError(
+    name: String,
+    description: String,
+    url: String? = null,
+    exception: Throwable? = null,
+) : StytchError(
+    name = name,
+    description = description,
+    url = url,
+    exception = exception,
+)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKUsageError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKUsageError.kt
@@ -1,0 +1,10 @@
+package com.stytch.sdk.common.errors
+
+/**
+ * An error that occurs when an SDK method is called with invalid input
+ */
+public class StytchSDKUsageError(description: String, url: String? = null) : StytchError(
+    name = "StytchSDKUsageError",
+    description = description,
+    url = url
+)


### PR DESCRIPTION
Linear Ticket: [SDK-1307](https://linear.app/stytch/issue/SDK-1307)

## Changes:

1. Adds new error classes for future implementation

## Notes:

- These classes obviously aren't used yet, it just sets up the implementation/inheritance hierarchy. Implementation will take place in SDK-1329 and SDK-1311

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A