### PR TITLE
SDK-1117 Create manually triggered, separate publish tasks for SDK and UI

### DIFF
--- a/.github/workflows/publishHeadless.yml
+++ b/.github/workflows/publishHeadless.yml
@@ -1,0 +1,37 @@
+name: Publish Headless SDK
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Release build and publish
+    runs-on: ubuntu-latest
+    env:
+      STYTCH_PUBLIC_TOKEN: 'abc123'
+      GOOGLE_OAUTH_CLIENT_ID: 'abc123'
+      STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
+      STYTCH_B2B_ORG_ID: 'abc123'
+      PASSKEYS_DOMAIN: 'abc123'
+      STYTCH_UI_PUBLIC_TOKEN: 'abc123'
+      UI_GOOGLE_CLIENT_ID: 'abc123'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Release build
+        run: ./gradlew :sdk:assembleRelease
+      - name: Source jar
+        run: ./gradlew :sdk:androidSourcesJar
+      - name: Publish to Maven Central
+        run: ./gradlew :sdk:publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/.github/workflows/publishUi.yml
+++ b/.github/workflows/publishUi.yml
@@ -1,8 +1,7 @@
-name: Publish
+name: Publish UI SDK
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -24,11 +23,11 @@ jobs:
           java-version: 17
 
       - name: Release build
-        run: ./gradlew :sdk:assembleRelease
+        run: ./gradlew :ui:assembleRelease
       - name: Source jar
-        run: ./gradlew androidSourcesJar
+        run: ./gradlew :ui:androidSourcesJar
       - name: Publish to Maven Central
-        run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew :ui:publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
Linear Ticket: [SDK-1117](https://linear.app/stytch/issue/SDK-1117)

## Changes:

1. Makes the publishing task manual/workflow_dispatch and creates separate workflows for publishing headless and UI SDKs

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A