### PR TITLE
SDK-1499 Fix multi-activity bug

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.20.0'
+  PUBLISH_VERSION = '0.20.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/ActivityProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/ActivityProvider.kt
@@ -11,6 +11,8 @@ internal class ActivityProvider(application: Application) : Application.Activity
     internal val currentActivity: Activity?
         get() = _currentActivity.get()
 
+    private var lastResumedActivityName: String? = null
+
     init {
         application.registerActivityLifecycleCallbacks(this)
     }
@@ -24,14 +26,17 @@ internal class ActivityProvider(application: Application) : Application.Activity
     }
 
     override fun onActivityResumed(activity: Activity) {
+        lastResumedActivityName = activity.localClassName
         _currentActivity = WeakReference(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {
+        if (lastResumedActivityName != activity.localClassName) return
         _currentActivity = WeakReference(null)
     }
 
     override fun onActivityStopped(activity: Activity) {
+        if (lastResumedActivityName != activity.localClassName) return
         _currentActivity = WeakReference(null)
     }
 
@@ -40,6 +45,7 @@ internal class ActivityProvider(application: Application) : Application.Activity
     }
 
     override fun onActivityDestroyed(activity: Activity) {
+        if (lastResumedActivityName != activity.localClassName) return
         _currentActivity = WeakReference(null)
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1499](https://linear.app/stytch/issue/SDK-1499)

## Changes:

1. Don't null the activity reference _unless_ it matches the last resumed activity. Fixes a bug when an app presents multiple activities because of the differences in activity lifecycles (eg: killing an activity resumes the previous activity _before_ the last activity is fully destroyed)

## Notes:

- Tested in workbench

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A