### PR TITLE
SDK-1449 Bump reCAPTCHA

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.19.0'
+  PUBLISH_VERSION = '0.20.0'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 
@@ -134,7 +134,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
     implementation 'com.google.crypto.tink:tink-android:1.8.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.72'
-    implementation 'com.google.android.recaptcha:recaptcha:18.2.1'
+    implementation 'com.google.android.recaptcha:recaptcha:18.4.0'
     implementation "androidx.credentials:credentials:1.2.0-rc01"
     implementation "androidx.credentials:credentials-play-services-auth:1.2.0-rc01"
 

--- a/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/StytchDFPInterceptor.kt
@@ -29,7 +29,8 @@ internal class StytchDFPInterceptor(
 ) : DFPInterceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        if (request.method == "GET" || request.method == "DELETE") return chain.proceed(request)
+        val isEventLogging = request.url.toUrl().path.contains("/events")
+        if (request.method == "GET" || request.method == "DELETE" || isEventLogging) return chain.proceed(request)
         if (!dfpProtectedAuthEnabled) return handleDisabledDFPStatus(chain)
         return when (dfpProtectedAuthMode) {
             DFPProtectedAuthMode.DECISIONING -> handleDFPDecisioningMode(chain)

--- a/sdk/src/test/java/com/stytch/sdk/common/network/StytchDFPInterceptorTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/network/StytchDFPInterceptorTest.kt
@@ -48,6 +48,9 @@ internal class StytchDFPInterceptorTest {
     fun `get requests do not inject DFP`() {
         val request: Request = mockk {
             every { method } returns "GET"
+            every { url } returns mockk {
+                every { toUrl() } returns mockk(relaxed = true)
+            }
         }
         val chain: Interceptor.Chain = mockk {
             every { request() } returns request
@@ -61,6 +64,27 @@ internal class StytchDFPInterceptorTest {
     fun `delete requests do not inject DFP`() {
         val request: Request = mockk {
             every { method } returns "DELETE"
+            every { url } returns mockk {
+                every { toUrl() } returns mockk(relaxed = true)
+            }
+        }
+        val chain: Interceptor.Chain = mockk {
+            every { request() } returns request
+            every { proceed(any()) } returns mockk()
+        }
+        interceptor.intercept(chain)
+        verify(exactly = 0) { request.toNewRequestWithParams(any()) }
+    }
+
+    @Test
+    fun `event logs do not inject DFP or CAPTCHA`() {
+        val request: Request = mockk {
+            every { method } returns "POST"
+            every { url } returns mockk {
+                every { toUrl() } returns mockk {
+                    every { path } returns "/events"
+                }
+            }
         }
         val chain: Interceptor.Chain = mockk {
             every { request() } returns request
@@ -74,6 +98,9 @@ internal class StytchDFPInterceptorTest {
     fun `intercept calls the appropriate method based on the DFPProtectedAuth type`() {
         val request: Request = mockk {
             every { method } returns "POST"
+            every { url } returns mockk {
+                every { toUrl() } returns mockk(relaxed = true)
+            }
             every { body } returns "".toRequestBody("application/json".toMediaTypeOrNull())
         }
         val chain: Interceptor.Chain = mockk {


### PR DESCRIPTION
Linear Ticket: [SDK-1449](https://linear.app/stytch/issue/SDK-1449)

## Changes:

1. Bumps Google reCAPTCHA version due to a new vulnerability
2. Fixes a bug when sending events with DFP enabled (the fix is to _not_ try to append DFP/CAPTCHA tokens to events)

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A