### PR TITLE
SDK-1588 Enable CNAME domains for OAuth and SSO

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.20.5'
+  PUBLISH_VERSION = '0.21.0'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.sso
 
 import android.net.Uri
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
+import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
@@ -20,9 +21,12 @@ internal class SSOImpl(
     private val dispatchers: StytchDispatchers,
     private val sessionStorage: B2BSessionStorage,
     private val storageHelper: StorageHelper,
-    private val api: StytchB2BApi.SSO
+    private val api: StytchB2BApi.SSO,
 ) : SSO {
-    internal fun buildUri(host: String, parameters: Map<String, String?>): Uri =
+    internal fun buildUri(
+        host: String,
+        parameters: Map<String, String?>,
+    ): Uri =
         Uri.parse("${host}public/sso/start")
             .buildUpon()
             .apply {
@@ -35,14 +39,18 @@ internal class SSOImpl(
             .build()
 
     override fun start(params: SSO.StartParams) {
-        val host = if (StytchB2BApi.isTestToken) Constants.TEST_API_URL else Constants.LIVE_API_URL
-        val potentialParameters = mapOf(
-            "connection_id" to params.connectionId,
-            "public_token" to StytchB2BApi.publicToken,
-            "pkce_code_challenge" to storageHelper.generateHashedCodeChallenge().second,
-            "login_redirect_url" to params.loginRedirectUrl,
-            "signup_redirect_url" to params.signupRedirectUrl,
-        )
+        val host =
+            StytchB2BClient.bootstrapData.cnameDomain?.let {
+                "https://$it/v1/"
+            } ?: if (StytchB2BApi.isTestToken) Constants.TEST_API_URL else Constants.LIVE_API_URL
+        val potentialParameters =
+            mapOf(
+                "connection_id" to params.connectionId,
+                "public_token" to StytchB2BApi.publicToken,
+                "pkce_code_challenge" to storageHelper.generateHashedCodeChallenge().second,
+                "login_redirect_url" to params.loginRedirectUrl,
+                "signup_redirect_url" to params.signupRedirectUrl,
+            )
         val requestUri = buildUri(host, potentialParameters)
         val intent = SSOManagerActivity.createBaseIntent(params.context)
         intent.putExtra(SSOManagerActivity.URI_KEY, requestUri.toString())
@@ -59,18 +67,22 @@ internal class SSOImpl(
                 result = StytchResult.Error(StytchMissingPKCEError(ex))
                 return@withContext
             }
-            result = api.authenticate(
-                ssoToken = params.ssoToken,
-                sessionDurationMinutes = params.sessionDurationMinutes,
-                codeVerifier = codeVerifier
-            ).apply {
-                launchSessionUpdater(dispatchers, sessionStorage)
-            }
+            result =
+                api.authenticate(
+                    ssoToken = params.ssoToken,
+                    sessionDurationMinutes = params.sessionDurationMinutes,
+                    codeVerifier = codeVerifier,
+                ).apply {
+                    launchSessionUpdater(dispatchers, sessionStorage)
+                }
         }
         return result
     }
 
-    override fun authenticate(params: SSO.AuthenticateParams, callback: (SSOAuthenticateResponse) -> Unit) {
+    override fun authenticate(
+        params: SSO.AuthenticateParams,
+        callback: (SSOAuthenticateResponse) -> Unit,
+    ) {
         externalScope.launch(dispatchers.ui) {
             val result = authenticate(params)
             callback(result)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
@@ -5,13 +5,19 @@ import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.sso.SSOManagerActivity.Companion.URI_KEY
+import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.StytchApi
 
 internal class ThirdPartyOAuthImpl(
     private val storageHelper: StorageHelper,
     override val providerName: String,
 ) : OAuth.ThirdParty {
-    internal fun buildUri(host: String, parameters: Map<String, String?>, pkce: String, token: String): Uri =
+    internal fun buildUri(
+        host: String,
+        parameters: Map<String, String?>,
+        pkce: String,
+        token: String,
+    ): Uri =
         Uri.parse("${host}public/oauth/$providerName/start")
             .buildUpon()
             .apply {
@@ -28,12 +34,16 @@ internal class ThirdPartyOAuthImpl(
     override fun start(parameters: OAuth.ThirdParty.StartParameters) {
         val pkce = storageHelper.generateHashedCodeChallenge().second
         val token = StytchApi.publicToken
-        val host = if (StytchApi.isTestToken) Constants.TEST_API_URL else Constants.LIVE_API_URL
-        val potentialParameters = mapOf(
-            "login_redirect_url" to parameters.loginRedirectUrl,
-            "signup_redirect_url" to parameters.signupRedirectUrl,
-            "custom_scopes" to parameters.customScopes?.joinToString(" ")
-        )
+        val host =
+            StytchClient.bootstrapData.cnameDomain?.let {
+                "https://$it/v1/"
+            } ?: if (StytchApi.isTestToken) Constants.TEST_API_URL else Constants.LIVE_API_URL
+        val potentialParameters =
+            mapOf(
+                "login_redirect_url" to parameters.loginRedirectUrl,
+                "signup_redirect_url" to parameters.signupRedirectUrl,
+                "custom_scopes" to parameters.customScopes?.joinToString(" "),
+            )
         val requestUri = buildUri(host, potentialParameters, pkce, token)
         val intent = SSOManagerActivity.createBaseIntent(parameters.context)
         intent.putExtra(URI_KEY, requestUri.toString())


### PR DESCRIPTION
Linear Ticket: [SDK-1588](https://linear.app/stytch/issue/SDK-1588)

## Changes:

1. Use cname if available for oauth and sso

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A