### PR TITLE
SDK-1538 Use correct date format for events client_sent_at

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/b2b/events/EventsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/events/EventsImpl.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.network.InfoHeaderModel
+import com.stytch.sdk.common.utils.ISO_DATE_FORMATTER
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -29,7 +30,7 @@ internal class EventsImpl(
                 eventId = "event-id-${UUID.randomUUID()}",
                 appSessionId = appSessionId,
                 persistentId = "persistent-id-${UUID.randomUUID()}",
-                clientSentAt = Date().toString(),
+                clientSentAt = ISO_DATE_FORMATTER.format(Date()),
                 timezone = TimeZone.getDefault().id,
                 eventName = eventName,
                 infoHeaderModel = infoHeaderModel,

--- a/sdk/src/main/java/com/stytch/sdk/common/utils/DateHelpers.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/utils/DateHelpers.kt
@@ -1,0 +1,5 @@
+package com.stytch.sdk.common.utils
+
+import java.text.SimpleDateFormat
+
+internal val ISO_DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")

--- a/sdk/src/main/java/com/stytch/sdk/common/utils/DateHelpers.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/utils/DateHelpers.kt
@@ -2,4 +2,5 @@ package com.stytch.sdk.common.utils
 
 import java.text.SimpleDateFormat
 
+// Format a date as ISO-8601, using the appropriate date and time patterns. See: https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
 internal val ISO_DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")

--- a/sdk/src/main/java/com/stytch/sdk/consumer/events/EventsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/events/EventsImpl.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.events
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.network.InfoHeaderModel
+import com.stytch.sdk.common.utils.ISO_DATE_FORMATTER
 import com.stytch.sdk.consumer.network.StytchApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -29,7 +30,7 @@ internal class EventsImpl(
                 eventId = "event-id-${UUID.randomUUID()}",
                 appSessionId = appSessionId,
                 persistentId = "persistent-id-${UUID.randomUUID()}",
-                clientSentAt = Date().toString(),
+                clientSentAt = ISO_DATE_FORMATTER.format(Date()),
                 timezone = TimeZone.getDefault().id,
                 eventName = eventName,
                 infoHeaderModel = infoHeaderModel,


### PR DESCRIPTION
Linear Ticket: [SDK-1538 ](https://linear.app/stytch/issue/SDK-1538 )

## Changes:

1. Updates the date string we send to match what the db is expecting

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A