### PR TITLE
SDK-1459 Add B2B MagicLinks.Email.Invite support

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
@@ -92,6 +92,24 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun sendInviteMagicLink() {
+        if (emailIsValid) {
+            showEmailError = false
+            viewModelScope.launch {
+                _loadingState.value = true
+                _currentResponse.value = StytchB2BClient.magicLinks.email.invite(
+                    B2BMagicLinks.EmailMagicLinks.InviteParameters(
+                        emailAddress = emailState.text,
+                    )
+                ).toFriendlyDisplay()
+            }.invokeOnCompletion {
+                _loadingState.value = false
+            }
+        } else {
+            showEmailError = true
+        }
+    }
+
     fun revokeSession() {
         viewModelScope.launch {
             _loadingState.value = true

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/MainScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/MainScreen.kt
@@ -32,7 +32,10 @@ fun MainScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .weight(1F, false),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             TextField(
@@ -84,12 +87,20 @@ fun MainScreen(
             )
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.send_invite_magic_link),
+                onClick = viewModel::sendInviteMagicLink
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.revoke_session),
                 onClick = { viewModel.revokeSession() }
             )
         }
         Column(
-            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .weight(1F, false),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (loading.value) {

--- a/b2bExampleApp/src/main/res/values/strings.xml
+++ b/b2bExampleApp/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="discovery">Discovery</string>
     <string name="discovery_discover">Discover Organizations</string>
     <string name="send_discovery_magic_link">Send Discovery Magic Link</string>
+    <string name="send_invite_magic_link">Send Invite Magic Link</string>
     <string name="create_organization">Create an organization</string>
     <string name="sso">SSO</string>
     <string name="sso_connection_id">Connection ID</string>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -2,8 +2,10 @@ package com.stytch.sdk.b2b.magicLinks
 
 import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
+import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.Constants
+import kotlinx.parcelize.RawValue
 
 /**
  * The B2BMagicLinks interface provides methods for sending and authenticating users with Email Magic Links.
@@ -152,21 +154,68 @@ public interface B2BMagicLinks {
         )
 
         /**
-         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
-         * status until they successfully authenticate. Sending invites to pending Members will update their status to
-         * invited. Sending invites to already active Members will return an error.
+         * Send a discovery magic link to an email address
          * @param parameters required to send a discovery magic link
          * @return [BaseResponse]
          */
         public suspend fun discoverySend(parameters: DiscoverySendParameters): BaseResponse
 
         /**
-         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
-         * status until they successfully authenticate. Sending invites to pending Members will update their status to
-         * invited. Sending invites to already active Members will return an error.
+         * Send a discovery magic link to an email address
          * @param parameters required to send a discovery magic link
          * @param callback a callback that receives a [BaseResponse]
          */
         public fun discoverySend(parameters: DiscoverySendParameters, callback: (BaseResponse) -> Unit)
+
+        /**
+         * A data class used for wrapping paramaters used for sending an invite magic link
+         * @property emailAddress is the account identifier for the account in the form of an Email address where you
+         * wish to receive a magic link to authenticate
+         * @property inviteRedirectUrl The URL that the Member clicks from the invite Email Magic Link. This URL should
+         * be an endpoint in the backend server that verifies the request by querying Stytch's authenticate endpoint and
+         * finishes the invite flow. If this value is not passed, the default `invite_redirect_url` that you set in your
+         * Dashboard is used. If you have not set a default `invite_redirect_url`, an error is returned.
+         * @property inviteTemplateId Use a custom template for invite emails. By default, it will use your default
+         * email template. The template must be a template using our built-in customizations or a custom HTML email for
+         * Magic Links - Invite.
+         * @property name The name of the Member.
+         * @property untrustedMetadata A map containing application-specific metadata. Use it to store fields that a
+         * member can be allowed to edit directly without backend validation - such as `display_theme` or
+         * `preferred_locale`. See our [metadata reference](https://stytch.com/docs/api/metadata) for complete details.
+         * @property locale The locale is used to determine which language to use in the email. Parameter is a
+         * [IETF BCP 47 language tag](https://www.w3.org/International/articles/language-tags/), e.g. "en". Currently
+         * supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is
+         * provided, the copy defaults to English.
+         * @property roles Roles to explicitly assign to this Member. See our
+         * [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/role-assignment) for more information about role
+         * assignment.
+         */
+        public data class InviteParameters(
+            val emailAddress: String,
+            val inviteRedirectUrl: String? = null,
+            val inviteTemplateId: String? = null,
+            val name: String? = null,
+            val untrustedMetadata: Map<String, Any?>? = null,
+            val locale: String? = null,
+            val roles: List<String>? = null,
+        )
+
+        /**
+         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
+         * status until they successfully authenticate. Sending invites to pending Members will update their status to
+         * invited. Sending invites to already active Members will return an error.
+         * @param parameters required to send an invite magic link
+         * @return [MemberResponse]
+         */
+        public suspend fun invite(parameters: InviteParameters): MemberResponse
+
+        /**
+         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
+         * status until they successfully authenticate. Sending invites to pending Members will update their status to
+         * invited. Sending invites to already active Members will return an error.
+         * @param parameters required to send a discovery magic link
+         * @param callback a callback that receives a [MemberResponse]
+         */
+        public fun invite(parameters: InviteParameters, callback: (MemberResponse) -> Unit)
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -5,7 +5,6 @@ import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
 import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.Constants
-import kotlinx.parcelize.RawValue
 
 /**
  * The B2BMagicLinks interface provides methods for sending and authenticating users with Email Magic Links.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -15,7 +15,6 @@ import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 
 internal class B2BMagicLinksImpl internal constructor(
     private val externalScope: CoroutineScope,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.magicLinks
 
 import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
+import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
@@ -14,6 +15,7 @@ import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 
 internal class B2BMagicLinksImpl internal constructor(
     private val externalScope: CoroutineScope,
@@ -164,6 +166,30 @@ internal class B2BMagicLinksImpl internal constructor(
         ) {
             externalScope.launch(dispatchers.ui) {
                 val result = discoverySend(parameters)
+                callback(result)
+            }
+        }
+
+        override suspend fun invite(parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters): MemberResponse {
+            return withContext(dispatchers.io) {
+                emailApi.invite(
+                    emailAddress = parameters.emailAddress,
+                    inviteRedirectUrl = parameters.inviteRedirectUrl,
+                    inviteTemplateId = parameters.inviteTemplateId,
+                    name = parameters.name,
+                    untrustedMetadata = parameters.untrustedMetadata,
+                    locale = parameters.locale,
+                    roles = parameters.roles,
+                )
+            }
+        }
+
+        override fun invite(
+            parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters,
+            callback: (MemberResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                val result = invite(parameters)
                 callback(result)
             }
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -40,6 +40,7 @@ import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
 import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.safeApiCall
+import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 
 internal object StytchB2BApi {
     internal lateinit var publicToken: String
@@ -155,6 +156,28 @@ internal object StytchB2BApi {
                         token = token,
                         codeVerifier = codeVerifier,
                         sessionDurationMinutes = sessionDurationMinutes.toInt()
+                    )
+                )
+            }
+
+            suspend fun invite(
+                emailAddress: String,
+                inviteRedirectUrl: String? = null,
+                inviteTemplateId: String? = null,
+                name: String? = null,
+                untrustedMetadata: Map<String, Any?>? = null,
+                locale: String? = null,
+                roles: List<String>? = null,
+            ): StytchResult<MemberResponseData> = safeB2BApiCall {
+                apiService.sendInviteMagicLink(
+                    B2BRequests.MagicLinks.Invite.InviteRequest(
+                        emailAddress = emailAddress,
+                        inviteRedirectUrl = inviteRedirectUrl,
+                        inviteTemplateId = inviteTemplateId,
+                        name = name,
+                        untrustedMetadata = untrustedMetadata,
+                        locale = locale,
+                        roles = roles,
                     )
                 )
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -40,7 +40,6 @@ import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
 import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.safeApiCall
-import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 
 internal object StytchB2BApi {
     internal lateinit var publicToken: String

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -32,6 +32,11 @@ internal interface StytchB2BApiService : ApiService {
     suspend fun authenticateDiscoveryMagicLink(
         @Body request: B2BRequests.MagicLinks.Discovery.AuthenticateRequest
     ): B2BResponses.MagicLinks.DiscoveryAuthenticateResponse
+
+    @POST("b2b/magic_links/email/invite")
+    suspend fun sendInviteMagicLink(
+        @Body request: B2BRequests.MagicLinks.Invite.InviteRequest
+    ): B2BResponses.MagicLinks.InviteResponse
     //endregion Magic Links
 
     //region Sessions

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -47,6 +47,23 @@ internal object B2BRequests {
             )
         }
 
+        object Invite {
+            @JsonClass(generateAdapter = true)
+            data class InviteRequest(
+                @Json(name = "email_address")
+                val emailAddress: String,
+                @Json(name = "invite_redirect_url")
+                val inviteRedirectUrl: String? = null,
+                @Json(name = "invite_template_id")
+                val inviteTemplateId: String? = null,
+                val name: String? = null,
+                @Json(name = "untrusted_metadata")
+                val untrustedMetadata: Map<String, Any?>? = null,
+                val locale: String? = null,
+                val roles: List<String>? = null,
+            )
+        }
+
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "magic_links_token")

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -13,6 +13,9 @@ internal object B2BResponses {
         class DiscoveryAuthenticateResponse(
             data: DiscoveryAuthenticateResponseData
         ) : StytchDataResponse<DiscoveryAuthenticateResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class InviteResponse(data: MemberResponseData) : StytchDataResponse<MemberResponseData>(data)
     }
 
     object Sessions {

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.magicLinks
 
 import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
+import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
@@ -54,7 +55,9 @@ internal class B2BMagicLinksImplTest {
     private val successfulAuthResponse = StytchResult.Success<B2BEMLAuthenticateData>(mockk(relaxed = true))
     private val authParameters = mockk<B2BMagicLinks.AuthParameters>(relaxed = true)
     private val emailMagicLinkParameters = mockk<B2BMagicLinks.EmailMagicLinks.Parameters>(relaxed = true)
+    private val emailInviteParameters = mockk<B2BMagicLinks.EmailMagicLinks.InviteParameters>(relaxed = true)
     private val mockBaseResponse = mockk<BaseResponse>()
+    private val mockMemberResponse = mockk<MemberResponse>()
 
     @Before
     fun before() {
@@ -128,6 +131,25 @@ internal class B2BMagicLinksImplTest {
     fun `MagicLinksImpl email loginOrCreate with callback calls callback method`() {
         val mockCallback = spyk<(BaseResponse) -> Unit>()
         impl.email.loginOrSignup(emailMagicLinkParameters, mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `MagicLinksImpl email invite delegates to api`() = runTest {
+        coEvery {
+            mockEmailApi.invite(any(), any(), any(), any(), any(), any(), any())
+        } returns mockMemberResponse
+        impl.email.invite(emailInviteParameters)
+        coVerify { mockEmailApi.invite(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `MagicLinksImpl email invite with callback calls callback method`() {
+        coEvery {
+            mockEmailApi.invite(any(), any(), any(), any(), any(), any(), any())
+        } returns mockMemberResponse
+        val mockCallback = spyk<(MemberResponse) -> Unit>()
+        impl.email.invite(emailInviteParameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksTest.kt
@@ -21,6 +21,21 @@ internal class B2BMagicLinksTest {
     }
 
     @Test
+    fun `MagicLinks EmailMagicLinks InviteParameters have correct default values`() {
+        val params = B2BMagicLinks.EmailMagicLinks.InviteParameters(emailAddress = "emailaddress")
+        val expected = B2BMagicLinks.EmailMagicLinks.InviteParameters(
+            emailAddress = "emailaddress",
+            inviteRedirectUrl = null,
+            inviteTemplateId = null,
+            name = null,
+            untrustedMetadata = null,
+            locale = null,
+            roles = null
+        )
+        assert(params == expected)
+    }
+
+    @Test
     fun `MagicLinks Discovery Send parameters have correct default values`() {
         val params = B2BMagicLinks.EmailMagicLinks.DiscoverySendParameters(
             emailAddress = "",

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -77,6 +77,34 @@ internal class StytchB2BApiServiceTest {
             )
         }
     }
+    @Test
+    fun `check magic links email invite request`() {
+        runBlocking {
+            val parameters = B2BRequests.MagicLinks.Invite.InviteRequest(
+                emailAddress = EMAIL,
+                inviteRedirectUrl = "invite-redirect-url",
+                inviteTemplateId = "invite-template-id",
+                name = "member name",
+                untrustedMetadata = mapOf("someMetadataKey" to "someMetadataValue"),
+                locale = "en",
+                roles = listOf("role1", "role2")
+            )
+            requestIgnoringResponseException {
+                apiService.sendInviteMagicLink(parameters)
+            }.verifyPost(
+                expectedPath = "/b2b/magic_links/email/invite",
+                expectedBody = mapOf(
+                    "email_address" to parameters.emailAddress,
+                    "invite_redirect_url" to parameters.inviteRedirectUrl,
+                    "invite_template_id" to parameters.inviteTemplateId,
+                    "name" to parameters.name,
+                    "untrusted_metadata" to parameters.untrustedMetadata,
+                    "locale" to parameters.locale,
+                    "roles" to parameters.roles,
+                )
+            )
+        }
+    }
 
     @Test
     fun `check magic links authenticate request`() {

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -107,6 +107,14 @@ internal class StytchB2BApiTest {
     }
 
     @Test
+    fun `StytchB2BApi MagicLinks Email invite calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        coEvery { StytchB2BApi.apiService.sendInviteMagicLink(any()) } returns mockk(relaxed = true)
+        StytchB2BApi.MagicLinks.Email.invite("email@address.com")
+        coVerify { StytchB2BApi.apiService.sendInviteMagicLink(any()) }
+    }
+
+    @Test
     fun `StytchB2BApi MagicLinks Discovery send calls appropriate apiService method`() = runTest {
         every { StytchB2BApi.isInitialized } returns true
         coEvery { StytchB2BApi.apiService.sendDiscoveryMagicLink(any()) } returns mockk(relaxed = true)


### PR DESCRIPTION
Linear Ticket: [SDK-1459](https://linear.app/stytch/issue/SDK-1459)

## Changes:

1. Adds functionality and tests for B2B.MagicLinks.Email.Invite
2. Updates Workbench app to test functionality

## Notes:

- Also fixes wrong docs for discoverySend

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A