### PR TITLE
Fix casing

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
@@ -106,7 +106,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             _loadingState.value = true
             val result = StytchB2BClient.handle(uri = uri, sessionDurationMinutes = 60u)
             _currentResponse.value = when (result) {
-                is DeeplinkHandledStatus.NotHandled -> result.reason.description
+                is DeeplinkHandledStatus.NotHandled -> result.reason.message
                 is DeeplinkHandledStatus.Handled -> {
                     // Hacking this in for organization discovery stuff
                     (result.response as? DeeplinkResponse.Discovery)

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/SSOViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/SSOViewModel.kt
@@ -46,7 +46,7 @@ class SSOViewModel : ViewModel() {
                     intent?.data?.let {
                         val result = StytchClient.handle(it, 60U)
                         when (result) {
-                            is DeeplinkHandledStatus.NotHandled -> result.reason.description
+                            is DeeplinkHandledStatus.NotHandled -> result.reason.message
                             is DeeplinkHandledStatus.Handled -> result.response.result.toFriendlyDisplay()
                             // This only happens for password reset deeplinks
                             is DeeplinkHandledStatus.ManualHandlingRequired -> ""

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/Util.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/Util.kt
@@ -27,7 +27,7 @@ fun isPhoneNumberValid(str: String): Boolean {
 fun <T : Any> StytchResult<T>.toFriendlyDisplay() = when (this) {
     is StytchResult.Success<*> -> this.toString()
     is StytchResult.Error -> {
-        var message = "Name: ${exception.name}\nDescription: ${exception.description}"
+        var message = "Name: ${exception}\nDescription: ${exception.message}"
         if (exception is StytchAPIError) {
             message += "\nURL: ${(exception as StytchAPIError).url}"
         }

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/HomeViewModel.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/HomeViewModel.kt
@@ -47,7 +47,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             _loadingState.value = true
             _currentResponse.value = when (val result = StytchClient.handle(uri = uri, sessionDurationMinutes = 60u)) {
-                is DeeplinkHandledStatus.NotHandled -> result.reason.description
+                is DeeplinkHandledStatus.NotHandled -> result.reason.message
                 is DeeplinkHandledStatus.Handled -> result.response.result.toFriendlyDisplay()
                 // This only happens for password reset deeplinks
                 is DeeplinkHandledStatus.ManualHandlingRequired ->

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/OAuthViewModel.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/OAuthViewModel.kt
@@ -99,7 +99,7 @@ class OAuthViewModel(application: Application) : AndroidViewModel(application) {
                 intent.data?.let {
                     val result = StytchClient.handle(it, 60U)
                     _currentResponse.value = when (result) {
-                        is DeeplinkHandledStatus.NotHandled -> result.reason.description
+                        is DeeplinkHandledStatus.NotHandled -> result.reason.message
                         is DeeplinkHandledStatus.Handled -> result.response.result.toFriendlyDisplay()
                         // This only happens for password reset deeplinks
                         is DeeplinkHandledStatus.ManualHandlingRequired -> ""

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/Util.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/Util.kt
@@ -27,7 +27,7 @@ fun isPhoneNumberValid(str: String): Boolean {
 fun <T : Any> StytchResult<T>.toFriendlyDisplay() = when (this) {
     is StytchResult.Success<*> -> this.toString()
     is StytchResult.Error -> {
-        var message = "Name: ${exception.name}\nDescription: ${exception.description}"
+        var message = "Name: ${exception}\nDescription: ${exception.message}"
         if (exception is StytchAPIError) {
             message += "\nURL: ${(exception as StytchAPIError).url}"
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -108,7 +108,7 @@ public object StytchB2BClient {
             }
         } catch (ex: Exception) {
             throw StytchInternalError(
-                description = "Failed to initialize the SDK",
+                message = "Failed to initialize the SDK",
                 exception = ex
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
@@ -5,10 +5,7 @@ package com.stytch.sdk.common.errors
  */
 public data class StytchAPIError(
     public val requestId: String? = null,
-    public override val name: String,
-    public override val description: String,
+    public val errorType: String,
+    public override val message: String,
     public val url: String? = null,
-) : StytchError(
-    name = name,
-    description = description,
-)
+) : StytchError(message = message)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
@@ -4,8 +4,5 @@ package com.stytch.sdk.common.errors
  * An error class representing a schema error that occurs in Stytch API
  */
 public data class StytchAPISchemaError(
-    public override val description: String,
-) : StytchError(
-    name = "StytchAPISchemaError",
-    description = description,
-)
+    public override val message: String,
+) : StytchError(message = message)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
@@ -4,9 +4,6 @@ package com.stytch.sdk.common.errors
  * An error class that occurs when Stytch SDK cannot reach the API
  */
 public data class StytchAPIUnreachableError(
-    public override val description: String,
+    public override val message: String,
     public val exception: Throwable? = null,
-) : StytchError(
-    name = "StytchAPIUnreachableError",
-    description = description,
-)
+) : StytchError(message = message)

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
@@ -4,6 +4,5 @@ package com.stytch.sdk.common.errors
  * A base error class for all errors returned by the Stytch SDK
  */
 public sealed class StytchError(
-    public open val name: String,
-    public open val description: String,
+    public override val message: String,
 ) : Exception()

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -8,20 +8,15 @@ package com.stytch.sdk.common.errors
  * rather we should be creating implementations for each of the known/expected errors we return.
  */
 public sealed class StytchSDKError(
-    name: String,
-    description: String,
+    message: String,
     public open val exception: Throwable? = null,
-) : StytchError(
-    name = name,
-    description = description,
-)
+) : StytchError(message = message)
 
 /**
  * Thrown when you try to use the SDK before it has been configured
  */
 public data class StytchSDKNotConfiguredError(val clientName: String) : StytchSDKError(
-    name = "sdk_not_configured",
-    description = "$clientName not configured. You must call `$clientName.configure(...)` before using any functionality of the SDK."
+    message = "$clientName not configured. You must call `$clientName.configure(...)` before using any functionality of the SDK."
 )
 
 /**
@@ -29,10 +24,9 @@ public data class StytchSDKNotConfiguredError(val clientName: String) : StytchSD
  */
 public data class StytchInternalError(
     public override val exception: Throwable? = null,
-    public override val description: String = "An internal error has occurred. Please contact Stytch if this occurs.",
+    public override val message: String = "An internal error has occurred. Please contact Stytch if this occurs.",
 ) : StytchSDKError(
-    name = "stytch_internal_error",
-    description = description,
+    message = message,
     exception = exception,
 )
 
@@ -42,8 +36,7 @@ public data class StytchInternalError(
 public data class StytchMissingPKCEError(
     public override val exception: Throwable?
 ) : StytchSDKError(
-    name = "missing_pkce",
-    description = "The PKCE code challenge or code verifier is missing. Make sure this flow is completed on the same device on which it was started.",
+    message = "The PKCE code challenge or code verifier is missing. Make sure this flow is completed on the same device on which it was started.",
     exception = exception,
 )
 
@@ -53,8 +46,7 @@ public data class StytchMissingPKCEError(
 public data class StytchFailedToCreateCodeChallengeError(
     public override val exception: Throwable,
 ) : StytchSDKError(
-    name = "failed_code_challenge",
-    description = "Failed to generate a PKCE code challenge",
+    message = "Failed to generate a PKCE code challenge",
     exception = exception
 )
 
@@ -62,48 +54,42 @@ public data class StytchFailedToCreateCodeChallengeError(
  * A type of error that can occur during deeplink handling
  */
 public interface StytchDeeplinkError {
-    public val name: String
-    public val description: String
+    public val message: String
 }
 
 /**
  * Thrown when we were passed an unknown deeplink token type
  */
 public object StytchDeeplinkUnkownTokenTypeError : StytchDeeplinkError, StytchSDKError(
-    name = "deeplink_unknown_token_type",
-    description = "The deeplink received has an unknown token type.",
+    message = "The deeplink received has an unknown token type.",
 )
 
 /**
  * Thrown when we attempted to handle a deeplink, but no token was found
  */
 public object StytchDeeplinkMissingTokenError : StytchDeeplinkError, StytchSDKError(
-    name = "deeplink_missing_token",
-    description = "The deeplink received has a missing token value.",
+    message = "The deeplink received has a missing token value.",
 )
 
 /**
  * Thrown when there is no current session persisted on device
  */
 public object StytchNoCurrentSessionError : StytchSDKError(
-    name = "no_current_session",
-    description = "There is no session currently available.",
+    message = "There is no session currently available.",
 )
 
 /**
  * Thrown when there are no biometric registrations present on the device
  */
 public object StytchNoBiometricsRegistrationError : StytchSDKError(
-    name = "no_biometrics_registration",
-    description = "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.",
+    message = "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.",
 )
 
 /**
  * Thrown when the keystore is unavailable, but the developer did not pass allowFallbackToCleartext=true
  */
 public object StytchKeystoreUnavailableError : StytchSDKError(
-    name = "keystore_unavailable",
-    description = "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.",
+    message = "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.",
 )
 
 /**
@@ -112,8 +98,7 @@ public object StytchKeystoreUnavailableError : StytchSDKError(
 public data class StytchMissingPublicKeyError(
     override val exception: Throwable?
 ) : StytchSDKError(
-    name = "missing_public_key",
-    description = "Failed to retrieve the public key. Add a new biometric registration.",
+    message = "Failed to retrieve the public key. Add a new biometric registration.",
     exception = exception,
 )
 
@@ -123,8 +108,7 @@ public data class StytchMissingPublicKeyError(
 public data class StytchChallengeSigningFailed(
     public override val exception: Throwable?
 ) : StytchSDKError(
-    name = "challenge_signing_failed",
-    description = "Failed to sign the challenge with the key.",
+    message = "Failed to sign the challenge with the key.",
     exception = exception,
 )
 
@@ -132,24 +116,21 @@ public data class StytchChallengeSigningFailed(
  * Thrown when the Google OneTap authorization credential was missing an id_token
  */
 public object StytchMissingAuthorizationCredentialIdTokenError : StytchSDKError(
-    name = "missing_authorization_credential_id_token",
-    description = "The authorization credential is missing an ID token.",
+    message = "The authorization credential is missing an ID token.",
 )
 
 /**
  * Thrown when the Google OneTap client or nonce is missing
  */
 public object StytchInvalidAuthorizationCredentialError : StytchSDKError(
-    name = "invalid_authorization_credential",
-    description = "The authorization credential is invalid.",
+    message = "The authorization credential is invalid.",
 )
 
 /**
  * Thrown when you attempt to perform a passkey flow on a device that does not support passkeys
  */
 public object StytchPasskeysNotSupportedError : StytchSDKError(
-    name = "passkeys_unsupported",
-    description = "Passkeys are not supported on this device.",
+    message = "Passkeys are not supported on this device.",
 )
 
 /**
@@ -158,8 +139,7 @@ public object StytchPasskeysNotSupportedError : StytchSDKError(
 public data class StytchFailedToDecryptDataError(
     public override val exception: Throwable?,
 ) : StytchSDKError(
-    name = "failed_to_decrypt_data",
-    description = "Failed to decrypt user data",
+    message = "Failed to decrypt user data",
     exception = exception,
 )
 
@@ -169,6 +149,5 @@ public data class StytchFailedToDecryptDataError(
 public data class StytchBiometricAuthenticationFailed(
     val reason: String,
 ) : StytchSDKError(
-    name = "biometrics_failed",
-    description = "Biometric authentication failed"
+    message = "Biometric authentication failed"
 )

--- a/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKUsageError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKUsageError.kt
@@ -4,8 +4,5 @@ package com.stytch.sdk.common.errors
  * An error that occurs when an SDK method is called with invalid input
  */
 public data class StytchSDKUsageError(
-    public override val description: String,
-) : StytchError(
-    name = "StytchSDKUsageError",
-    description = description,
-)
+    public override val message: String,
+) : StytchError(message = message)

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/HttpExceptionExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/HttpExceptionExt.kt
@@ -32,16 +32,16 @@ internal fun HttpException.toStytchError(): StytchError {
     StytchLog.w("http error code: $errorCode, errorResponse: $parsedErrorResponse")
     return when (parsedErrorResponse) {
         is StytchErrorResponse -> StytchAPIError(
-            name = parsedErrorResponse.errorType,
-            description = parsedErrorResponse.errorMessage ?: "",
+            errorType = parsedErrorResponse.errorType,
+            message = parsedErrorResponse.errorMessage ?: "",
             url = parsedErrorResponse.errorUrl,
             requestId = parsedErrorResponse.requestId
         )
         is StytchSchemaError -> StytchAPISchemaError(
-            description = "Request does not match expected schema: ${parsedErrorResponse.body}"
+            message = "Request does not match expected schema: ${parsedErrorResponse.body}"
         )
         else -> StytchAPIUnreachableError(
-            description = message ?: "Invalid or no response from server",
+            message = message ?: "Invalid or no response from server",
             exception = this
         )
     }

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ThrowableExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ThrowableExt.kt
@@ -12,7 +12,7 @@ internal fun Throwable.toStytchError(): StytchError = when (this) {
         printStackTrace()
         StytchLog.w("Network Error")
         StytchAPIUnreachableError(
-            description = message ?: "Invalid or no response from server",
+            message = message ?: "Invalid or no response from server",
             exception = this
         )
     }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -113,7 +113,7 @@ public object StytchClient {
             }
         } catch (ex: Exception) {
             throw StytchInternalError(
-                description = "Failed to initialize the SDK",
+                message = "Failed to initialize the SDK",
                 exception = ex,
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -315,7 +315,7 @@ internal class StytchB2BApiTest {
     fun `safeApiCall returns correct error for StytchErrors`() = runTest {
         every { StytchB2BApi.isInitialized } returns true
         fun mockApiCall(): StytchDataResponse<Boolean> {
-            throw StytchAPIError(name = "", description = "")
+            throw StytchAPIError(errorType = "", message = "")
         }
         val result = StytchB2BApi.safeB2BApiCall { mockApiCall() }
         assert(result is StytchResult.Error)

--- a/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
@@ -9,63 +9,55 @@ internal class StytchErrorTests {
     fun `StytchAPIError has expected properties`() {
         val error = StytchAPIError(
             requestId = "request-id-1234",
-            name = "error_name",
-            description = "error_description",
+            errorType = "error_name",
+            message = "error_description",
             url = "https://stytch.com"
         )
         assert(error.requestId == "request-id-1234")
-        assert(error.name == "error_name")
-        assert(error.description == "error_description")
+        assert(error.errorType == "error_name")
+        assert(error.message == "error_description")
         assert(error.url == "https://stytch.com")
     }
 
     @Test
     fun `StytchAPISchemaError has expected properties`() {
-        val error = StytchAPISchemaError(
-            description = "a schema error occurred",
-        )
-        assert(error.name == "StytchAPISchemaError")
-        assert(error.description == "a schema error occurred")
+        val error = StytchAPISchemaError(message = "a schema error occurred")
+        assert(error.message == "a schema error occurred")
     }
 
     @Test
     fun `StytchAPIUnreachableError has expected properties`() {
         val underlyingException = RuntimeException("testing")
         val error = StytchAPIUnreachableError(
-            description = "a schema error occurred",
+            message = "a schema error occurred",
             exception = underlyingException,
         )
-        assert(error.name == "StytchAPIUnreachableError")
-        assert(error.description == "a schema error occurred")
+        assert(error.message == "a schema error occurred")
         assert(error.exception == underlyingException)
     }
 
     @Test
     fun `StytchSDKNotConfiguredError has expected properties`() {
         val error = StytchSDKNotConfiguredError("Test")
-        assert(error.name == "sdk_not_configured")
-        assert(error.description == "Test not configured. You must call `Test.configure(...)` before using any functionality of the SDK.")
+        assert(error.message == "Test not configured. You must call `Test.configure(...)` before using any functionality of the SDK.")
     }
 
     @Test
     fun `StytchInternalError has expected properties`() {
         val underlyingException = RuntimeException("testing")
         val error1 = StytchInternalError(exception = underlyingException)
-        assert(error1.name == "stytch_internal_error")
         assert(error1.exception == underlyingException)
-        assert(error1.description == "An internal error has occurred. Please contact Stytch if this occurs.")
-        val error2 = StytchInternalError(description = "test")
-        assert(error2.name == "stytch_internal_error")
+        assert(error1.message == "An internal error has occurred. Please contact Stytch if this occurs.")
+        val error2 = StytchInternalError(message = "test")
         assert(error2.exception == null)
-        assert(error2.description == "test")
+        assert(error2.message == "test")
     }
 
     @Test
     fun `StytchMissingPKCEError has expected properties`() {
         val underlyingException = RuntimeException("testing")
         val error = StytchMissingPKCEError(underlyingException)
-        assert(error.name == "missing_pkce")
-        assert(error.description == "The PKCE code challenge or code verifier is missing. Make sure this flow is completed on the same device on which it was started.")
+        assert(error.message == "The PKCE code challenge or code verifier is missing. Make sure this flow is completed on the same device on which it was started.")
         assert(error.exception == underlyingException)
     }
 
@@ -73,52 +65,45 @@ internal class StytchErrorTests {
     fun `StytchFailedToCreateCodeChallengeError has expected properties`() {
         val underlyingException = RuntimeException("testing")
         val error = StytchFailedToCreateCodeChallengeError(underlyingException)
-        assert(error.name == "failed_code_challenge")
-        assert(error.description == "Failed to generate a PKCE code challenge")
+        assert(error.message == "Failed to generate a PKCE code challenge")
         assert(error.exception == underlyingException)
     }
 
     @Test
     fun `StytchDeeplinkUnkownTokenTypeError has expected properties`() {
         val error = StytchDeeplinkUnkownTokenTypeError
-        assert(error.name == "deeplink_unknown_token_type")
-        assert(error.description == "The deeplink received has an unknown token type.")
+        assert(error.message == "The deeplink received has an unknown token type.")
     }
 
     @Test
     fun `StytchDeeplinkMissingTokenError has expected properties`() {
         val error = StytchDeeplinkMissingTokenError
-        assert(error.name == "deeplink_missing_token")
-        assert(error.description == "The deeplink received has a missing token value.")
+        assert(error.message == "The deeplink received has a missing token value.")
     }
 
     @Test
     fun `StytchNoCurrentSessionError has expected properties`() {
         val error = StytchNoCurrentSessionError
-        assert(error.name == "no_current_session")
-        assert(error.description == "There is no session currently available.")
+        assert(error.message == "There is no session currently available.")
     }
 
     @Test
     fun `StytchNoBiometricsRegistrationError has expected properties`() {
         val error = StytchNoBiometricsRegistrationError
-        assert(error.name == "no_biometrics_registration")
-        assert(error.description == "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.")
+        assert(error.message == "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.")
     }
 
     @Test
     fun `StytchKeystoreUnavailableError has expected properties`() {
         val error = StytchKeystoreUnavailableError
-        assert(error.name == "keystore_unavailable")
-        assert(error.description == "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.")
+        assert(error.message == "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.")
     }
 
     @Test
     fun `StytchMissingPublicKeyError has expected properties`() {
         val underlyingException = RuntimeException("test")
         val error = StytchMissingPublicKeyError(underlyingException)
-        assert(error.name == "missing_public_key")
-        assert(error.description == "Failed to retrieve the public key. Add a new biometric registration.")
+        assert(error.message == "Failed to retrieve the public key. Add a new biometric registration.")
         assert(error.exception == underlyingException)
     }
 
@@ -126,53 +111,46 @@ internal class StytchErrorTests {
     fun `StytchChallengeSigningFailed has expected properties`() {
         val underlyingException = RuntimeException("test")
         val error = StytchChallengeSigningFailed(underlyingException)
-        assert(error.name == "challenge_signing_failed")
-        assert(error.description == "Failed to sign the challenge with the key.")
+        assert(error.message == "Failed to sign the challenge with the key.")
         assert(error.exception == underlyingException)
     }
 
     @Test
     fun `StytchMissingAuthorizationCredentialIdTokenError has expected properties`() {
         val error = StytchMissingAuthorizationCredentialIdTokenError
-        assert(error.name == "missing_authorization_credential_id_token")
-        assert(error.description == "The authorization credential is missing an ID token.")
+        assert(error.message == "The authorization credential is missing an ID token.")
     }
 
     @Test
     fun `StytchInvalidAuthorizationCredentialError has expected properties`() {
         val error = StytchInvalidAuthorizationCredentialError
-        assert(error.name == "invalid_authorization_credential")
-        assert(error.description == "The authorization credential is invalid.")
+        assert(error.message == "The authorization credential is invalid.")
     }
 
     @Test
     fun `StytchPasskeysNotSupportedError has expected properties`() {
         val error = StytchPasskeysNotSupportedError
-        assert(error.name == "passkeys_unsupported")
-        assert(error.description == "Passkeys are not supported on this device.")
+        assert(error.message == "Passkeys are not supported on this device.")
     }
 
     @Test
     fun `StytchFailedToDecryptDataError has expected properties`() {
         val underlyingException = RuntimeException("test")
         val error = StytchFailedToDecryptDataError(underlyingException)
-        assert(error.name == "failed_to_decrypt_data")
-        assert(error.description == "Failed to decrypt user data")
+        assert(error.message == "Failed to decrypt user data")
         assert(error.exception == underlyingException)
     }
 
     @Test
     fun `StytchBiometricAuthenticationFailed has expected properties`() {
         val error = StytchBiometricAuthenticationFailed("Some reason from the device")
-        assert(error.name == "biometrics_failed")
-        assert(error.description == "Biometric authentication failed")
+        assert(error.message == "Biometric authentication failed")
         assert(error.reason == "Some reason from the device")
     }
 
     @Test
     fun `StytchSDKUsageError has expected properties`() {
         val error = StytchSDKUsageError("You did something wrong")
-        assert(error.name == "StytchSDKUsageError")
-        assert(error.description == "You did something wrong")
+        assert(error.message == "You did something wrong")
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -215,7 +215,7 @@ internal class BiometricsImplTest {
             EncryptionManager.generateEd25519KeyPair()
         } returns Pair(base64EncodedString, base64EncodedString)
         coEvery { mockApi.registerStart(base64EncodedString) } returns StytchResult.Error(
-            StytchAPIError(name = "", description = "")
+            StytchAPIError(errorType = "", message = "")
         )
         val result = impl.register(mockk(relaxed = true))
         require(result is StytchResult.Error)
@@ -356,7 +356,7 @@ internal class BiometricsImplTest {
             EncryptionManager.deriveEd25519PublicKeyFromPrivateKeyBytes(base64DecodedByteArray)
         } returns "publicKey"
         coEvery { mockApi.authenticateStart("publicKey") } returns StytchResult.Error(
-            StytchAPIError(name = "", description = "")
+            StytchAPIError(errorType = "", message = "")
         )
         val result = impl.authenticate(mockk(relaxed = true))
         require(result is StytchResult.Error)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -462,7 +462,7 @@ internal class StytchApiTest {
     fun `safeApiCall returns correct error for StytchErrors`() = runTest {
         every { StytchApi.isInitialized } returns true
         fun mockApiCall(): StytchDataResponse<Boolean> {
-            throw StytchAPIError(name = "", description = "")
+            throw StytchAPIError(errorType = "", message = "")
         }
         val result = StytchApi.safeConsumerApiCall { mockApiCall() }
         assert(result is StytchResult.Error)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
@@ -228,7 +228,7 @@ internal class GoogleOneTapImplTest {
             }
         }
         coEvery { mockApi.authenticateWithGoogleIdToken(any(), any(), any()) } returns StytchResult.Error(
-            StytchAPIError(name = "something_went_wrong", description = "testing")
+            StytchAPIError(errorType = "something_went_wrong", message = "testing")
         )
         val result = impl.authenticate(mockk(relaxed = true))
         require(result is StytchResult.Error)

--- a/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -113,7 +113,7 @@ internal class OAuthImplTest {
     fun `authenticate returns correct error if api call fails`() = runTest {
         every { mockStorageHelper.retrieveCodeVerifier() } returns "code-challenge"
         coEvery { mockApi.authenticateWithThirdPartyToken(any(), any(), any()) } returns StytchResult.Error(
-            StytchAPIError(name = "something_went_wrong", description = "testing")
+            StytchAPIError(errorType = "something_went_wrong", message = "testing")
         )
         val result = impl.authenticate(mockk(relaxed = true))
         require(result is StytchResult.Error)


### PR DESCRIPTION
Linear Ticket: No ticket

## Changes:

1. Remove the unnecessary snake_case error name
2. change description to message
3. Add errorType for the snake_cased error_type returned for API errors

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A