### PR TITLE
SDK-1414 Add profile_picture_url to Provider class

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -112,6 +112,9 @@ public data class Provider(
     // The type of the provider.
     @Json(name = "provider_type")
     val providerType: String,
+    // The profile picture url, if available
+    @Json(name = "profile_picture_url")
+    val profilePictureUrl: String? = null,
 ) : Parcelable
 
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
Linear Ticket: [SDK-1414](https://linear.app/stytch/issue/SDK-1414)

## Changes:

1. Adds profilePictureUrl to Provider class

## Notes:

- Tested in demo app with GitHub login

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A