### PR TITLE
SDK-1585 Use SecureRandom instead of Random for PKCE code challenges

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.20.4'
+  PUBLISH_VERSION = '0.20.5'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/common/EncryptionManager.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/EncryptionManager.kt
@@ -15,20 +15,18 @@ import com.stytch.sdk.common.extensions.hexStringToByteArray
 import com.stytch.sdk.common.extensions.toBase64DecodedByteArray
 import com.stytch.sdk.common.extensions.toBase64EncodedString
 import com.stytch.sdk.common.extensions.toHexString
-import java.security.InvalidKeyException
-import java.security.MessageDigest
-import java.security.SecureRandom
-import kotlin.random.Random
 import org.bouncycastle.crypto.Signer
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
+import java.security.InvalidKeyException
+import java.security.MessageDigest
+import java.security.SecureRandom
 
 @Suppress("TooManyFunctions")
 internal object EncryptionManager {
-
     private const val PREF_FILE_NAME = "stytch_secured_pref"
     private const val MASTER_KEY_URI = "android-keystore://stytch_master_key"
     private var keysetManager: AndroidKeysetManager? = null
@@ -39,7 +37,10 @@ internal object EncryptionManager {
         SignatureConfig.register()
     }
 
-    private fun getOrGenerateNewAES256KeysetManager(context: Context, keyAlias: String): AndroidKeysetManager {
+    private fun getOrGenerateNewAES256KeysetManager(
+        context: Context,
+        keyAlias: String,
+    ): AndroidKeysetManager {
         return try {
             AndroidKeysetManager.Builder()
                 .withSharedPref(context, keyAlias, PREF_FILE_NAME)
@@ -93,15 +94,18 @@ internal object EncryptionManager {
     /**
      * @throws Exception - if failed to generate keys
      */
-    fun createNewKeys(context: Context, rsaKeyAlias: String) {
+    fun createNewKeys(
+        context: Context,
+        rsaKeyAlias: String,
+    ) {
         val ksm = getOrGenerateNewAES256KeysetManager(context, rsaKeyAlias)
         keysetManager = ksm
         aead = ksm.keysetHandle.getPrimitive(Aead::class.java)
     }
 
     fun generateCodeChallenge(): String {
-        val randomGenerator = Random(System.currentTimeMillis())
-        val randomBytes: ByteArray = randomGenerator.nextBytes(Constants.CODE_CHALLENGE_BYTE_COUNT)
+        val randomBytes = ByteArray(Constants.CODE_CHALLENGE_BYTE_COUNT)
+        SecureRandom().nextBytes(randomBytes)
         return randomBytes.toHexString()
     }
 
@@ -128,34 +132,40 @@ internal object EncryptionManager {
 
     fun isKeysetUsingKeystore(): Boolean = keysetManager?.isUsingKeystore == true
 
-    fun generateEd25519KeyPair(): Pair<String, String> = try {
-        val gen = Ed25519KeyPairGenerator()
-        gen.init(Ed25519KeyGenerationParameters(SecureRandom()))
-        val keyPair = gen.generateKeyPair()
-        val publicKey = keyPair.public as Ed25519PublicKeyParameters
-        val privateKey = keyPair.private as Ed25519PrivateKeyParameters
-        Pair(publicKey.encoded.toBase64EncodedString(), privateKey.encoded.toBase64EncodedString())
-    } catch (e: Exception) {
-        throw StytchMissingPublicKeyError(e)
-    }
+    fun generateEd25519KeyPair(): Pair<String, String> =
+        try {
+            val gen = Ed25519KeyPairGenerator()
+            gen.init(Ed25519KeyGenerationParameters(SecureRandom()))
+            val keyPair = gen.generateKeyPair()
+            val publicKey = keyPair.public as Ed25519PublicKeyParameters
+            val privateKey = keyPair.private as Ed25519PrivateKeyParameters
+            Pair(publicKey.encoded.toBase64EncodedString(), privateKey.encoded.toBase64EncodedString())
+        } catch (e: Exception) {
+            throw StytchMissingPublicKeyError(e)
+        }
 
-    fun signEd25519Challenge(challengeString: String, privateKeyString: String): String = try {
-        val signer: Signer = Ed25519Signer()
-        val challenge = challengeString.toBase64DecodedByteArray()
-        val privateKey = Ed25519PrivateKeyParameters(privateKeyString.toBase64DecodedByteArray())
-        signer.init(true, privateKey)
-        signer.update(challenge, 0, challenge.size)
-        val signature: ByteArray = signer.generateSignature()
-        signature.toBase64EncodedString()
-    } catch (e: Exception) {
-        throw StytchChallengeSigningFailed(e)
-    }
+    fun signEd25519Challenge(
+        challengeString: String,
+        privateKeyString: String,
+    ): String =
+        try {
+            val signer: Signer = Ed25519Signer()
+            val challenge = challengeString.toBase64DecodedByteArray()
+            val privateKey = Ed25519PrivateKeyParameters(privateKeyString.toBase64DecodedByteArray())
+            signer.init(true, privateKey)
+            signer.update(challenge, 0, challenge.size)
+            val signature: ByteArray = signer.generateSignature()
+            signature.toBase64EncodedString()
+        } catch (e: Exception) {
+            throw StytchChallengeSigningFailed(e)
+        }
 
-    fun deriveEd25519PublicKeyFromPrivateKeyBytes(privateKeyBytes: ByteArray): String = try {
-        val privateKeyRebuild = Ed25519PrivateKeyParameters(privateKeyBytes, 0)
-        val publicKeyRebuild = privateKeyRebuild.generatePublicKey()
-        publicKeyRebuild.encoded.toBase64EncodedString()
-    } catch (e: Exception) {
-        throw StytchMissingPublicKeyError(e)
-    }
+    fun deriveEd25519PublicKeyFromPrivateKeyBytes(privateKeyBytes: ByteArray): String =
+        try {
+            val privateKeyRebuild = Ed25519PrivateKeyParameters(privateKeyBytes, 0)
+            val publicKeyRebuild = privateKeyRebuild.generatePublicKey()
+            publicKeyRebuild.encoded.toBase64EncodedString()
+        } catch (e: Exception) {
+            throw StytchMissingPublicKeyError(e)
+        }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/EncryptionManager.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/EncryptionManager.kt
@@ -15,15 +15,15 @@ import com.stytch.sdk.common.extensions.hexStringToByteArray
 import com.stytch.sdk.common.extensions.toBase64DecodedByteArray
 import com.stytch.sdk.common.extensions.toBase64EncodedString
 import com.stytch.sdk.common.extensions.toHexString
+import java.security.InvalidKeyException
+import java.security.MessageDigest
+import java.security.SecureRandom
 import org.bouncycastle.crypto.Signer
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
-import java.security.InvalidKeyException
-import java.security.MessageDigest
-import java.security.SecureRandom
 
 @Suppress("TooManyFunctions")
 internal object EncryptionManager {


### PR DESCRIPTION
Linear Ticket: [SDK-1585](https://linear.app/stytch/issue/SDK-1585)

## Changes:

1. Use SecureRandom instead of Random to generate cryptographically secure challenges for PKCE

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A