### PR TITLE
SDK-1401 Add quick win metrics

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -112,9 +112,11 @@ public object StytchB2BClient {
                     }
                 }
                 _isInitialized.value = true
+                events.logEvent("client_initialization_success")
                 callback(_isInitialized.value)
             }
         } catch (ex: Exception) {
+            events.logEvent("client_initialization_failure", null, ex)
             throw StytchInternalError(
                 message = "Failed to initialize the SDK",
                 exception = ex
@@ -291,6 +293,7 @@ public object StytchB2BClient {
             }
             when (val tokenType = B2BTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
                 B2BTokenType.MULTI_TENANT_MAGIC_LINKS -> {
+                    events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
                         DeeplinkResponse.Auth(
                             magicLinks.authenticate(B2BMagicLinks.AuthParameters(token, sessionDurationMinutes))
@@ -298,6 +301,7 @@ public object StytchB2BClient {
                     )
                 }
                 B2BTokenType.DISCOVERY -> {
+                    events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
                         DeeplinkResponse.Discovery(
                             magicLinks.discoveryAuthenticate(
@@ -309,9 +313,11 @@ public object StytchB2BClient {
                     )
                 }
                 B2BTokenType.MULTI_TENANT_PASSWORDS -> {
+                    events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.ManualHandlingRequired(type = tokenType, token = token)
                 }
                 B2BTokenType.SSO -> {
+                    events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
                         DeeplinkResponse.Auth(
                             sso.authenticate(
@@ -324,6 +330,7 @@ public object StytchB2BClient {
                     )
                 }
                 else -> {
+                    events.logEvent("deeplink_handled_failure", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError)
                 }
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/events/EventsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/events/EventsImpl.kt
@@ -29,7 +29,8 @@ internal class EventsImpl(
                 timezone = TimeZone.getDefault().id,
                 eventName = eventName,
                 infoHeaderModel = infoHeaderModel,
-                details = details
+                details = details,
+                error = error,
             )
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -401,6 +401,7 @@ internal object StytchB2BApi {
             eventName: String,
             infoHeaderModel: InfoHeaderModel,
             details: Map<String, Any>? = null,
+            error: Exception? = null
         ): NoResponseResponse = safeB2BApiCall {
             apiService.logEvent(
                 listOf(
@@ -432,6 +433,7 @@ internal object StytchB2BApi {
                             publicToken = publicToken,
                             eventName = eventName,
                             details = details,
+                            errorDescription = error?.message
                         )
                     )
                 )

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
@@ -56,6 +56,8 @@ internal object CommonRequests {
             @Json(name = "event_name")
             val eventName: String,
             val details: Map<String, Any>? = null,
+            @Json(name = "error_description")
+            val errorDescription: String? = null,
         )
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/events/EventsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/events/EventsImpl.kt
@@ -29,7 +29,8 @@ internal class EventsImpl(
                 timezone = TimeZone.getDefault().id,
                 eventName = eventName,
                 infoHeaderModel = infoHeaderModel,
-                details = details
+                details = details,
+                error = error,
             )
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -682,6 +682,7 @@ internal object StytchApi {
             eventName: String,
             infoHeaderModel: InfoHeaderModel,
             details: Map<String, Any>? = null,
+            error: Exception? = null
         ): NoResponseResponse = safeConsumerApiCall {
             apiService.logEvent(
                 listOf(
@@ -713,6 +714,7 @@ internal object StytchApi {
                             publicToken = publicToken,
                             eventName = eventName,
                             details = details,
+                            errorDescription = error?.message
                         )
                     )
                 )

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -300,7 +300,9 @@ internal class StytchB2BClientTest {
     @Test
     fun `handle with coroutines returns NotHandled with correct error when token is missing`() {
         runBlocking {
-            every { StytchB2BApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchB2BClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns null
             }
@@ -313,7 +315,9 @@ internal class StytchB2BClientTest {
     @Test
     fun `handle with coroutines returns NotHandled with correct error when token is unknown`() {
         runBlocking {
-            every { StytchB2BApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchB2BClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "something unexpected"
             }
@@ -326,7 +330,9 @@ internal class StytchB2BClientTest {
     @Test
     fun `handle with coroutines delegates to magiclinks when token is DISCOVERY`() {
         runBlocking {
-            every { StytchB2BApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchB2BClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "DISCOVERY"
             }
@@ -341,7 +347,9 @@ internal class StytchB2BClientTest {
     @Test
     fun `handle with coroutines delegates to magiclinks when token is MAGIC_LINKS`() {
         runBlocking {
-            every { StytchB2BApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchB2BClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "MULTI_TENANT_MAGIC_LINKS"
             }
@@ -356,7 +364,9 @@ internal class StytchB2BClientTest {
     @Test
     fun `handle with coroutines returns NotHandled with correct error  when token is OAUTH`() {
         runBlocking {
-            every { StytchB2BApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchB2BClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "OAUTH"
             }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -317,7 +317,9 @@ internal class StytchClientTest {
     @Test
     fun `handle with coroutines returns NotHandled with correct error when token is missing`() {
         runBlocking {
-            every { StytchApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns null
             }
@@ -330,7 +332,9 @@ internal class StytchClientTest {
     @Test
     fun `handle with coroutines returns NotHandled with correct error when token is unknown`() {
         runBlocking {
-            every { StytchApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "something unexpected"
             }
@@ -343,7 +347,9 @@ internal class StytchClientTest {
     @Test
     fun `handle with coroutines delegates to magiclinks when token is MAGIC_LINKS`() {
         runBlocking {
-            every { StytchApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "MAGIC_LINKS"
             }
@@ -358,7 +364,9 @@ internal class StytchClientTest {
     @Test
     fun `handle with coroutines delegates to oauth when token is OAUTH`() {
         runBlocking {
-            every { StytchApi.isInitialized } returns true
+            val deviceInfo = DeviceInfo()
+            every { mContextMock.getDeviceInfo() } returns deviceInfo
+            StytchClient.configure(mContextMock, "")
             val mockUri = mockk<Uri> {
                 every { getQueryParameter(any()) } returns "OAUTH"
             }

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
@@ -92,6 +92,16 @@ internal class AuthenticationActivity : ComponentActivity() {
     }
 
     internal fun returnAuthenticationResult(result: StytchResult<*>) {
+        if (StytchClient.isInitialized.value) {
+            when (result) {
+                is StytchResult.Success -> StytchClient.events.logEvent("ui_authentication_success")
+                is StytchResult.Error -> StytchClient.events.logEvent(
+                    eventName = "ui_authentication_failure",
+                    details = null,
+                    error = result.exception
+                )
+            }
+        }
         val data = Intent().apply {
             putExtra(STYTCH_RESULT_KEY, result)
         }

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/AuthenticationActivity.kt
@@ -11,13 +11,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import cafe.adriel.voyager.androidx.AndroidScreen
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapter
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchUIInvalidConfiguration
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.ui.data.EventState
-import com.stytch.sdk.ui.data.StytchProductConfig
 import com.stytch.sdk.ui.data.StytchUIConfig
 import com.stytch.sdk.ui.theme.StytchTheme
 import kotlinx.coroutines.launch
@@ -27,7 +24,6 @@ internal class AuthenticationActivity : ComponentActivity() {
     private lateinit var uiConfig: StytchUIConfig
     internal lateinit var savedStateHandle: SavedStateHandle
 
-    @OptIn(ExperimentalStdlibApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         uiConfig = intent.getParcelableExtra(STYTCH_UI_CONFIG_KEY)
@@ -39,12 +35,10 @@ internal class AuthenticationActivity : ComponentActivity() {
                 return@onCreate
             }
         // log render_login_screen
-        val moshi = Moshi.Builder().build()
-        val options = moshi.adapter<StytchProductConfig>().toJson(uiConfig.productConfig)
         if (StytchClient.isInitialized.value) {
             StytchClient.events.logEvent(
                 eventName = "render_login_screen",
-                details = mapOf("options" to options)
+                details = mapOf("options" to uiConfig.productConfig)
             )
         }
         lifecycleScope.launch {


### PR DESCRIPTION
Linear Ticket: [SDK-1401](https://linear.app/stytch/issue/SDK-1401)

## Changes:

1. Adds the metrics as defined in the ticket
2. Fixes the logging of the ui config for `render_login_screen` so that it sends the actual JSON instead of a string

## Notes:

- Events verified in Proxyman/demo apps
- I don't like that the EventsImpl uses the global StytchClient object, but couldn't figure out a good/clean way to get it in there without duplicating code

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A