### PR TITLE
SDK-1352 Deeplink handling

### DIFF
--- a/ui/src/main/kotlin/com/stytch/sdk/ui/StytchAuthenticationApp.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/StytchAuthenticationApp.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.androidx.AndroidScreen
+import cafe.adriel.voyager.navigator.CurrentScreen
 import cafe.adriel.voyager.navigator.Navigator
 import com.stytch.sdk.common.errors.StytchUIInvalidConfiguration
 import com.stytch.sdk.common.network.models.BootstrapData
@@ -59,7 +60,12 @@ internal fun StytchAuthenticationApp(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
         ) {
-            Navigator(listOfNotNull(MainScreen, screen))
+            Navigator(listOfNotNull(MainScreen, screen)) { navigator ->
+                screen?.let {
+                    navigator.push(it)
+                }
+                CurrentScreen()
+            }
             if (!bootstrapData.disableSDKWatermark) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Linear Ticket: [SDK-1352](https://linear.app/stytch/issue/SDK-1352)

## Changes:

1. The voyager documentation is a little sparse on deeplinks, and what I _thought_ would work, well, didn't. This explicitly pushes the desired screen, if necessary.

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A