### PR TITLE
SDK-1117 Configure publishing for UI module

### DIFF
--- a/.github/workflows/uiTests.yml
+++ b/.github/workflows/uiTests.yml
@@ -52,7 +52,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedCheck
+          script: ./gradlew :ui:connectedCheck
         env:
           STYTCH_PUBLIC_TOKEN: 'abc123'
           GOOGLE_OAUTH_CLIENT_ID: 'abc123'

--- a/build.gradle
+++ b/build.gradle
@@ -12,12 +12,16 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://storage.googleapis.com/r8-releases/raw")
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
         classpath("org.jetbrains.dokka:versioning-plugin:$dokka_version")
+        classpath("com.android.tools:r8:8.2.33")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -75,6 +75,8 @@ android {
 }
 
 tasks.named("dokkaHtml").configure {
+    dependsOn(tasks.named("kaptDebugKotlin"))
+    dependsOn(tasks.named("kaptReleaseKotlin"))
     dependencies {
         dokkaPlugin("org.jetbrains.dokka:versioning-plugin:$dokka_version")
     }

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -2,7 +2,16 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-parcelize'
+    id "org.jetbrains.dokka"
 }
+
+ext {
+    PUBLISH_GROUP_ID = 'com.stytch.sdk'
+    PUBLISH_VERSION = '0.0.1'
+    PUBLISH_ARTIFACT_ID = 'ui'
+}
+
+apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 
 android {
     namespace 'com.stytch.sdk.ui'
@@ -86,4 +95,36 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     // Needed for createAndroidComposeRule, but not createComposeRule:
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+}
+
+tasks.named("dokkaHtml").configure {
+    dependsOn(tasks.named("kaptDebugKotlin"))
+    dependsOn(tasks.named("kaptReleaseKotlin"))
+    dependencies {
+        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:$dokka_version")
+    }
+    moduleName.set("Stytch Android UI")
+    suppressInheritedMembers.set(true)
+    dokkaSourceSets {
+        configureEach {
+            includes.from([
+                "module.md",
+            ])
+            perPackageOption {
+                matchingRegex.set(".*\\.components.*")
+                matchingRegex.set(".*\\.screens.*")
+                matchingRegex.set(".*\\.theme.*")
+                matchingRegex.set(".*\\.utils.*")
+                suppress.set(true)
+            }
+            reportUndocumented.set(true)
+        }
+        // TODO: Switch to KTS files to make this a lot easier/more idiomatic
+        pluginsMapConfiguration.set([
+                "org.jetbrains.dokka.versioning.VersioningPlugin" : """{
+                "version": "$PUBLISH_VERSION",
+                "olderVersionsDir": "$projectDir/../../docs/docs/olderVersions/ui"
+            }"""
+        ])
+    }
 }

--- a/ui/module.md
+++ b/ui/module.md
@@ -1,0 +1,9 @@
+# Module Stytch Android UI
+[Stytch](https://stytch.com) is an authentication platform, written by developers for developers, with a focus on
+improving security and user experience via passwordless authentication. Stytch offers direct API integrations,
+language-specific libraries, and SDKs (like this one) to make the process of setting up an authentication flow for your
+app as easy as possible.
+
+The module contains our pre-built UI components
+
+TKTKTK

--- a/ui/proguard-rules.pro
+++ b/ui/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-dontwarn java.lang.invoke.StringConcatFactory


### PR DESCRIPTION
Linear Ticket: [SDK-1117](https://linear.app/stytch/issue/SDK-1117)

## Changes:

1. Updates R8 since the UI module was having some problems (see: https://stackoverflow.com/a/76954759)
2. Configures UI module for publishing
3. Starts adding in some initial documentation tasks, since that's relevant for publishing, but the real documentation will come in SDK-1344

## Notes:

- Tested publishing to mavenLocal:
<img width="597" alt="Screenshot 2024-01-03 at 2 19 20 PM" src="https://github.com/stytchauth/stytch-android/assets/117691317/4d6ae605-9160-47e6-b780-480d4e87a261">

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A