### PR TITLE
Error simplification and additional tests

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/Util.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/Util.kt
@@ -1,6 +1,7 @@
 package com.stytch.exampleapp.b2b
 
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.StytchAPIError
 import java.util.regex.Pattern
 
 private val EMAIL_ADDRESS_PATTERN = Pattern.compile(
@@ -25,5 +26,11 @@ fun isPhoneNumberValid(str: String): Boolean {
 
 fun <T : Any> StytchResult<T>.toFriendlyDisplay() = when (this) {
     is StytchResult.Success<*> -> this.toString()
-    is StytchResult.Error -> "Name: ${exception.name}\nDescription: ${exception.description}\nURL: ${exception.url}"
+    is StytchResult.Error -> {
+        var message = "Name: ${exception.name}\nDescription: ${exception.description}"
+        if (exception is StytchAPIError) {
+            message += "\nURL: ${(exception as StytchAPIError).url}"
+        }
+        message
+    }
 }

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/Util.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/Util.kt
@@ -1,6 +1,7 @@
 package com.stytch.exampleapp
 
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.StytchAPIError
 import java.util.regex.Pattern
 
 private val EMAIL_ADDRESS_PATTERN = Pattern.compile(
@@ -25,5 +26,11 @@ fun isPhoneNumberValid(str: String): Boolean {
 
 fun <T : Any> StytchResult<T>.toFriendlyDisplay() = when (this) {
     is StytchResult.Success<*> -> this.toString()
-    is StytchResult.Error -> "Name: ${exception.name}\nDescription: ${exception.description}\nURL: ${exception.url}"
+    is StytchResult.Error -> {
+        var message = "Name: ${exception.name}\nDescription: ${exception.description}"
+        if (exception is StytchAPIError) {
+            message += "\nURL: ${(exception as StytchAPIError).url}"
+        }
+        message
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
@@ -7,9 +7,8 @@ public data class StytchAPIError(
     public val requestId: String? = null,
     public override val name: String,
     public override val description: String,
-    public override val url: String? = null,
+    public val url: String? = null,
 ) : StytchError(
     name = name,
     description = description,
-    url = url
 )

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
@@ -5,9 +5,7 @@ package com.stytch.sdk.common.errors
  */
 public data class StytchAPISchemaError(
     public override val description: String,
-    public override val url: String? = null,
 ) : StytchError(
     name = "StytchAPISchemaError",
     description = description,
-    url = url
 )

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
@@ -5,11 +5,8 @@ package com.stytch.sdk.common.errors
  */
 public data class StytchAPIUnreachableError(
     public override val description: String,
-    public override val url: String? = null,
-    public override val exception: Throwable?
+    public val exception: Throwable? = null,
 ) : StytchError(
     name = "StytchAPIUnreachableError",
     description = description,
-    url = url,
-    exception = exception,
 )

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
@@ -6,6 +6,4 @@ package com.stytch.sdk.common.errors
 public sealed class StytchError(
     public open val name: String,
     public open val description: String,
-    public open val url: String? = null,
-    public open val exception: Throwable? = null,
 ) : Exception()

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -10,13 +10,10 @@ package com.stytch.sdk.common.errors
 public sealed class StytchSDKError(
     name: String,
     description: String,
-    url: String? = null,
-    exception: Throwable? = null,
+    public open val exception: Throwable? = null,
 ) : StytchError(
     name = name,
     description = description,
-    url = url,
-    exception = exception,
 )
 
 /**

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKUsageError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKUsageError.kt
@@ -5,9 +5,7 @@ package com.stytch.sdk.common.errors
  */
 public data class StytchSDKUsageError(
     public override val description: String,
-    public override val url: String? = null
 ) : StytchError(
     name = "StytchSDKUsageError",
     description = description,
-    url = url
 )

--- a/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
@@ -1,0 +1,178 @@
+@file:Suppress("MaxLineLength")
+/* ktlint-disable max-line-length */
+package com.stytch.sdk.common.errors
+
+import org.junit.Test
+
+internal class StytchErrorTests {
+    @Test
+    fun `StytchAPIError has expected properties`() {
+        val error = StytchAPIError(
+            requestId = "request-id-1234",
+            name = "error_name",
+            description = "error_description",
+            url = "https://stytch.com"
+        )
+        assert(error.requestId == "request-id-1234")
+        assert(error.name == "error_name")
+        assert(error.description == "error_description")
+        assert(error.url == "https://stytch.com")
+    }
+
+    @Test
+    fun `StytchAPISchemaError has expected properties`() {
+        val error = StytchAPISchemaError(
+            description = "a schema error occurred",
+        )
+        assert(error.name == "StytchAPISchemaError")
+        assert(error.description == "a schema error occurred")
+    }
+
+    @Test
+    fun `StytchAPIUnreachableError has expected properties`() {
+        val underlyingException = RuntimeException("testing")
+        val error = StytchAPIUnreachableError(
+            description = "a schema error occurred",
+            exception = underlyingException,
+        )
+        assert(error.name == "StytchAPIUnreachableError")
+        assert(error.description == "a schema error occurred")
+        assert(error.exception == underlyingException)
+    }
+
+    @Test
+    fun `StytchSDKNotConfiguredError has expected properties`() {
+        val error = StytchSDKNotConfiguredError("Test")
+        assert(error.name == "sdk_not_configured")
+        assert(error.description == "Test not configured. You must call `Test.configure(...)` before using any functionality of the SDK.")
+    }
+
+    @Test
+    fun `StytchInternalError has expected properties`() {
+        val underlyingException = RuntimeException("testing")
+        val error1 = StytchInternalError(exception = underlyingException)
+        assert(error1.name == "stytch_internal_error")
+        assert(error1.exception == underlyingException)
+        assert(error1.description == "An internal error has occurred. Please contact Stytch if this occurs.")
+        val error2 = StytchInternalError(description = "test")
+        assert(error2.name == "stytch_internal_error")
+        assert(error2.exception == null)
+        assert(error2.description == "test")
+    }
+
+    @Test
+    fun `StytchMissingPKCEError has expected properties`() {
+        val underlyingException = RuntimeException("testing")
+        val error = StytchMissingPKCEError(underlyingException)
+        assert(error.name == "missing_pkce")
+        assert(error.description == "The PKCE code challenge or code verifier is missing. Make sure this flow is completed on the same device on which it was started.")
+        assert(error.exception == underlyingException)
+    }
+
+    @Test
+    fun `StytchFailedToCreateCodeChallengeError has expected properties`() {
+        val underlyingException = RuntimeException("testing")
+        val error = StytchFailedToCreateCodeChallengeError(underlyingException)
+        assert(error.name == "failed_code_challenge")
+        assert(error.description == "Failed to generate a PKCE code challenge")
+        assert(error.exception == underlyingException)
+    }
+
+    @Test
+    fun `StytchDeeplinkUnkownTokenTypeError has expected properties`() {
+        val error = StytchDeeplinkUnkownTokenTypeError
+        assert(error.name == "deeplink_unknown_token_type")
+        assert(error.description == "The deeplink received has an unknown token type.")
+    }
+
+    @Test
+    fun `StytchDeeplinkMissingTokenError has expected properties`() {
+        val error = StytchDeeplinkMissingTokenError
+        assert(error.name == "deeplink_missing_token")
+        assert(error.description == "The deeplink received has a missing token value.")
+    }
+
+    @Test
+    fun `StytchNoCurrentSessionError has expected properties`() {
+        val error = StytchNoCurrentSessionError
+        assert(error.name == "no_current_session")
+        assert(error.description == "There is no session currently available.")
+    }
+
+    @Test
+    fun `StytchNoBiometricsRegistrationError has expected properties`() {
+        val error = StytchNoBiometricsRegistrationError
+        assert(error.name == "no_biometrics_registration")
+        assert(error.description == "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.")
+    }
+
+    @Test
+    fun `StytchKeystoreUnavailableError has expected properties`() {
+        val error = StytchKeystoreUnavailableError
+        assert(error.name == "keystore_unavailable")
+        assert(error.description == "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.")
+    }
+
+    @Test
+    fun `StytchMissingPublicKeyError has expected properties`() {
+        val underlyingException = RuntimeException("test")
+        val error = StytchMissingPublicKeyError(underlyingException)
+        assert(error.name == "missing_public_key")
+        assert(error.description == "Failed to retrieve the public key. Add a new biometric registration.")
+        assert(error.exception == underlyingException)
+    }
+
+    @Test
+    fun `StytchChallengeSigningFailed has expected properties`() {
+        val underlyingException = RuntimeException("test")
+        val error = StytchChallengeSigningFailed(underlyingException)
+        assert(error.name == "challenge_signing_failed")
+        assert(error.description == "Failed to sign the challenge with the key.")
+        assert(error.exception == underlyingException)
+    }
+
+    @Test
+    fun `StytchMissingAuthorizationCredentialIdTokenError has expected properties`() {
+        val error = StytchMissingAuthorizationCredentialIdTokenError
+        assert(error.name == "missing_authorization_credential_id_token")
+        assert(error.description == "The authorization credential is missing an ID token.")
+    }
+
+    @Test
+    fun `StytchInvalidAuthorizationCredentialError has expected properties`() {
+        val error = StytchInvalidAuthorizationCredentialError
+        assert(error.name == "invalid_authorization_credential")
+        assert(error.description == "The authorization credential is invalid.")
+    }
+
+    @Test
+    fun `StytchPasskeysNotSupportedError has expected properties`() {
+        val error = StytchPasskeysNotSupportedError
+        assert(error.name == "passkeys_unsupported")
+        assert(error.description == "Passkeys are not supported on this device.")
+    }
+
+    @Test
+    fun `StytchFailedToDecryptDataError has expected properties`() {
+        val underlyingException = RuntimeException("test")
+        val error = StytchFailedToDecryptDataError(underlyingException)
+        assert(error.name == "failed_to_decrypt_data")
+        assert(error.description == "Failed to decrypt user data")
+        assert(error.exception == underlyingException)
+    }
+
+    @Test
+    fun `StytchBiometricAuthenticationFailed has expected properties`() {
+        val error = StytchBiometricAuthenticationFailed("Some reason from the device")
+        assert(error.name == "biometrics_failed")
+        assert(error.description == "Biometric authentication failed")
+        assert(error.reason == "Some reason from the device")
+    }
+
+    @Test
+    fun `StytchSDKUsageError has expected properties`() {
+        val error = StytchSDKUsageError("You did something wrong")
+        assert(error.name == "StytchSDKUsageError")
+        assert(error.description == "You did something wrong")
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
@@ -203,7 +203,7 @@ internal class GoogleOneTapImplTest {
         val result = impl.authenticate(mockk(relaxed = true))
         require(result is StytchResult.Error)
         require(result.exception is StytchInternalError)
-        assert(result.exception.exception is ApiException)
+        assert((result.exception as StytchInternalError).exception is ApiException)
     }
 
     @Test


### PR DESCRIPTION
Linear Ticket: None

## Changes:

1. Dumb down StytchError to the basics
2. Anything that is specific to a type of error (exception, url, etc) is only included for that type
3. Update util functions in workbench apps to account for above changes
4. Add some tests for each error type to make sure we're passing the correct name, etc

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A