### PR TITLE
SDK-1316 Test new errors

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
@@ -1,6 +1,6 @@
 package com.stytch.sdk.common
 
-import com.stytch.sdk.common.errors.StytchError
+import com.stytch.sdk.common.errors.StytchDeeplinkError
 
 /**
  * A class representing the three states of a deeplink handled by StytchClient.handle() / StytchB2BClient.handle()
@@ -19,9 +19,9 @@ public sealed interface DeeplinkHandledStatus {
      * This could happen if you pass a non-Stytch deeplink intent to the StytchClient.handle() method, or are trying to
      * use a Consumer/B2B token in the wrong SDK.
      *
-     * @property reason An error explaining why the deeplink was not handled
+     * @property reason A StytchDeeplinkError explaining why the deeplink was not handled
      */
-    public data class NotHandled(val reason: StytchError) : DeeplinkHandledStatus
+    public data class NotHandled(val reason: StytchDeeplinkError) : DeeplinkHandledStatus
 
     /**
      * Indicates that this was a supported Stytch deeplink, but there is something more your application needs to do

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -101,38 +101,6 @@ public object StytchNoBiometricsRegistrationError : StytchSDKError(
     description = "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.",
 )
 
-/* These Biometric errors are not thrown on Android
-public object StytchBiometricsUnavailableError : StytchSDKError(
-    name = "biometrics_unavailable",
-    description = "Biometrics is not available on the device.",
-)
-
-public object StytchKeyInvalidatedError : StytchSDKError(
-    name = "key_invalidated",
-    description = "The biometrics enrollment on the device has changed.",
-)
-
-public object StytchNoBiometricsEnrolledError : StytchSDKError(
-    name = "no_biometrics_enrolled",
-    description = "There is no biometric factor enrolled on the device. Add a biometric factor in the device settings.",
-)
-
-public object StytchUserCancellationError : StytchSDKError(
-    name = "user_cancellation",
-    description = "The user canceled the prompt. Ask the user to try again.",
-)
-
-public object StytchUserLockedOutError : StytchSDKError(
-    name = "user_locked_out",
-    description = "The user has been locked out due to too many failed attempts. Ask the user to try again later.",
-)
-
-public object StytchDeviceCredentialsNotAllowedError : StytchSDKError(
-    name = "device_credentials_not_allowed",
-    description = "The device credentials allowment is mismatched. Change the allowDeviceCredentials parameter to be the same in both the register and authenticate methods.",
-)
-*/
-
 /**
  * Thrown when the keystore is unavailable, but the developer did not pass allowFallbackToCleartext=true
  */

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -62,9 +62,17 @@ public data class StytchFailedToCreateCodeChallengeError(
 )
 
 /**
+ * A type of error that can occur during deeplink handling
+ */
+public interface StytchDeeplinkError {
+    public val name: String
+    public val description: String
+}
+
+/**
  * Thrown when we were passed an unknown deeplink token type
  */
