### PR TITLE
SDK-1391 Event logging infrastructure and logging when UI SDK is launched

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/b2b/events/Events.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/events/Events.kt
@@ -1,0 +1,5 @@
+package com.stytch.sdk.b2b.events
+
+public interface Events {
+    public fun logEvent(eventName: String, details: Map<String, Any>? = null, error: Exception? = null)
+}

--- a/sdk/src/main/java/com/stytch/sdk/b2b/events/EventsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/events/EventsImpl.kt
@@ -1,0 +1,36 @@
+package com.stytch.sdk.b2b.events
+
+import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.network.InfoHeaderModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.TimeZone
+import java.util.UUID
+
+internal class EventsImpl(
+    deviceInfo: DeviceInfo,
+    private val appSessionId: String,
+    private val externalScope: CoroutineScope,
+    private val dispatchers: StytchDispatchers,
+    private val api: StytchB2BApi.Events,
+) : Events {
+    private val infoHeaderModel = InfoHeaderModel.fromDeviceInfo(deviceInfo)
+
+    override fun logEvent(eventName: String, details: Map<String, Any>?, error: Exception?) {
+        externalScope.launch(dispatchers.io) {
+            api.logEvent(
+                eventId = "event-id-${UUID.randomUUID()}",
+                appSessionId = appSessionId,
+                persistentId = "persistent-id-${UUID.randomUUID()}",
+                clientSentAt = Date().toString(),
+                timezone = TimeZone.getDefault().id,
+                eventName = eventName,
+                infoHeaderModel = infoHeaderModel,
+                details = details
+            )
+        }
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -38,6 +38,7 @@ import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
+import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.safeApiCall
 
 internal object StytchB2BApi {
@@ -402,37 +403,41 @@ internal object StytchB2BApi {
             details: Map<String, Any>? = null,
         ): NoResponseResponse = safeB2BApiCall {
             apiService.logEvent(
-                CommonRequests.Events.Event(
-                    telemetry = CommonRequests.Events.EventTelemetry(
-                        eventId = eventId,
-                        appSessionId = appSessionId,
-                        persistentId = persistentId,
-                        clientSentAt = clientSentAt,
-                        timezone = timezone,
-                        app = CommonRequests.Events.VersionIdentifier(
-                            identifier = infoHeaderModel.app.identifier,
-                            version = infoHeaderModel.app.version
+                listOf(
+                    CommonRequests.Events.Event(
+                        telemetry = CommonRequests.Events.EventTelemetry(
+                            eventId = eventId,
+                            appSessionId = appSessionId,
+                            persistentId = persistentId,
+                            clientSentAt = clientSentAt,
+                            timezone = timezone,
+                            app = CommonRequests.Events.VersionIdentifier(
+                                identifier = infoHeaderModel.app.identifier,
+                                version = infoHeaderModel.app.version
+                            ),
+                            sdk = CommonRequests.Events.VersionIdentifier(
+                                identifier = infoHeaderModel.sdk.identifier,
+                                version = infoHeaderModel.sdk.version
+                            ),
+                            os = CommonRequests.Events.VersionIdentifier(
+                                identifier = infoHeaderModel.os.identifier,
+                                version = infoHeaderModel.os.version
+                            ),
+                            device = CommonRequests.Events.DeviceIdentifier(
+                                model = infoHeaderModel.device.identifier,
+                                screenSize = infoHeaderModel.device.version
+                            )
                         ),
-                        sdk = CommonRequests.Events.VersionIdentifier(
-                            identifier = infoHeaderModel.sdk.identifier,
-                            version = infoHeaderModel.sdk.version
-                        ),
-                        os = CommonRequests.Events.VersionIdentifier(
-                            identifier = infoHeaderModel.os.identifier,
-                            version = infoHeaderModel.os.version
-                        ),
-                        device = CommonRequests.Events.DeviceIdentifier(
-                            model = infoHeaderModel.device.identifier,
-                            screenSize = infoHeaderModel.device.version
+                        event = CommonRequests.Events.EventEvent(
+                            publicToken = publicToken,
+                            eventName = eventName,
+                            details = details,
                         )
-                    ),
-                    event = CommonRequests.Events.EventEvent(
-                        publicToken = publicToken,
-                        eventName = eventName,
-                        details = details,
                     )
                 )
             )
+            // Endpoint returns null, but we expect _something_
+            StytchDataResponse(NoResponseData())
         }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -24,11 +24,13 @@ import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.b2b.network.models.StrengthCheckResponseData
 import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.NoResponseResponse
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.CaptchaProvider
 import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.network.ApiService
+import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchAuthHeaderInterceptor
 import com.stytch.sdk.common.network.StytchDFPInterceptor
 import com.stytch.sdk.common.network.StytchDataResponse
@@ -383,6 +385,52 @@ internal object StytchB2BApi {
                     ssoToken = ssoToken,
                     sessionDurationMinutes = sessionDurationMinutes.toInt(),
                     codeVerifier = codeVerifier,
+                )
+            )
+        }
+    }
+
+    internal object Events {
+        suspend fun logEvent(
+            eventId: String,
+            appSessionId: String,
+            persistentId: String,
+            clientSentAt: String,
+            timezone: String,
+            eventName: String,
+            infoHeaderModel: InfoHeaderModel,
+            details: Map<String, Any>? = null,
+        ): NoResponseResponse = safeB2BApiCall {
+            apiService.logEvent(
+                CommonRequests.Events.Event(
+                    telemetry = CommonRequests.Events.EventTelemetry(
+                        eventId = eventId,
+                        appSessionId = appSessionId,
+                        persistentId = persistentId,
+                        clientSentAt = clientSentAt,
+                        timezone = timezone,
+                        app = CommonRequests.Events.VersionIdentifier(
+                            identifier = infoHeaderModel.app.identifier,
+                            version = infoHeaderModel.app.version
+                        ),
+                        sdk = CommonRequests.Events.VersionIdentifier(
+                            identifier = infoHeaderModel.sdk.identifier,
+                            version = infoHeaderModel.sdk.version
+                        ),
+                        os = CommonRequests.Events.VersionIdentifier(
+                            identifier = infoHeaderModel.os.identifier,
+                            version = infoHeaderModel.os.version
+                        ),
+                        device = CommonRequests.Events.DeviceIdentifier(
+                            model = infoHeaderModel.device.identifier,
+                            screenSize = infoHeaderModel.device.version
+                        )
+                    ),
+                    event = CommonRequests.Events.EventEvent(
+                        publicToken = publicToken,
+                        eventName = eventName,
+                        details = details,
+                    )
                 )
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -113,4 +113,11 @@ internal interface StytchB2BApiService : ApiService {
         @Path(value = "publicToken") publicToken: String
     ): CommonResponses.Bootstrap.BootstrapResponse
     //endregion Bootstrap
+
+    //region Events
+    @POST("events")
+    suspend fun logEvent(
+        @Body request: CommonRequests.Events.Event
+    ): CommonResponses.NoResponse
+    //endredion Events
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.network.models.B2BResponses
 import com.stytch.sdk.common.network.ApiService
 import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.CommonResponses
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -117,7 +118,8 @@ internal interface StytchB2BApiService : ApiService {
     //region Events
     @POST("events")
     suspend fun logEvent(
-        @Body request: CommonRequests.Events.Event
-    ): CommonResponses.NoResponse
+        // endpoint expects a list of events because JS SDK batches them
+        @Body request: List<CommonRequests.Events.Event>
+    ): Response<Unit>
     //endredion Events
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -121,5 +121,5 @@ internal interface StytchB2BApiService : ApiService {
         // endpoint expects a list of events because JS SDK batches them
         @Body request: List<CommonRequests.Events.Event>
     ): Response<Unit>
-    //endredion Events
+    //endregion Events
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/Typealiases.kt
@@ -2,8 +2,14 @@
 package com.stytch.sdk.common
 
 import com.stytch.sdk.common.network.models.BasicData
+import com.stytch.sdk.common.network.models.NoResponseData
 
 /**
  * Type alias for StytchResult<BasicData> used for basic responses
  */
 public typealias BaseResponse = StytchResult<BasicData>
+
+/**
+ * Type alias for StytchResult<NoResponseData> used for empty responses
+ */
+public typealias NoResponseResponse = StytchResult<NoResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/common/network/InfoHeaderModel.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/InfoHeaderModel.kt
@@ -1,5 +1,9 @@
 package com.stytch.sdk.common.network
 
+import com.stytch.sdk.BuildConfig
+import com.stytch.sdk.common.Constants
+import com.stytch.sdk.common.DeviceInfo
+
 internal data class InfoHeaderModel(
     val sdk: Item,
     val app: Item,
@@ -28,5 +32,27 @@ internal data class InfoHeaderModel(
             get() {
                 return "{ \"$identifierName\": \"$identifier\", \"$versionName\": \"$version\" }"
             }
+    }
+    companion object {
+        fun fromDeviceInfo(deviceInfo: DeviceInfo): InfoHeaderModel = InfoHeaderModel(
+            sdk = Item(
+                Constants.AUTH_HEADER_SDK_NAME,
+                BuildConfig.STYTCH_SDK_VERSION
+            ),
+            app = Item(
+                deviceInfo.applicationPackageName ?: "",
+                deviceInfo.applicationVersion ?: ""
+            ),
+            os = Item(
+                deviceInfo.osName ?: "",
+                deviceInfo.osVersion ?: ""
+            ),
+            device = Item(
+                deviceInfo.deviceName ?: "",
+                deviceInfo.screenSize ?: "",
+                "model",
+                "screen_size"
+            )
+        )
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/network/StytchAuthHeaderInterceptor.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/StytchAuthHeaderInterceptor.kt
@@ -1,8 +1,6 @@
 package com.stytch.sdk.common.network
 
 import com.google.crypto.tink.subtle.Base64
-import com.stytch.sdk.BuildConfig
-import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.DeviceInfo
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -23,26 +21,7 @@ internal class StytchAuthHeaderInterceptor(
             Base64.NO_WRAP
         )
         val infoHeader = Base64.encodeToString(
-            InfoHeaderModel(
-                sdk = InfoHeaderModel.Item(
-                    Constants.AUTH_HEADER_SDK_NAME,
-                    BuildConfig.STYTCH_SDK_VERSION
-                ),
-                app = InfoHeaderModel.Item(
-                    deviceInfo.applicationPackageName ?: "",
-                    deviceInfo.applicationVersion ?: ""
-                ),
-                os = InfoHeaderModel.Item(
-                    deviceInfo.osName ?: "",
-                    deviceInfo.osVersion ?: ""
-                ),
-                device = InfoHeaderModel.Item(
-                    deviceInfo.deviceName ?: "",
-                    deviceInfo.screenSize ?: "",
-                    "model",
-                    "screen_size"
-                )
-            ).json.toByteArray(),
+            InfoHeaderModel.fromDeviceInfo(deviceInfo).json.toByteArray(),
             Base64.NO_WRAP
         )
 

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
@@ -11,4 +11,51 @@ internal object CommonRequests {
             val sessionDurationMinutes: Int?,
         )
     }
+
+    object Events {
+        @JsonClass(generateAdapter = true)
+        data class Event(
+            val telemetry: EventTelemetry,
+            val event: EventEvent,
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class EventTelemetry(
+            @Json(name = "event_id")
+            val eventId: String,
+            @Json(name = "app_session_id")
+            val appSessionId: String,
+            @Json(name = "persistent_id")
+            val persistentId: String,
+            @Json(name = "client_sent_at")
+            val clientSentAt: String,
+            val timezone: String,
+            val app: VersionIdentifier,
+            val os: VersionIdentifier,
+            val sdk: VersionIdentifier,
+            val device: DeviceIdentifier,
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class VersionIdentifier(
+            val identifier: String,
+            val version: String? = null
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class DeviceIdentifier(
+            val model: String? = null,
+            @Json(name = "screen_size")
+            val screenSize: String? = null,
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class EventEvent(
+            @Json(name = "public_token")
+            val publicToken: String,
+            @Json(name = "event_name")
+            val eventName: String,
+            val details: Map<String, Any>? = null,
+        )
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -365,3 +365,7 @@ public data class CaptchaSettings(
     val enabled: Boolean = false,
     val siteKey: String = ""
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public class NoResponseData : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponses.kt
@@ -30,4 +30,7 @@ internal object CommonResponses {
 
     @JsonClass(generateAdapter = true)
     class SendResponse(data: BasicData) : StytchDataResponse<BasicData>(data)
+
+    @JsonClass(generateAdapter = true)
+    class NoResponse(data: NoResponseData) : StytchDataResponse<NoResponseData>(data)
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/events/Events.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/events/Events.kt
@@ -1,0 +1,5 @@
+package com.stytch.sdk.consumer.events
+
+public interface Events {
+    public fun logEvent(eventName: String, details: Map<String, Any>? = null, error: Exception? = null)
+}

--- a/sdk/src/main/java/com/stytch/sdk/consumer/events/EventsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/events/EventsImpl.kt
@@ -1,0 +1,36 @@
+package com.stytch.sdk.consumer.events
+
+import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.network.InfoHeaderModel
+import com.stytch.sdk.consumer.network.StytchApi
+import java.util.Date
+import java.util.TimeZone
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal class EventsImpl(
+    deviceInfo: DeviceInfo,
+    private val appSessionId: String,
+    private val externalScope: CoroutineScope,
+    private val dispatchers: StytchDispatchers,
+    private val api: StytchApi.Events,
+) : Events {
+    private val infoHeaderModel = InfoHeaderModel.fromDeviceInfo(deviceInfo)
+
+    override fun logEvent(eventName: String, details: Map<String, Any>?, error: Exception?) {
+        externalScope.launch(dispatchers.io) {
+            api.logEvent(
+                eventId = "event-id-${UUID.randomUUID()}",
+                appSessionId = appSessionId,
+                persistentId = "persistent-id-${UUID.randomUUID()}",
+                clientSentAt = Date().toString(),
+                timezone = TimeZone.getDefault().id,
+                eventName = eventName,
+                infoHeaderModel = infoHeaderModel,
+                details = details
+            )
+        }
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.Constants.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.NoResponseResponse
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.StytchResult.Success
 import com.stytch.sdk.common.dfp.CaptchaProvider
 import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
@@ -21,6 +22,7 @@ import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.common.network.models.NameData
+import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.models.OTPSendResponseData
 import com.stytch.sdk.common.network.safeApiCall
 import com.stytch.sdk.consumer.AuthResponse
@@ -683,37 +685,41 @@ internal object StytchApi {
             details: Map<String, Any>? = null,
         ): NoResponseResponse = safeConsumerApiCall {
             apiService.logEvent(
-                CommonRequests.Events.Event(
-                    telemetry = CommonRequests.Events.EventTelemetry(
-                        eventId = eventId,
-                        appSessionId = appSessionId,
-                        persistentId = persistentId,
-                        clientSentAt = clientSentAt,
-                        timezone = timezone,
-                        app = CommonRequests.Events.VersionIdentifier(
-                            identifier = infoHeaderModel.app.identifier,
-                            version = infoHeaderModel.app.version
+                listOf(
+                    CommonRequests.Events.Event(
+                        telemetry = CommonRequests.Events.EventTelemetry(
+                            eventId = eventId,
+                            appSessionId = appSessionId,
+                            persistentId = persistentId,
+                            clientSentAt = clientSentAt,
+                            timezone = timezone,
+                            app = CommonRequests.Events.VersionIdentifier(
+                                identifier = infoHeaderModel.app.identifier,
+                                version = infoHeaderModel.app.version
+                            ),
+                            sdk = CommonRequests.Events.VersionIdentifier(
+                                identifier = infoHeaderModel.sdk.identifier,
+                                version = infoHeaderModel.sdk.version
+                            ),
+                            os = CommonRequests.Events.VersionIdentifier(
+                                identifier = infoHeaderModel.os.identifier,
+                                version = infoHeaderModel.os.version
+                            ),
+                            device = CommonRequests.Events.DeviceIdentifier(
+                                model = infoHeaderModel.device.identifier,
+                                screenSize = infoHeaderModel.device.version
+                            )
                         ),
-                        sdk = CommonRequests.Events.VersionIdentifier(
-                            identifier = infoHeaderModel.sdk.identifier,
-                            version = infoHeaderModel.sdk.version
-                        ),
-                        os = CommonRequests.Events.VersionIdentifier(
-                            identifier = infoHeaderModel.os.identifier,
-                            version = infoHeaderModel.os.version
-                        ),
-                        device = CommonRequests.Events.DeviceIdentifier(
-                            model = infoHeaderModel.device.identifier,
-                            screenSize = infoHeaderModel.device.version
+                        event = CommonRequests.Events.EventEvent(
+                            publicToken = publicToken,
+                            eventName = eventName,
+                            details = details,
                         )
-                    ),
-                    event = CommonRequests.Events.EventEvent(
-                        publicToken = publicToken,
-                        eventName = eventName,
-                        details = details,
                     )
                 )
             )
+            // Endpoint returns null, but we expect _something_
+            StytchDataResponse(NoResponseData())
         }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.CommonResponses
 import com.stytch.sdk.consumer.network.models.ConsumerRequests
 import com.stytch.sdk.consumer.network.models.ConsumerResponses
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -239,7 +240,8 @@ internal interface StytchApiService : ApiService {
     //region Events
     @POST("events")
     suspend fun logEvent(
-        @Body request: CommonRequests.Events.Event
-    ): CommonResponses.NoResponse
-    //endredion Events
+        // endpoint expects a list of events because JS SDK batches them
+        @Body request: List<CommonRequests.Events.Event>
+    ): Response<Unit>
+    //endregion Events
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -235,4 +235,11 @@ internal interface StytchApiService : ApiService {
         @Body request: ConsumerRequests.WebAuthn.UpdateRequest
     ): ConsumerResponses.WebAuthn.UpdateResponse
     //endregion WebAuthn
+
+    //region Events
+    @POST("events")
+    suspend fun logEvent(
+        @Body request: CommonRequests.Events.Event
+    ): CommonResponses.NoResponse
+    //endredion Events
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/events/EventsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/events/EventsImplTest.kt
@@ -1,0 +1,85 @@
+package com.stytch.sdk.b2b.events
+
+import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.EncryptionManager
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.network.InfoHeaderModel
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.security.KeyStore
+import java.util.TimeZone
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class EventsImplTest {
+    @MockK
+    private lateinit var mockEventsAPI: StytchB2BApi.Events
+
+    private lateinit var impl: EventsImpl
+
+    private val dispatcher = Dispatchers.Unconfined
+
+    private val mockDeviceInfo = DeviceInfo(
+        applicationPackageName = "com.stytch.test",
+        applicationVersion = "1.0.0",
+        osName = "Android",
+        osVersion = "14",
+        deviceName = "Test Device",
+        screenSize = ""
+    )
+
+    @Before
+    fun before() {
+        mockkStatic(KeyStore::class)
+        mockkObject(EncryptionManager)
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
+        MockKAnnotations.init(this, true, true)
+        mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
+        impl = EventsImpl(
+            deviceInfo = mockDeviceInfo,
+            appSessionId = "app-session-id",
+            dispatchers = StytchDispatchers(dispatcher, dispatcher),
+            externalScope = TestScope(),
+            api = mockEventsAPI
+        )
+    }
+
+    @After
+    fun after() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `EventsImpl logEvent delegates to api`() = runTest {
+        coEvery { mockEventsAPI.logEvent(any(), any(), any(), any(), any(), any(), any()) } returns mockk()
+        val mockDetails = mapOf("test-key" to "test value")
+        impl.logEvent("test-event", mockDetails)
+        coVerify(exactly = 1) {
+            mockEventsAPI.logEvent(
+                eventId = any(),
+                appSessionId = "app-session-id",
+                persistentId = any(),
+                clientSentAt = any(),
+                timezone = TimeZone.getDefault().id,
+                eventName = "test-event",
+                infoHeaderModel = InfoHeaderModel.fromDeviceInfo(mockDeviceInfo),
+                details = mockDetails,
+            )
+        }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.b2b.network
 
-import com.squareup.moshi.Json
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BRequests
@@ -164,7 +163,7 @@ internal class StytchB2BApiServiceTest {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.revokeSessions()
-            }.verifyPost(expectedPath = "/b2b/sessions/revoke")
+            }.verifyPost(expectedPath = "/b2b/sessions/revoke", emptyMap())
         }
     }
 
@@ -481,37 +480,39 @@ internal class StytchB2BApiServiceTest {
                 )
             )
             requestIgnoringResponseException {
-                apiService.logEvent(parameters)
+                apiService.logEvent(listOf(parameters))
             }.verifyPost(
                 expectedPath = "/events",
-                expectedBody = mapOf(
-                    "telemetry" to mapOf(
-                        "event_id" to parameters.telemetry.eventId,
-                        "app_session_id" to parameters.telemetry.appSessionId,
-                        "persistent_id" to parameters.telemetry.persistentId,
-                        "client_sent_at" to parameters.telemetry.clientSentAt,
-                        "timezone" to parameters.telemetry.timezone,
-                        "app" to mapOf(
-                            "identifier" to parameters.telemetry.app.identifier,
-                            "version" to parameters.telemetry.app.version
+                expectedBody = listOf(
+                    mapOf(
+                        "telemetry" to mapOf(
+                            "event_id" to parameters.telemetry.eventId,
+                            "app_session_id" to parameters.telemetry.appSessionId,
+                            "persistent_id" to parameters.telemetry.persistentId,
+                            "client_sent_at" to parameters.telemetry.clientSentAt,
+                            "timezone" to parameters.telemetry.timezone,
+                            "app" to mapOf(
+                                "identifier" to parameters.telemetry.app.identifier,
+                                "version" to parameters.telemetry.app.version
+                            ),
+                            "sdk" to mapOf(
+                                "identifier" to parameters.telemetry.sdk.identifier,
+                                "version" to parameters.telemetry.sdk.version
+                            ),
+                            "os" to mapOf(
+                                "identifier" to parameters.telemetry.os.identifier,
+                                "version" to parameters.telemetry.os.version
+                            ),
+                            "device" to mapOf(
+                                "model" to parameters.telemetry.device.model,
+                                "screen_size" to parameters.telemetry.device.screenSize,
+                            )
                         ),
-                        "sdk" to mapOf(
-                            "identifier" to parameters.telemetry.sdk.identifier,
-                            "version" to parameters.telemetry.sdk.version
-                        ),
-                        "os" to mapOf(
-                            "identifier" to parameters.telemetry.os.identifier,
-                            "version" to parameters.telemetry.os.version
-                        ),
-                        "device" to mapOf(
-                            "model" to parameters.telemetry.device.model,
-                            "screen_size" to parameters.telemetry.device.screenSize,
+                        "event" to mapOf(
+                            "public_token" to parameters.event.publicToken,
+                            "event_name" to parameters.event.eventName,
+                            "details" to parameters.event.details
                         )
-                    ),
-                    "event" to mapOf(
-                        "public_token" to parameters.event.publicToken,
-                        "event_name" to parameters.event.eventName,
-                        "details" to parameters.event.details
                     )
                 )
             )

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.network
 
+import com.squareup.moshi.Json
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BRequests
@@ -444,6 +445,79 @@ internal class StytchB2BApiServiceTest {
         }
     }
     // endregion Bootstrap
+
+    //region Events
+    @Test
+    fun `check Events logEvent request`() {
+        runBlocking {
+            val parameters: CommonRequests.Events.Event = CommonRequests.Events.Event(
+                telemetry = CommonRequests.Events.EventTelemetry(
+                    eventId = "event-id",
+                    appSessionId = "app-session-id",
+                    persistentId = "persistent-id",
+                    clientSentAt = "client sent at",
+                    timezone = "timezone",
+                    app = CommonRequests.Events.VersionIdentifier(
+                        identifier = "app-id",
+                        version = "app-version"
+                    ),
+                    os = CommonRequests.Events.VersionIdentifier(
+                        identifier = "os-id",
+                        version = "os-version"
+                    ),
+                    sdk = CommonRequests.Events.VersionIdentifier(
+                        identifier = "sdk-id",
+                        version = "sdk-version"
+                    ),
+                    device = CommonRequests.Events.DeviceIdentifier(
+                        model = "device-model",
+                        screenSize = "screen-size"
+                    ),
+                ),
+                event = CommonRequests.Events.EventEvent(
+                    publicToken = "public-token",
+                    eventName = "event name",
+                    details = mapOf("test-key" to "test value"),
+                )
+            )
+            requestIgnoringResponseException {
+                apiService.logEvent(parameters)
+            }.verifyPost(
+                expectedPath = "/events",
+                expectedBody = mapOf(
+                    "telemetry" to mapOf(
+                        "event_id" to parameters.telemetry.eventId,
+                        "app_session_id" to parameters.telemetry.appSessionId,
+                        "persistent_id" to parameters.telemetry.persistentId,
+                        "client_sent_at" to parameters.telemetry.clientSentAt,
+                        "timezone" to parameters.telemetry.timezone,
+                        "app" to mapOf(
+                            "identifier" to parameters.telemetry.app.identifier,
+                            "version" to parameters.telemetry.app.version
+                        ),
+                        "sdk" to mapOf(
+                            "identifier" to parameters.telemetry.sdk.identifier,
+                            "version" to parameters.telemetry.sdk.version
+                        ),
+                        "os" to mapOf(
+                            "identifier" to parameters.telemetry.os.identifier,
+                            "version" to parameters.telemetry.os.version
+                        ),
+                        "device" to mapOf(
+                            "model" to parameters.telemetry.device.model,
+                            "screen_size" to parameters.telemetry.device.screenSize,
+                        )
+                    ),
+                    "event" to mapOf(
+                        "public_token" to parameters.event.publicToken,
+                        "event_name" to parameters.event.eventName,
+                        "details" to parameters.event.details
+                    )
+                )
+            )
+        }
+    }
+    //endregion Events
 
     private suspend fun requestIgnoringResponseException(block: suspend () -> Unit): RecordedRequest {
         try {

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.network
 
 import android.app.Application
 import android.content.Context
+import com.squareup.moshi.Json
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.AuthMethods
@@ -15,7 +16,9 @@ import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
+import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchDataResponse
+import com.stytch.sdk.common.network.models.CommonRequests
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -27,16 +30,23 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import java.security.KeyStore
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import retrofit2.HttpException
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class StytchB2BApiTest {
     var mContextMock = mockk<Context>(relaxed = true)
+
+    private val mockDeviceInfo = DeviceInfo(
+        applicationPackageName = "com.stytch.test",
+        applicationVersion = "1.0.0",
+        osName = "Android",
+        osVersion = "14",
+        deviceName = "Test Device",
+        screenSize = ""
+    )
 
     @Before
     fun before() {
@@ -278,6 +288,59 @@ internal class StytchB2BApiTest {
         coEvery { StytchB2BApi.apiService.getBootstrapData("mock-public-token") } returns mockk(relaxed = true)
         StytchB2BApi.getBootstrapData()
         coVerify { StytchB2BApi.apiService.getBootstrapData("mock-public-token") }
+    }
+
+    @Test
+    fun `StytchB2BApi Events logEvent calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        every { StytchB2BApi.publicToken } returns "mock-public-token"
+        coEvery { StytchB2BApi.apiService.logEvent(any()) } returns mockk(relaxed = true)
+        val details = mapOf("test-key" to "test value")
+        val header = InfoHeaderModel.fromDeviceInfo(mockDeviceInfo)
+        val result = StytchB2BApi.Events.logEvent(
+            eventId = "event-id",
+            appSessionId = "app-session-id",
+            persistentId = "persistent-id",
+            clientSentAt = "ISO date string",
+            timezone = "Timezone/Identifier",
+            eventName = "event-name",
+            infoHeaderModel = header,
+            details = details,
+        )
+        coVerify(exactly = 1) {
+            StytchB2BApi.apiService.logEvent(
+                CommonRequests.Events.Event(
+                    telemetry = CommonRequests.Events.EventTelemetry(
+                        eventId = "event-id",
+                        appSessionId = "app-session-id",
+                        persistentId = "persistent-id",
+                        clientSentAt = "ISO date string",
+                        timezone = "Timezone/Identifier",
+                        app = CommonRequests.Events.VersionIdentifier(
+                            identifier = header.app.identifier,
+                            version = header.app.version
+                        ),
+                        os = CommonRequests.Events.VersionIdentifier(
+                            identifier = header.os.identifier,
+                            version = header.os.version
+                        ),
+                        sdk = CommonRequests.Events.VersionIdentifier(
+                            identifier = header.sdk.identifier,
+                            version = header.sdk.version
+                        ),
+                        device = CommonRequests.Events.DeviceIdentifier(
+                            model = header.device.identifier,
+                            screenSize = header.device.version
+                        ),
+                    ),
+                    event = CommonRequests.Events.EventEvent(
+                        publicToken = "mock-public-token",
+                        eventName = "event-name",
+                        details = details,
+                    ),
+                )
+            )
+        }
     }
 
     @Test(expected = StytchSDKNotConfiguredError::class)

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -2,7 +2,6 @@ package com.stytch.sdk.b2b.network
 
 import android.app.Application
 import android.content.Context
-import com.squareup.moshi.Json
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.AuthMethods
@@ -309,35 +308,37 @@ internal class StytchB2BApiTest {
         )
         coVerify(exactly = 1) {
             StytchB2BApi.apiService.logEvent(
-                CommonRequests.Events.Event(
-                    telemetry = CommonRequests.Events.EventTelemetry(
-                        eventId = "event-id",
-                        appSessionId = "app-session-id",
-                        persistentId = "persistent-id",
-                        clientSentAt = "ISO date string",
-                        timezone = "Timezone/Identifier",
-                        app = CommonRequests.Events.VersionIdentifier(
-                            identifier = header.app.identifier,
-                            version = header.app.version
+                listOf(
+                    CommonRequests.Events.Event(
+                        telemetry = CommonRequests.Events.EventTelemetry(
+                            eventId = "event-id",
+                            appSessionId = "app-session-id",
+                            persistentId = "persistent-id",
+                            clientSentAt = "ISO date string",
+                            timezone = "Timezone/Identifier",
+                            app = CommonRequests.Events.VersionIdentifier(
+                                identifier = header.app.identifier,
+                                version = header.app.version
+                            ),
+                            os = CommonRequests.Events.VersionIdentifier(
+                                identifier = header.os.identifier,
+                                version = header.os.version
+                            ),
+                            sdk = CommonRequests.Events.VersionIdentifier(
+                                identifier = header.sdk.identifier,
+                                version = header.sdk.version
+                            ),
+                            device = CommonRequests.Events.DeviceIdentifier(
+                                model = header.device.identifier,
+                                screenSize = header.device.version
+                            ),
                         ),
-                        os = CommonRequests.Events.VersionIdentifier(
-                            identifier = header.os.identifier,
-                            version = header.os.version
+                        event = CommonRequests.Events.EventEvent(
+                            publicToken = "mock-public-token",
+                            eventName = "event-name",
+                            details = details,
                         ),
-                        sdk = CommonRequests.Events.VersionIdentifier(
-                            identifier = header.sdk.identifier,
-                            version = header.sdk.version
-                        ),
-                        device = CommonRequests.Events.DeviceIdentifier(
-                            model = header.device.identifier,
-                            screenSize = header.device.version
-                        ),
-                    ),
-                    event = CommonRequests.Events.EventEvent(
-                        publicToken = "mock-public-token",
-                        eventName = "event-name",
-                        details = details,
-                    ),
+                    )
                 )
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/events/EventsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/events/EventsImplTest.kt
@@ -1,0 +1,85 @@
+package com.stytch.sdk.consumer.events
+
+import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.EncryptionManager
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.network.InfoHeaderModel
+import com.stytch.sdk.consumer.network.StytchApi
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.security.KeyStore
+import java.util.TimeZone
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class EventsImplTest {
+    @MockK
+    private lateinit var mockEventsAPI: StytchApi.Events
+
+    private lateinit var impl: EventsImpl
+
+    private val dispatcher = Dispatchers.Unconfined
+
+    private val mockDeviceInfo = DeviceInfo(
+        applicationPackageName = "com.stytch.test",
+        applicationVersion = "1.0.0",
+        osName = "Android",
+        osVersion = "14",
+        deviceName = "Test Device",
+        screenSize = ""
+    )
+
+    @Before
+    fun before() {
+        mockkStatic(KeyStore::class)
+        mockkObject(EncryptionManager)
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
+        MockKAnnotations.init(this, true, true)
+        mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
+        impl = EventsImpl(
+            deviceInfo = mockDeviceInfo,
+            appSessionId = "app-session-id",
+            dispatchers = StytchDispatchers(dispatcher, dispatcher),
+            externalScope = TestScope(),
+            api = mockEventsAPI
+        )
+    }
+
+    @After
+    fun after() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `EventsImpl logEvent delegates to api`() = runTest {
+        coEvery { mockEventsAPI.logEvent(any(), any(), any(), any(), any(), any(), any()) } returns mockk()
+        val mockDetails = mapOf("test-key" to "test value")
+        impl.logEvent("test-event", mockDetails)
+        coVerify(exactly = 1) {
+            mockEventsAPI.logEvent(
+                eventId = any(),
+                appSessionId = "app-session-id",
+                persistentId = any(),
+                clientSentAt = any(),
+                timezone = TimeZone.getDefault().id,
+                eventName = "test-event",
+                infoHeaderModel = InfoHeaderModel.fromDeviceInfo(mockDeviceInfo),
+                details = mockDetails,
+            )
+        }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -879,6 +879,79 @@ internal class StytchApiServiceTests {
     }
     //endregion
 
+    //region Events
+    @Test
+    fun `check Events logEvent request`() {
+        runBlocking {
+            val parameters: CommonRequests.Events.Event = CommonRequests.Events.Event(
+                telemetry = CommonRequests.Events.EventTelemetry(
+                    eventId = "event-id",
+                    appSessionId = "app-session-id",
+                    persistentId = "persistent-id",
+                    clientSentAt = "client sent at",
+                    timezone = "timezone",
+                    app = CommonRequests.Events.VersionIdentifier(
+                        identifier = "app-id",
+                        version = "app-version"
+                    ),
+                    os = CommonRequests.Events.VersionIdentifier(
+                        identifier = "os-id",
+                        version = "os-version"
+                    ),
+                    sdk = CommonRequests.Events.VersionIdentifier(
+                        identifier = "sdk-id",
+                        version = "sdk-version"
+                    ),
+                    device = CommonRequests.Events.DeviceIdentifier(
+                        model = "device-model",
+                        screenSize = "screen-size"
+                    ),
+                ),
+                event = CommonRequests.Events.EventEvent(
+                    publicToken = "public-token",
+                    eventName = "event name",
+                    details = mapOf("test-key" to "test value"),
+                )
+            )
+            requestIgnoringResponseException {
+                apiService.logEvent(parameters)
+            }.verifyPost(
+                expectedPath = "/events",
+                expectedBody = mapOf(
+                    "telemetry" to mapOf(
+                        "event_id" to parameters.telemetry.eventId,
+                        "app_session_id" to parameters.telemetry.appSessionId,
+                        "persistent_id" to parameters.telemetry.persistentId,
+                        "client_sent_at" to parameters.telemetry.clientSentAt,
+                        "timezone" to parameters.telemetry.timezone,
+                        "app" to mapOf(
+                            "identifier" to parameters.telemetry.app.identifier,
+                            "version" to parameters.telemetry.app.version
+                        ),
+                        "sdk" to mapOf(
+                            "identifier" to parameters.telemetry.sdk.identifier,
+                            "version" to parameters.telemetry.sdk.version
+                        ),
+                        "os" to mapOf(
+                            "identifier" to parameters.telemetry.os.identifier,
+                            "version" to parameters.telemetry.os.version
+                        ),
+                        "device" to mapOf(
+                            "model" to parameters.telemetry.device.model,
+                            "screen_size" to parameters.telemetry.device.screenSize,
+                        )
+                    ),
+                    "event" to mapOf(
+                        "public_token" to parameters.event.publicToken,
+                        "event_name" to parameters.event.eventName,
+                        "details" to parameters.event.details
+                    )
+                )
+            )
+        }
+    }
+    //endregion Events
+
     private suspend fun requestIgnoringResponseException(block: suspend () -> Unit): RecordedRequest {
         try {
             block()

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -524,7 +524,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.revokeSessions()
-            }.verifyPost(expectedPath = "/sessions/revoke")
+            }.verifyPost(expectedPath = "/sessions/revoke", emptyMap())
         }
     }
 
@@ -914,37 +914,39 @@ internal class StytchApiServiceTests {
                 )
             )
             requestIgnoringResponseException {
-                apiService.logEvent(parameters)
+                apiService.logEvent(listOf(parameters))
             }.verifyPost(
                 expectedPath = "/events",
-                expectedBody = mapOf(
-                    "telemetry" to mapOf(
-                        "event_id" to parameters.telemetry.eventId,
-                        "app_session_id" to parameters.telemetry.appSessionId,
-                        "persistent_id" to parameters.telemetry.persistentId,
-                        "client_sent_at" to parameters.telemetry.clientSentAt,
-                        "timezone" to parameters.telemetry.timezone,
-                        "app" to mapOf(
-                            "identifier" to parameters.telemetry.app.identifier,
-                            "version" to parameters.telemetry.app.version
+                expectedBody = listOf(
+                    mapOf(
+                        "telemetry" to mapOf(
+                            "event_id" to parameters.telemetry.eventId,
+                            "app_session_id" to parameters.telemetry.appSessionId,
+                            "persistent_id" to parameters.telemetry.persistentId,
+                            "client_sent_at" to parameters.telemetry.clientSentAt,
+                            "timezone" to parameters.telemetry.timezone,
+                            "app" to mapOf(
+                                "identifier" to parameters.telemetry.app.identifier,
+                                "version" to parameters.telemetry.app.version
+                            ),
+                            "sdk" to mapOf(
+                                "identifier" to parameters.telemetry.sdk.identifier,
+                                "version" to parameters.telemetry.sdk.version
+                            ),
+                            "os" to mapOf(
+                                "identifier" to parameters.telemetry.os.identifier,
+                                "version" to parameters.telemetry.os.version
+                            ),
+                            "device" to mapOf(
+                                "model" to parameters.telemetry.device.model,
+                                "screen_size" to parameters.telemetry.device.screenSize,
+                            )
                         ),
-                        "sdk" to mapOf(
-                            "identifier" to parameters.telemetry.sdk.identifier,
-                            "version" to parameters.telemetry.sdk.version
-                        ),
-                        "os" to mapOf(
-                            "identifier" to parameters.telemetry.os.identifier,
-                            "version" to parameters.telemetry.os.version
-                        ),
-                        "device" to mapOf(
-                            "model" to parameters.telemetry.device.model,
-                            "screen_size" to parameters.telemetry.device.screenSize,
+                        "event" to mapOf(
+                            "public_token" to parameters.event.publicToken,
+                            "event_name" to parameters.event.eventName,
+                            "details" to parameters.event.details
                         )
-                    ),
-                    "event" to mapOf(
-                        "public_token" to parameters.event.publicToken,
-                        "event_name" to parameters.event.eventName,
-                        "details" to parameters.event.details
                     )
                 )
             )

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -469,35 +469,37 @@ internal class StytchApiTest {
         )
         coVerify(exactly = 1) {
             StytchApi.apiService.logEvent(
-                CommonRequests.Events.Event(
-                    telemetry = CommonRequests.Events.EventTelemetry(
-                        eventId = "event-id",
-                        appSessionId = "app-session-id",
-                        persistentId = "persistent-id",
-                        clientSentAt = "ISO date string",
-                        timezone = "Timezone/Identifier",
-                        app = CommonRequests.Events.VersionIdentifier(
-                            identifier = header.app.identifier,
-                            version = header.app.version
+                listOf(
+                    CommonRequests.Events.Event(
+                        telemetry = CommonRequests.Events.EventTelemetry(
+                            eventId = "event-id",
+                            appSessionId = "app-session-id",
+                            persistentId = "persistent-id",
+                            clientSentAt = "ISO date string",
+                            timezone = "Timezone/Identifier",
+                            app = CommonRequests.Events.VersionIdentifier(
+                                identifier = header.app.identifier,
+                                version = header.app.version
+                            ),
+                            os = CommonRequests.Events.VersionIdentifier(
+                                identifier = header.os.identifier,
+                                version = header.os.version
+                            ),
+                            sdk = CommonRequests.Events.VersionIdentifier(
+                                identifier = header.sdk.identifier,
+                                version = header.sdk.version
+                            ),
+                            device = CommonRequests.Events.DeviceIdentifier(
+                                model = header.device.identifier,
+                                screenSize = header.device.version
+                            ),
                         ),
-                        os = CommonRequests.Events.VersionIdentifier(
-                            identifier = header.os.identifier,
-                            version = header.os.version
+                        event = CommonRequests.Events.EventEvent(
+                            publicToken = "mock-public-token",
+                            eventName = "event-name",
+                            details = details,
                         ),
-                        sdk = CommonRequests.Events.VersionIdentifier(
-                            identifier = header.sdk.identifier,
-                            version = header.sdk.version
-                        ),
-                        device = CommonRequests.Events.DeviceIdentifier(
-                            model = header.device.identifier,
-                            screenSize = header.device.version
-                        ),
-                    ),
-                    event = CommonRequests.Events.EventEvent(
-                        publicToken = "mock-public-token",
-                        eventName = "event-name",
-                        details = details,
-                    ),
+                    )
                 )
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -8,7 +8,9 @@ import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
+import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchDataResponse
+import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.models.ConsumerRequests
 import io.mockk.clearAllMocks
@@ -22,16 +24,23 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import java.security.KeyStore
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import retrofit2.HttpException
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class StytchApiTest {
     var mContextMock = mockk<Context>(relaxed = true)
+
+    private val mockDeviceInfo = DeviceInfo(
+        applicationPackageName = "com.stytch.test",
+        applicationVersion = "1.0.0",
+        osName = "Android",
+        osVersion = "14",
+        deviceName = "Test Device",
+        screenSize = ""
+    )
 
     @Before
     fun before() {
@@ -439,6 +448,59 @@ internal class StytchApiTest {
         coEvery { StytchApi.apiService.webAuthnUpdate(any(), any()) } returns mockk(relaxed = true)
         StytchApi.WebAuthn.update("", "my new name")
         coVerify { StytchApi.apiService.webAuthnUpdate("", any()) }
+    }
+
+    @Test
+    fun `StytchApi Events logEvent calls appropriate apiService method`() = runTest {
+        every { StytchApi.isInitialized } returns true
+        every { StytchApi.publicToken } returns "mock-public-token"
+        coEvery { StytchApi.apiService.logEvent(any()) } returns mockk(relaxed = true)
+        val details = mapOf("test-key" to "test value")
+        val header = InfoHeaderModel.fromDeviceInfo(mockDeviceInfo)
+        val result = StytchApi.Events.logEvent(
+            eventId = "event-id",
+            appSessionId = "app-session-id",
+            persistentId = "persistent-id",
+            clientSentAt = "ISO date string",
+            timezone = "Timezone/Identifier",
+            eventName = "event-name",
+            infoHeaderModel = header,
+            details = details,
+        )
+        coVerify(exactly = 1) {
+            StytchApi.apiService.logEvent(
+                CommonRequests.Events.Event(
+                    telemetry = CommonRequests.Events.EventTelemetry(
+                        eventId = "event-id",
+                        appSessionId = "app-session-id",
+                        persistentId = "persistent-id",
+                        clientSentAt = "ISO date string",
+                        timezone = "Timezone/Identifier",
+                        app = CommonRequests.Events.VersionIdentifier(
+                            identifier = header.app.identifier,
+                            version = header.app.version
+                        ),
+                        os = CommonRequests.Events.VersionIdentifier(
+                            identifier = header.os.identifier,
+                            version = header.os.version
+                        ),
+                        sdk = CommonRequests.Events.VersionIdentifier(
+                            identifier = header.sdk.identifier,
+                            version = header.sdk.version
+                        ),
+                        device = CommonRequests.Events.DeviceIdentifier(
+                            model = header.device.identifier,
+                            screenSize = header.device.version
+                        ),
+                    ),
+                    event = CommonRequests.Events.EventEvent(
+                        publicToken = "mock-public-token",
+                        eventName = "event-name",
+                        details = details,
+                    ),
+                )
+            )
+        }
     }
 
     @Test(expected = StytchSDKNotConfiguredError::class)

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-parcelize'
+    id 'kotlin-kapt'
     id "org.jetbrains.dokka"
 }
 
@@ -81,6 +82,8 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview"
     implementation "androidx.compose.material3:material3"
     implementation "androidx.compose.material:material-icons-extended"
+    implementation "com.squareup.moshi:moshi:$moshi_version"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     debugImplementation "androidx.compose.ui:ui-tooling"
     implementation "com.googlecode.libphonenumber:libphonenumber:8.12.52"
     api project(":sdk")

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
@@ -11,22 +11,16 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import cafe.adriel.voyager.androidx.AndroidScreen
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonReader
-import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.adapter
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchUIInvalidConfiguration
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.ui.data.EventState
-import com.stytch.sdk.ui.data.OAuthProvider
 import com.stytch.sdk.ui.data.StytchProductConfig
 import com.stytch.sdk.ui.data.StytchUIConfig
 import com.stytch.sdk.ui.theme.StytchTheme
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.RawValue
 
 internal class AuthenticationActivity : ComponentActivity() {
     private val viewModel: AuthenticationViewModel by viewModels { AuthenticationViewModel.Factory }

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
@@ -11,18 +11,29 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import cafe.adriel.voyager.androidx.AndroidScreen
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchUIInvalidConfiguration
+import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.ui.data.EventState
+import com.stytch.sdk.ui.data.OAuthProvider
+import com.stytch.sdk.ui.data.StytchProductConfig
 import com.stytch.sdk.ui.data.StytchUIConfig
 import com.stytch.sdk.ui.theme.StytchTheme
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.RawValue
 
 internal class AuthenticationActivity : ComponentActivity() {
     private val viewModel: AuthenticationViewModel by viewModels { AuthenticationViewModel.Factory }
     private lateinit var uiConfig: StytchUIConfig
     internal lateinit var savedStateHandle: SavedStateHandle
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         uiConfig = intent.getParcelableExtra(STYTCH_UI_CONFIG_KEY)
@@ -33,6 +44,13 @@ internal class AuthenticationActivity : ComponentActivity() {
                 )
                 return@onCreate
             }
+        // log render_login_screen
+        val moshi = Moshi.Builder().build()
+        val options = moshi.adapter<StytchProductConfig>().toJson(uiConfig.productConfig)
+        StytchClient.events.logEvent(
+            eventName = "render_login_screen",
+            details = mapOf("options" to options)
+        )
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationViewModel.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationViewModel.kt
@@ -42,7 +42,7 @@ internal class AuthenticationViewModel(
         scope.launch {
             val parameters = OAuth.GoogleOneTap.AuthenticateParameters(
                 data = data,
-                sessionDurationMinutes = sessionOptions.sessionDurationMinutes,
+                sessionDurationMinutes = sessionOptions.sessionDurationMinutes.toUInt(),
             )
             val result = stytchClient.oauth.googleOneTap.authenticate(parameters)
             _eventFlow.emit(EventState.Authenticated(result))
@@ -58,7 +58,7 @@ internal class AuthenticationViewModel(
         scope.launch {
             if (resultCode == Activity.RESULT_OK) {
                 intent.data?.let {
-                    when (val result = stytchClient.handle(it, sessionOptions.sessionDurationMinutes)) {
+                    when (val result = stytchClient.handle(it, sessionOptions.sessionDurationMinutes.toUInt())) {
                         is DeeplinkHandledStatus.Handled -> {
                             _eventFlow.emit(EventState.Authenticated(result.response.result))
                         }
@@ -80,7 +80,7 @@ internal class AuthenticationViewModel(
             when (
                 val result = stytchClient.handle(
                     uri = uri,
-                    sessionDurationMinutes = sessionOptions.sessionDurationMinutes
+                    sessionDurationMinutes = sessionOptions.sessionDurationMinutes.toUInt()
                 )
             ) {
                 is DeeplinkHandledStatus.Handled -> {

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/EmailMagicLinksOptions.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/EmailMagicLinksOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import com.stytch.sdk.consumer.magicLinks.MagicLinks
 import kotlinx.parcelize.Parcelize
 
@@ -12,9 +13,10 @@ import kotlinx.parcelize.Parcelize
  * @property signupTemplateId The ID of an email template (defined in the Stytch Dashboard) for signup emails
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class EmailMagicLinksOptions(
-    val loginExpirationMinutes: UInt? = null,
-    val signupExpirationMinutes: UInt? = null,
+    val loginExpirationMinutes: Int? = null,
+    val signupExpirationMinutes: Int? = null,
     val loginTemplateId: String? = null,
     val signupTemplateId: String? = null,
 ) : Parcelable {
@@ -22,8 +24,8 @@ public data class EmailMagicLinksOptions(
         email = emailAddress,
         loginMagicLinkUrl = "stytchui-$publicToken://deeplink",
         signupMagicLinkUrl = "stytchui-$publicToken://deeplink",
-        loginExpirationMinutes = loginExpirationMinutes,
-        signupExpirationMinutes = signupExpirationMinutes,
+        loginExpirationMinutes = loginExpirationMinutes?.toUInt(),
+        signupExpirationMinutes = signupExpirationMinutes?.toUInt(),
         loginTemplateId = loginTemplateId,
         signupTemplateId = signupTemplateId,
     )

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/GoogleOAuthOptions.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/GoogleOAuthOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -8,6 +9,7 @@ import kotlinx.parcelize.Parcelize
  * @property clientId the client ID you used to configure Google OAuth
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class GoogleOAuthOptions(
     val clientId: String? = null,
 ) : Parcelable

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/OAuthOptions.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/OAuthOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -10,6 +11,7 @@ import kotlinx.parcelize.Parcelize
  * @property providers A list of [OAuthProvider]s that you would like to support
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class OAuthOptions(
     val loginRedirectURL: String? = null,
     val signupRedirectURL: String? = null,

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/OTPOptions.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/OTPOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.Constants.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
 import com.stytch.sdk.consumer.otp.OTP
 import kotlinx.parcelize.Parcelize
@@ -13,26 +14,27 @@ import kotlinx.parcelize.Parcelize
  * @property signupTemplateId The ID of an OTP template (defined in the Stytch Dashboard) for signup requests
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class OTPOptions(
     val methods: List<OTPMethods> = emptyList(),
-    val expirationMinutes: UInt = DEFAULT_OTP_EXPIRATION_TIME_MINUTES,
+    val expirationMinutes: Int = DEFAULT_OTP_EXPIRATION_TIME_MINUTES.toInt(),
     val loginTemplateId: String? = null,
     val signupTemplateId: String? = null,
 ) : Parcelable {
     internal fun toEmailOtpParameters(emailAddress: String) = OTP.EmailOTP.Parameters(
         email = emailAddress,
-        expirationMinutes = expirationMinutes,
+        expirationMinutes = expirationMinutes.toUInt(),
         loginTemplateId = loginTemplateId,
         signupTemplateId = signupTemplateId,
     )
 
     internal fun toSMSOtpParameters(phoneNumber: String) = OTP.SmsOTP.Parameters(
         phoneNumber = phoneNumber,
-        expirationMinutes = expirationMinutes,
+        expirationMinutes = expirationMinutes.toUInt(),
     )
 
     internal fun toWhatsAppOtpParameters(phoneNumber: String) = OTP.WhatsAppOTP.Parameters(
         phoneNumber = phoneNumber,
-        expirationMinutes = expirationMinutes,
+        expirationMinutes = expirationMinutes.toUInt(),
     )
 }

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/PasswordOptions.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/PasswordOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import com.stytch.sdk.consumer.passwords.Passwords
 import kotlinx.parcelize.Parcelize
 
@@ -11,18 +12,19 @@ import kotlinx.parcelize.Parcelize
  * @property resetPasswordTemplateId The ID of an email template (defined in the Stytch Dashboard) for password resets
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class PasswordOptions(
-    val loginExpirationMinutes: UInt? = null,
-    val resetPasswordExpirationMinutes: UInt? = null,
+    val loginExpirationMinutes: Int? = null,
+    val resetPasswordExpirationMinutes: Int? = null,
     val resetPasswordTemplateId: String? = null,
 ) : Parcelable {
     internal fun toResetByEmailStartParameters(emailAddress: String, publicToken: String) =
         Passwords.ResetByEmailStartParameters(
             email = emailAddress,
             loginRedirectUrl = "stytchui-$publicToken://deeplink",
-            loginExpirationMinutes = loginExpirationMinutes,
+            loginExpirationMinutes = loginExpirationMinutes?.toUInt(),
             resetPasswordRedirectUrl = "stytchui-$publicToken://deeplink",
-            resetPasswordExpirationMinutes = resetPasswordExpirationMinutes,
+            resetPasswordExpirationMinutes = resetPasswordExpirationMinutes?.toUInt(),
             resetPasswordTemplateId = resetPasswordTemplateId,
         )
 }

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/SessionOptions.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/SessionOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.Constants.DEFAULT_SESSION_TIME_MINUTES
 import kotlinx.parcelize.Parcelize
 
@@ -9,6 +10,7 @@ import kotlinx.parcelize.Parcelize
  * @property sessionDurationMinutes The number of minutes that a granted session should be active. Defaults to 30
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class SessionOptions(
-    val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+    val sessionDurationMinutes: Int = DEFAULT_SESSION_TIME_MINUTES.toInt(),
 ) : Parcelable

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/data/StytchProductConfig.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/data/StytchProductConfig.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.data
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -14,6 +15,7 @@ import kotlinx.parcelize.Parcelize
  * @property googleOauthOptions an instance of [GoogleOAuthOptions]
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 public data class StytchProductConfig(
     val products: List<StytchProduct> = listOf(
         StytchProduct.EMAIL_MAGIC_LINKS,

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/screens/NewUserScreen.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/screens/NewUserScreen.kt
@@ -64,7 +64,7 @@ internal object NewUserScreen : AndroidScreen(), Parcelable {
             onEmailAddressChanged = viewModel::onEmailAddressChanged,
             onPasswordChanged = viewModel::onPasswordChanged,
             onEmailAndPasswordSubmitted = {
-                viewModel.createAccountWithPassword(productConfig.sessionOptions.sessionDurationMinutes)
+                viewModel.createAccountWithPassword(productConfig.sessionOptions.sessionDurationMinutes.toUInt())
             },
             hasEML = hasEML,
             hasEmailOTP = hasEmailOTP,

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/screens/OTPConfirmationScreenViewModel.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/screens/OTPConfirmationScreenViewModel.kt
@@ -84,7 +84,7 @@ internal class OTPConfirmationScreenViewModel(
                     OTP.AuthParameters(
                         token = token,
                         methodId = methodId,
-                        sessionDurationMinutes = sessionOptions.sessionDurationMinutes,
+                        sessionDurationMinutes = sessionOptions.sessionDurationMinutes.toUInt(),
                     ),
                 )
             ) {

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/screens/ReturningUserScreenViewModel.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/screens/ReturningUserScreenViewModel.kt
@@ -74,7 +74,7 @@ internal class ReturningUserScreenViewModel(
             val parameters = Passwords.AuthParameters(
                 email = uiState.value.emailState.emailAddress,
                 password = uiState.value.passwordState.password,
-                sessionDurationMinutes = sessionOptions.sessionDurationMinutes,
+                sessionDurationMinutes = sessionOptions.sessionDurationMinutes.toUInt(),
             )
             when (val result = stytchClient.passwords.authenticate(parameters)) {
                 is StytchResult.Success -> {

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/screens/SetPasswordScreenViewModel.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/screens/SetPasswordScreenViewModel.kt
@@ -87,7 +87,7 @@ internal class SetPasswordScreenViewModel(
             val parameters = Passwords.ResetByEmailParameters(
                 token = token,
                 password = password,
-                sessionDurationMinutes = sessionOptions.sessionDurationMinutes,
+                sessionDurationMinutes = sessionOptions.sessionDurationMinutes.toUInt(),
             )
             when (val result = stytchClient.passwords.resetByEmail(parameters)) {
                 is StytchResult.Success -> _eventFlow.emit(

--- a/ui/src/test/kotlin/com/stytch/sdk/ui/data/EmailMagicLinksOptionsTest.kt
+++ b/ui/src/test/kotlin/com/stytch/sdk/ui/data/EmailMagicLinksOptionsTest.kt
@@ -8,8 +8,8 @@ internal class EmailMagicLinksOptionsTest {
     @Test
     fun `EmailMagicLinksOptions toParameters produces expected output`() {
         val options = EmailMagicLinksOptions(
-            loginExpirationMinutes = 30U,
-            signupExpirationMinutes = 20U,
+            loginExpirationMinutes = 30,
+            signupExpirationMinutes = 20,
             loginTemplateId = "login-template-id",
             signupTemplateId = "signup-template-id",
         )
@@ -17,8 +17,8 @@ internal class EmailMagicLinksOptionsTest {
             email = "my@email.com",
             loginMagicLinkUrl = "stytchui-publicToken://deeplink",
             signupMagicLinkUrl = "stytchui-publicToken://deeplink",
-            loginExpirationMinutes = options.loginExpirationMinutes,
-            signupExpirationMinutes = options.signupExpirationMinutes,
+            loginExpirationMinutes = options.loginExpirationMinutes?.toUInt(),
+            signupExpirationMinutes = options.signupExpirationMinutes?.toUInt(),
             loginTemplateId = options.loginTemplateId,
             signupTemplateId = options.signupTemplateId,
         )

--- a/ui/src/test/kotlin/com/stytch/sdk/ui/data/OTPOptionsTest.kt
+++ b/ui/src/test/kotlin/com/stytch/sdk/ui/data/OTPOptionsTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 internal class OTPOptionsTest {
     private val defaultOTPOptions = OTPOptions(
-        expirationMinutes = 30U,
+        expirationMinutes = 30,
         loginTemplateId = "login-template-id",
         signupTemplateId = "signup-template-id"
     )
@@ -14,7 +14,7 @@ internal class OTPOptionsTest {
     fun `OTPOptions toEmailOtpParameters produces expected output`() {
         val expected = OTP.EmailOTP.Parameters(
             email = "my@email.com",
-            expirationMinutes = defaultOTPOptions.expirationMinutes,
+            expirationMinutes = defaultOTPOptions.expirationMinutes.toUInt(),
             loginTemplateId = defaultOTPOptions.loginTemplateId,
             signupTemplateId = defaultOTPOptions.signupTemplateId,
         )
@@ -25,7 +25,7 @@ internal class OTPOptionsTest {
     fun `OTPOptions toSMSOtpParameters produces expected output`() {
         val expected = OTP.SmsOTP.Parameters(
             phoneNumber = "123-456-7890",
-            expirationMinutes = defaultOTPOptions.expirationMinutes,
+            expirationMinutes = defaultOTPOptions.expirationMinutes.toUInt(),
         )
         assert(defaultOTPOptions.toSMSOtpParameters("123-456-7890") == expected)
     }
@@ -34,7 +34,7 @@ internal class OTPOptionsTest {
     fun `OTPOptions toWhatsAppOtpParameters produces expected output`() {
         val expected = OTP.WhatsAppOTP.Parameters(
             phoneNumber = "123-456-7890",
-            expirationMinutes = defaultOTPOptions.expirationMinutes,
+            expirationMinutes = defaultOTPOptions.expirationMinutes.toUInt(),
         )
         assert(defaultOTPOptions.toWhatsAppOtpParameters("123-456-7890") == expected)
     }

--- a/ui/src/test/kotlin/com/stytch/sdk/ui/data/PasswordOptionsTest.kt
+++ b/ui/src/test/kotlin/com/stytch/sdk/ui/data/PasswordOptionsTest.kt
@@ -7,16 +7,16 @@ internal class PasswordOptionsTest {
     @Test
     fun `PasswordOptions toResetByEmailStartParameters returns the expected output`() {
         val options = PasswordOptions(
-            loginExpirationMinutes = 30U,
-            resetPasswordExpirationMinutes = 20U,
+            loginExpirationMinutes = 30,
+            resetPasswordExpirationMinutes = 20,
             resetPasswordTemplateId = "reset-password-template-id",
         )
         val expected = Passwords.ResetByEmailStartParameters(
             email = "my@email.com",
             loginRedirectUrl = "stytchui-publicToken://deeplink",
-            loginExpirationMinutes = options.loginExpirationMinutes,
+            loginExpirationMinutes = options.loginExpirationMinutes?.toUInt(),
             resetPasswordRedirectUrl = "stytchui-publicToken://deeplink",
-            resetPasswordExpirationMinutes = options.resetPasswordExpirationMinutes,
+            resetPasswordExpirationMinutes = options.resetPasswordExpirationMinutes?.toUInt(),
             resetPasswordTemplateId = options.resetPasswordTemplateId,
         )
         assert(options.toResetByEmailStartParameters("my@email.com", "publicToken") == expected)


### PR DESCRIPTION
Linear Ticket: [SDK-1391](https://linear.app/stytch/issue/SDK-1391)

## Changes:

1. Adds infrastructure and tests for event logging (we're only going to be logging UI renders, but we're in a place to start adding more if we want to)
2. Adds the appropriate event for reporting UI launches based on the JS SDK implementation

## Notes:

- Proxyman log showing successful response: 
<img width="1119" alt="Screenshot 2024-01-22 at 12 31 28 PM" src="https://github.com/stytchauth/stytch-android/assets/117691317/9d78f59f-7834-4b3b-90e5-b97c7d29b889">


## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A