### PR TITLE
SDK-1357 Catch and retry keysetmanager creation for InvalidKeyException, too

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.18.1'
+  PUBLISH_VERSION = '0.18.2'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/common/EncryptionManager.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/EncryptionManager.kt
@@ -1,8 +1,6 @@
 package com.stytch.sdk.common
 
 import android.content.Context
-import android.content.Context.MODE_PRIVATE
-import android.os.Build
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.aead.AeadConfig
@@ -17,23 +15,21 @@ import com.stytch.sdk.common.extensions.hexStringToByteArray
 import com.stytch.sdk.common.extensions.toBase64DecodedByteArray
 import com.stytch.sdk.common.extensions.toBase64EncodedString
 import com.stytch.sdk.common.extensions.toHexString
-import java.io.File
+import java.security.InvalidKeyException
 import java.security.MessageDigest
 import java.security.SecureRandom
 import kotlin.random.Random
-import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 import org.bouncycastle.crypto.Signer
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
-import java.security.InvalidKeyException
 
 @Suppress("TooManyFunctions")
 internal object EncryptionManager {
 
-    internal const val PREF_FILE_NAME = "stytch_secured_pref"
+    private const val PREF_FILE_NAME = "stytch_secured_pref"
     private const val MASTER_KEY_URI = "android-keystore://stytch_master_key"
     private var keysetManager: AndroidKeysetManager? = null
     private var aead: Aead? = null
@@ -53,13 +49,13 @@ internal object EncryptionManager {
         } catch (_: InvalidProtocolBufferException) {
             // Possible that the signing key was changed. This causes the preferences file to be unreadable,
             // so we need to destroy and recreate it
-            context.clearPreferences()
-            return getOrGenerateNewAES256KeysetManager(context, keyAlias)
+            context.clearPreferences(PREF_FILE_NAME)
+            getOrGenerateNewAES256KeysetManager(context, keyAlias)
         } catch (_: InvalidKeyException) {
             // Possible that the signing key was changed. This causes the preferences file to be unreadable,
             // so we need to destroy and recreate it
-            context.clearPreferences()
-            return getOrGenerateNewAES256KeysetManager(context, keyAlias)
+            context.clearPreferences(PREF_FILE_NAME)
+            getOrGenerateNewAES256KeysetManager(context, keyAlias)
         }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
@@ -3,7 +3,6 @@ package com.stytch.sdk.common.extensions // ktlint-disable filename
 import android.content.Context
 import android.os.Build
 import com.stytch.sdk.common.DeviceInfo
-import com.stytch.sdk.common.EncryptionManager
 import java.io.File
 
 internal fun Context.getDeviceInfo(): DeviceInfo {
@@ -30,12 +29,12 @@ internal fun Context.getDeviceInfo(): DeviceInfo {
     return deviceInfo
 }
 
-internal fun Context.clearPreferences() {
+internal fun Context.clearPreferences(preferencesName: String) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        deleteSharedPreferences(EncryptionManager.PREF_FILE_NAME)
+        deleteSharedPreferences(preferencesName)
     } else {
-        getSharedPreferences(EncryptionManager.PREF_FILE_NAME, Context.MODE_PRIVATE).edit().clear().apply()
+        getSharedPreferences(preferencesName, Context.MODE_PRIVATE).edit().clear().apply()
         val dir = File(applicationInfo.dataDir, "shared_prefs")
-        File(dir, "${EncryptionManager.PREF_FILE_NAME}.xml").delete()
+        File(dir, "$preferencesName.xml").delete()
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
-import org.bouncycastle.asn1.x500.style.RFC4519Style
 import java.io.File
 
 internal fun Context.getDeviceInfo(): DeviceInfo {
@@ -37,6 +36,6 @@ internal fun Context.clearPreferences() {
     } else {
         getSharedPreferences(EncryptionManager.PREF_FILE_NAME, Context.MODE_PRIVATE).edit().clear().apply()
         val dir = File(applicationInfo.dataDir, "shared_prefs")
-        File(dir, "${RFC4519Style.name}.xml").delete()
+        File(dir, "${EncryptionManager.PREF_FILE_NAME}.xml").delete()
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
@@ -3,6 +3,9 @@ package com.stytch.sdk.common.extensions // ktlint-disable filename
 import android.content.Context
 import android.os.Build
 import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.EncryptionManager
+import org.bouncycastle.asn1.x500.style.RFC4519Style
+import java.io.File
 
 internal fun Context.getDeviceInfo(): DeviceInfo {
     val deviceInfo = DeviceInfo()
@@ -26,4 +29,14 @@ internal fun Context.getDeviceInfo(): DeviceInfo {
 
     deviceInfo.screenSize = "($width,$height)"
     return deviceInfo
+}
+
+internal fun Context.clearPreferences() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        deleteSharedPreferences(EncryptionManager.PREF_FILE_NAME)
+    } else {
+        getSharedPreferences(EncryptionManager.PREF_FILE_NAME, Context.MODE_PRIVATE).edit().clear().apply()
+        val dir = File(applicationInfo.dataDir, "shared_prefs")
+        File(dir, "${RFC4519Style.name}.xml").delete()
+    }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1357](https://linear.app/stytch/issue/SDK-1357)

## Changes:

1. Catch InvalidKeyException and treat it as an unrecoverable key error (ie: clear preferences and recreate)

## Notes:

- This is a followup to the Tink upgrade which, unfortunately, did not work :(

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A