-public object StytchDeeplinkUnkownTokenTypeError : StytchSDKError(
+public object StytchDeeplinkUnkownTokenTypeError : StytchDeeplinkError, StytchSDKError(
     name = "deeplink_unknown_token_type",
     description = "The deeplink received has an unknown token type.",
 )
@@ -72,7 +80,7 @@ public object StytchDeeplinkUnkownTokenTypeError : StytchSDKError(
 /**
  * Thrown when we attempted to handle a deeplink, but no token was found
  */
-public object StytchDeeplinkMissingTokenError : StytchSDKError(
+public object StytchDeeplinkMissingTokenError : StytchDeeplinkError, StytchSDKError(
     name = "deeplink_missing_token",
     description = "The deeplink received has a missing token value.",
 )
@@ -93,21 +101,37 @@ public object StytchNoBiometricsRegistrationError : StytchSDKError(
     description = "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.",
 )
 
-/**
- * Thrown when biometrics are unavailable on the device
- */
+/* These Biometric errors are not thrown on Android
 public object StytchBiometricsUnavailableError : StytchSDKError(
     name = "biometrics_unavailable",
     description = "Biometrics is not available on the device.",
 )
 
-/**
- * Thrown when the biometrics key was invalidated
- */
 public object StytchKeyInvalidatedError : StytchSDKError(
     name = "key_invalidated",
     description = "The biometrics enrollment on the device has changed.",
 )
+
+public object StytchNoBiometricsEnrolledError : StytchSDKError(
+    name = "no_biometrics_enrolled",
+    description = "There is no biometric factor enrolled on the device. Add a biometric factor in the device settings.",
+)
+
+public object StytchUserCancellationError : StytchSDKError(
+    name = "user_cancellation",
+    description = "The user canceled the prompt. Ask the user to try again.",
+)
+
+public object StytchUserLockedOutError : StytchSDKError(
+    name = "user_locked_out",
+    description = "The user has been locked out due to too many failed attempts. Ask the user to try again later.",
+)
+
+public object StytchDeviceCredentialsNotAllowedError : StytchSDKError(
+    name = "device_credentials_not_allowed",
+    description = "The device credentials allowment is mismatched. Change the allowDeviceCredentials parameter to be the same in both the register and authenticate methods.",
+)
+*/
 
 /**
  * Thrown when the keystore is unavailable, but the developer did not pass allowFallbackToCleartext=true
@@ -115,38 +139,6 @@ public object StytchKeyInvalidatedError : StytchSDKError(
 public object StytchKeystoreUnavailableError : StytchSDKError(
     name = "keystore_unavailable",
     description = "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.",
-)
-
-/**
- * Thrown when there are no biometric enrollments on the device (ie: no fingerprints/faces)
- */
-public object StytchNoBiometricsEnrolledError : StytchSDKError(
-    name = "no_biometrics_enrolled",
-    description = "There is no biometric factor enrolled on the device. Add a biometric factor in the device settings.",
-)
-
-/**
- * Thrown when the user canceled something
- */
-public object StytchUserCancellationError : StytchSDKError(
-    name = "user_cancellation",
-    description = "The user canceled the prompt. Ask the user to try again.",
-)
-
-/**
- * Thrown when the user has been locked out
- */
-public object StytchUserLockedOutError : StytchSDKError(
-    name = "user_locked_out",
-    description = "The user has been locked out due to too many failed attempts. Ask the user to try again later.",
-)
-
-/**
- * Thrown when the allowDeviceCredentials parameter used for registration and authentication are different
- */
-public object StytchDeviceCredentialsNotAllowedError : StytchSDKError(
-    name = "device_credentials_not_allowed",
-    description = "The device credentials allowment is mismatched. Change the allowDeviceCredentials parameter to be the same in both the register and authenticate methods.",
 )
 
 /**

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ThrowableExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ThrowableExt.kt
@@ -1,0 +1,19 @@
+package com.stytch.sdk.common.extensions
+
+import com.stytch.sdk.common.StytchLog
+import com.stytch.sdk.common.errors.StytchAPIUnreachableError
+import com.stytch.sdk.common.errors.StytchError
+import retrofit2.HttpException
+
+internal fun Throwable.toStytchError(): StytchError = when (this) {
+    is StytchError -> this
+    is HttpException -> toStytchError()
+    else -> {
+        printStackTrace()
+        StytchLog.w("Network Error")
+        StytchAPIUnreachableError(
+            description = message ?: "Invalid or no response from server",
+            exception = this
+        )
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/network/SafeApiCall.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/SafeApiCall.kt
@@ -1,0 +1,18 @@
+package com.stytch.sdk.common.network
+
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.extensions.toStytchError
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal suspend fun <T1, T : StytchDataResponse<T1>> safeApiCall(
+    assertInitialized: () -> Unit,
+    apiCall: suspend () -> T
+): StytchResult<T1> = withContext(Dispatchers.IO) {
+    assertInitialized()
+    try {
+        StytchResult.Success(apiCall().data)
+    } catch (throwable: Throwable) {
+        StytchResult.Error(throwable.toStytchError())
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -22,7 +22,7 @@ public data class StytchErrorResponse(
     @Json(name = "error_message")
     val errorMessage: String?,
     @Json(name = "error_url")
-    val errorUrl: String,
+    val errorUrl: String? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/sdk/src/test/java/com/stytch/sdk/common/extensions/HttpExceptionExtTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/extensions/HttpExceptionExtTest.kt
@@ -1,0 +1,34 @@
+package com.stytch.sdk.common.extensions
+
+import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPISchemaError
+import com.stytch.sdk.common.errors.StytchAPIUnreachableError
+import com.stytch.sdk.utils.API_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.EMPTY_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.SCHEMA_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.createHttpExceptionReturningString
+import org.junit.Test
+import retrofit2.HttpException
+
+internal class HttpExceptionExtTest {
+    @Test
+    fun `StytchErrorResponse returns a StytchAPIError`() {
+        val exception: HttpException = createHttpExceptionReturningString(API_ERROR_RESPONSE_STRING)
+        val error = exception.toStytchError()
+        assert(error is StytchAPIError)
+    }
+
+    @Test
+    fun `StytchSchemaError returns a StytchAPISchemaError`() {
+        val exception: HttpException = createHttpExceptionReturningString(SCHEMA_ERROR_RESPONSE_STRING)
+        val error = exception.toStytchError()
+        assert(error is StytchAPISchemaError)
+    }
+
+    @Test
+    fun `Empty returns a StytchAPIUnreachableError`() {
+        val exception: HttpException = createHttpExceptionReturningString(EMPTY_ERROR_RESPONSE_STRING)
+        val error = exception.toStytchError()
+        assert(error is StytchAPIUnreachableError)
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/common/extensions/ThrowableExtTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/extensions/ThrowableExtTest.kt
@@ -1,0 +1,37 @@
+package com.stytch.sdk.common.extensions
+
+import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPISchemaError
+import com.stytch.sdk.common.errors.StytchAPIUnreachableError
+import com.stytch.sdk.common.errors.StytchDeeplinkUnkownTokenTypeError
+import com.stytch.sdk.utils.API_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.EMPTY_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.SCHEMA_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.createHttpExceptionReturningString
+import org.junit.Test
+
+internal class ThrowableExtTest {
+    @Test
+    fun `A StytchError returns the same StytchError`() {
+        val originalException = StytchDeeplinkUnkownTokenTypeError
+        val returnedException = originalException.toStytchError()
+        assert(originalException == returnedException)
+    }
+
+    @Test
+    fun `An HttpException returns the appropriate StytchError`() {
+        // cast the HttpExceptions as Throwables to ensure we're testing the correct extension method
+        val originalApiError: Throwable = createHttpExceptionReturningString(API_ERROR_RESPONSE_STRING)
+        val originalSchemaError: Throwable = createHttpExceptionReturningString(SCHEMA_ERROR_RESPONSE_STRING)
+        val originalUnknownError: Throwable = createHttpExceptionReturningString(EMPTY_ERROR_RESPONSE_STRING)
+        assert(originalApiError.toStytchError() is StytchAPIError)
+        assert(originalSchemaError.toStytchError() is StytchAPISchemaError)
+        assert(originalUnknownError.toStytchError() is StytchAPIUnreachableError)
+    }
+
+    @Test
+    fun `Anything else returns StytchAPIUnreachableError`() {
+        val originalException = RuntimeException("Something BAAAAAAD happened")
+        assert(originalException.toStytchError() is StytchAPIUnreachableError)
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/common/network/SafeApiCallTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/network/SafeApiCallTest.kt
@@ -1,0 +1,32 @@
+package com.stytch.sdk.common.network
+
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.network.models.CommonResponses
+import com.stytch.sdk.utils.API_ERROR_RESPONSE_STRING
+import com.stytch.sdk.utils.createHttpExceptionReturningString
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class SafeApiCallTest {
+    @Test
+    fun `A successful request returns StytchResult_Success`() = runTest {
+        val result = safeApiCall({}) {
+            mockk<CommonResponses.Bootstrap.BootstrapResponse>(relaxed = true)
+        }
+        assert(result is StytchResult.Success)
+    }
+
+    @Test
+    fun `An unsuccessful request returns StytchResult_Error`() = runTest {
+        val result = safeApiCall({}) {
+            mockk<CommonResponses.Bootstrap.BootstrapResponse> {
+                every { data } throws createHttpExceptionReturningString(API_ERROR_RESPONSE_STRING)
+            }
+        }
+        require(result is StytchResult.Error)
+        assert(result.exception is StytchAPIError)
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorageTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorageTest.kt
@@ -1,0 +1,46 @@
+package com.stytch.sdk.consumer.sessions
+
+import com.stytch.sdk.common.Constants
+import com.stytch.sdk.common.StorageHelper
+import com.stytch.sdk.common.errors.StytchNoCurrentSessionError
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import org.junit.Before
+import org.junit.Test
+import java.security.KeyStore
+
+internal class ConsumerSessionStorageTest {
+
+    private lateinit var impl: ConsumerSessionStorage
+
+    @Before
+    fun before() {
+        mockkStatic(KeyStore::class)
+        every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
+        mockkObject(StorageHelper)
+        every { StorageHelper.saveValue(any(), any()) } just runs
+        impl = ConsumerSessionStorage(StorageHelper)
+    }
+
+    @Test(expected = StytchNoCurrentSessionError::class)
+    fun `ensureSessionIsValidOrThrow throws StytchNoCurrentSessionError if missing sessionToken and sessionJwt`() {
+        impl.ensureSessionIsValidOrThrow()
+    }
+
+    @Test
+    fun `ensureSessionIsValidOrThrow doesn't throw StytchNoCurrentSessionError if either exists`() {
+        every { StorageHelper.loadValue(Constants.PREFERENCES_NAME_SESSION_TOKEN) } returns "sessionToken"
+        every { StorageHelper.loadValue(Constants.PREFERENCES_NAME_SESSION_JWT) } returns null
+        impl.ensureSessionIsValidOrThrow()
+        every { StorageHelper.loadValue(Constants.PREFERENCES_NAME_SESSION_TOKEN) } returns null
+        every { StorageHelper.loadValue(Constants.PREFERENCES_NAME_SESSION_JWT) } returns "sessionJwt"
+        impl.ensureSessionIsValidOrThrow()
+        every { StorageHelper.loadValue(Constants.PREFERENCES_NAME_SESSION_TOKEN) } returns "sessionToken"
+        every { StorageHelper.loadValue(Constants.PREFERENCES_NAME_SESSION_JWT) } returns "sessionJwt"
+        impl.ensureSessionIsValidOrThrow()
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/utils/HttpExceptionUtils.kt
+++ b/sdk/src/test/java/com/stytch/sdk/utils/HttpExceptionUtils.kt
@@ -1,0 +1,28 @@
+package com.stytch.sdk.utils
+
+import io.mockk.every
+import io.mockk.mockk
+import retrofit2.HttpException
+
+internal const val API_ERROR_RESPONSE_STRING = """{
+    "status_code": 400,
+    "error_type": "some_api_error",
+    "error_message": "This is a test error message",
+    "error_url": "https://stytch.com/docs/something"
+}"""
+
+internal const val SCHEMA_ERROR_RESPONSE_STRING = """{
+    "body": ""
+}"""
+
+internal const val EMPTY_ERROR_RESPONSE_STRING = ""
+
+internal fun createHttpExceptionReturningString(string: String): HttpException = mockk {
+    every { code() } returns 400
+    every { message } returns "Something went wrong"
+    every { response() } returns mockk {
+        every { errorBody() } returns mockk {
+            every { string() } returns string
+        }
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1316](https://linear.app/stytch/issue/SDK-1316)

## Changes:

1. Make DeeplinkHandledStatus report only a subset of SDKErrors for better DX
2. Minor refactoring for easier testing
3. Add some missing tests
4. Remove out some unused biometric-specific errors. On Android and iOS we expose the same information in an availability object (or a simple boolean). RN will be updated to match

## Notes:

- Not really a lot in this PR, but that's a good thing, because the other errors are already being tested for in existing tests

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A