### PR TITLE
SDK-1463 Add SSO Methods

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/SSOScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/SSOScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
@@ -22,19 +23,17 @@ import com.stytch.exampleapp.b2b.R
 import com.stytch.exampleapp.b2b.SSOViewModel
 
 @Composable
-fun SSOScreen(
-    viewModel: SSOViewModel,
-) {
+fun SSOScreen(viewModel: SSOViewModel) {
     val responseState = viewModel.currentResponse.collectAsState()
     val loading = viewModel.loadingState.collectAsState()
     val context = LocalContext.current as FragmentActivity
     Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             TextField(
                 modifier = Modifier.fillMaxWidth(),
@@ -46,22 +45,88 @@ fun SSOScreen(
                 onValueChange = {
                     viewModel.ssoConnectionId = it
                 },
-                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize)
+                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
+            )
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = viewModel.metadataUrl,
+                singleLine = true,
+                label = {
+                    Text(text = stringResource(id = R.string.sso_metadata_url))
+                },
+                onValueChange = {
+                    viewModel.metadataUrl = it
+                },
+                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
+            )
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = viewModel.certificateId,
+                singleLine = true,
+                label = {
+                    Text(text = stringResource(id = R.string.sso_certificate_id))
+                },
+                onValueChange = {
+                    viewModel.certificateId = it
+                },
+                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
             )
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.sso_start),
-                onClick = { viewModel.startSSO(context) }
+                onClick = { viewModel.startSSO(context) },
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_get_connections),
+                onClick = viewModel::getConnections,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_delete_connection),
+                onClick = viewModel::deleteConnection,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_saml_create),
+                onClick = viewModel::createSamlConnection,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_saml_update),
+                onClick = viewModel::updateSamlConnection,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_saml_update_url),
+                onClick = viewModel::updateSamlConnectionByUrl,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_saml_delete_certificate),
+                onClick = viewModel::deleteVerificationCertificate,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_oidc_create),
+                onClick = viewModel::createOidcConnection,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_oidc_update),
+                onClick = viewModel::updateOidcConnection,
             )
         }
         Column(
             modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(0.5F, false),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (loading.value) {
                 CircularProgressIndicator()
             } else {
-                Text(text = responseState.value, modifier = Modifier.padding(8.dp))
+                SelectionContainer {
+                    Text(text = responseState.value, modifier = Modifier.padding(8.dp))
+                }
             }
         }
     }

--- a/b2bExampleApp/src/main/res/values/strings.xml
+++ b/b2bExampleApp/src/main/res/values/strings.xml
@@ -27,6 +27,16 @@
     <string name="sso">SSO</string>
     <string name="sso_connection_id">Connection ID</string>
     <string name="sso_start">Start SSO Flow</string>
+    <string name="sso_metadata_url">Metadata URL</string>
+    <string name="sso_certificate_id">Certificate ID</string>
+    <string name="sso_get_connections">Get Connections</string>
+    <string name="sso_delete_connection">Delete Connection</string>
+    <string name="sso_saml_create">Create SAML Connection</string>
+    <string name="sso_saml_update">Update SAML Connection</string>
+    <string name="sso_saml_update_url">Update SAML URL</string>
+    <string name="sso_saml_delete_certificate">SAML Delete Certificate</string>
+    <string name="sso_oidc_create">Create OIDC Connection</string>
+    <string name="sso_oidc_update">Update OIDC Connection</string>
     <string name="member">Member</string>
     <string name="member_name">Member Name</string>
     <string name="update_name">Update Member Name</string>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b
 
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
@@ -136,3 +137,5 @@ public typealias OAuthDiscoveryAuthenticateResponse = StytchResult<DiscoveryAuth
 public typealias B2BSSOGetConnectionsResponse = StytchResult<B2BSSOGetConnectionsResponseData>
 
 public typealias B2BSSODeleteConnectionResponse = StytchResult<B2BSSODeleteConnectionResponseData>
+
+public typealias B2BSSOSAMLCreateConnectionResponse = StytchResult<B2BSSOSAMLCreateConnectionResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLDeleteVerificationCertificateResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionByURLResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
@@ -147,6 +148,9 @@ public typealias B2BSSOSAMLCreateConnectionResponse = StytchResult<B2BSSOSAMLCre
 public typealias B2BSSOSAMLUpdateConnectionResponse = StytchResult<B2BSSOSAMLUpdateConnectionResponseData>
 
 public typealias B2BSSOSAMLUpdateConnectionByURLResponse = StytchResult<B2BSSOSAMLUpdateConnectionByURLResponseData>
+
+public typealias B2BSSOSAMLDeleteVerificationCertificateResponse =
+    StytchResult<B2BSSOSAMLDeleteVerificationCertificateResponseData>
 
 public typealias B2BSSOOIDCCreateConnectionResponse = StytchResult<B2BSSOOIDCCreateConnectionResponseData>
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b
 
+import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
@@ -133,3 +134,5 @@ public typealias OAuthAuthenticateResponse = StytchResult<OAuthAuthenticateRespo
 public typealias OAuthDiscoveryAuthenticateResponse = StytchResult<DiscoveryAuthenticateResponseData>
 
 public typealias B2BSSOGetConnectionsResponse = StytchResult<B2BSSOGetConnectionsResponseData>
+
+public typealias B2BSSODeleteConnectionResponse = StytchResult<B2BSSODeleteConnectionResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
@@ -140,5 +141,7 @@ public typealias B2BSSOGetConnectionsResponse = StytchResult<B2BSSOGetConnection
 public typealias B2BSSODeleteConnectionResponse = StytchResult<B2BSSODeleteConnectionResponseData>
 
 public typealias B2BSSOSAMLCreateConnectionResponse = StytchResult<B2BSSOSAMLCreateConnectionResponseData>
+
+public typealias B2BSSOSAMLUpdateConnectionResponse = StytchResult<B2BSSOSAMLUpdateConnectionResponseData>
 
 public typealias B2BSSOOIDCCreateConnectionResponse = StytchResult<B2BSSOOIDCCreateConnectionResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b
 
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
@@ -139,3 +140,5 @@ public typealias B2BSSOGetConnectionsResponse = StytchResult<B2BSSOGetConnection
 public typealias B2BSSODeleteConnectionResponse = StytchResult<B2BSSODeleteConnectionResponseData>
 
 public typealias B2BSSOSAMLCreateConnectionResponse = StytchResult<B2BSSOSAMLCreateConnectionResponseData>
+
+public typealias B2BSSOOIDCCreateConnectionResponse = StytchResult<B2BSSOOIDCCreateConnectionResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionByURLResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
@@ -144,6 +145,8 @@ public typealias B2BSSODeleteConnectionResponse = StytchResult<B2BSSODeleteConne
 public typealias B2BSSOSAMLCreateConnectionResponse = StytchResult<B2BSSOSAMLCreateConnectionResponseData>
 
 public typealias B2BSSOSAMLUpdateConnectionResponse = StytchResult<B2BSSOSAMLUpdateConnectionResponseData>
+
+public typealias B2BSSOSAMLUpdateConnectionByURLResponse = StytchResult<B2BSSOSAMLUpdateConnectionByURLResponseData>
 
 public typealias B2BSSOOIDCCreateConnectionResponse = StytchResult<B2BSSOOIDCCreateConnectionResponseData>
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
@@ -145,3 +146,5 @@ public typealias B2BSSOSAMLCreateConnectionResponse = StytchResult<B2BSSOSAMLCre
 public typealias B2BSSOSAMLUpdateConnectionResponse = StytchResult<B2BSSOSAMLUpdateConnectionResponseData>
 
 public typealias B2BSSOOIDCCreateConnectionResponse = StytchResult<B2BSSOOIDCCreateConnectionResponseData>
+
+public typealias B2BSSOOIDCUpdateConnectionResponse = StytchResult<B2BSSOOIDCUpdateConnectionResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b
 
+import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
@@ -130,3 +131,5 @@ public typealias RecoveryCodesRecoverResponse = StytchResult<RecoveryCodeRecover
 public typealias OAuthAuthenticateResponse = StytchResult<OAuthAuthenticateResponseData>
 
 public typealias OAuthDiscoveryAuthenticateResponse = StytchResult<DiscoveryAuthenticateResponseData>
+
+public typealias B2BSSOGetConnectionsResponse = StytchResult<B2BSSOGetConnectionsResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -12,6 +12,7 @@ import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionByURLResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
@@ -690,6 +691,21 @@ internal object StytchB2BApi {
                             x509Certificate = x509Certificate,
                             samlConnectionImplicitRoleAssignment = samlConnectionImplicitRoleAssignment,
                             samlGroupImplicitRoleAssignment = samlGroupImplicitRoleAssignment,
+                        ),
+                )
+            }
+
+        suspend fun samlUpdateByUrl(
+            connectionId: String,
+            metadataUrl: String,
+        ): StytchResult<B2BSSOSAMLUpdateConnectionByURLResponseData> =
+            safeB2BApiCall {
+                apiService.ssoSamlUpdateByUrl(
+                    connectionId = connectionId,
+                    request =
+                        B2BRequests.SSO.B2BSSOSAMLUpdateConnectionByURLRequest(
+                            connectionId = connectionId,
+                            metadataUrl = metadataUrl,
                         ),
                 )
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
+import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
@@ -642,6 +643,11 @@ internal object StytchB2BApi {
         suspend fun getConnections(): StytchResult<B2BSSOGetConnectionsResponseData> =
             safeB2BApiCall {
                 apiService.ssoGetConnections()
+            }
+
+        suspend fun deleteConnection(connectionId: String): StytchResult<B2BSSODeleteConnectionResponseData> =
+            safeB2BApiCall {
+                apiService.ssoDeleteConnection(connectionId = connectionId)
             }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -12,6 +12,7 @@ import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLDeleteVerificationCertificateResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionByURLResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
@@ -707,6 +708,17 @@ internal object StytchB2BApi {
                             connectionId = connectionId,
                             metadataUrl = metadataUrl,
                         ),
+                )
+            }
+
+        suspend fun samlDeleteVerificationCertificate(
+            connectionId: String,
+            certificateId: String,
+        ): StytchResult<B2BSSOSAMLDeleteVerificationCertificateResponseData> =
+            safeB2BApiCall {
+                apiService.ssoSamlDeleteVerificationCertificate(
+                    connectionId = connectionId,
+                    certificateId = certificateId,
                 )
             }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailInvites
@@ -648,6 +649,17 @@ internal object StytchB2BApi {
         suspend fun deleteConnection(connectionId: String): StytchResult<B2BSSODeleteConnectionResponseData> =
             safeB2BApiCall {
                 apiService.ssoDeleteConnection(connectionId = connectionId)
+            }
+
+        suspend fun samlCreateConnection(
+            displayName: String? = null,
+        ): StytchResult<B2BSSOSAMLCreateConnectionResponseData> =
+            safeB2BApiCall {
+                apiService.ssoSamlCreate(
+                    B2BRequests.SSO.SAMLCreateRequest(
+                        displayName = displayName,
+                    ),
+                )
             }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
@@ -657,6 +658,17 @@ internal object StytchB2BApi {
             safeB2BApiCall {
                 apiService.ssoSamlCreate(
                     B2BRequests.SSO.SAMLCreateRequest(
+                        displayName = displayName,
+                    ),
+                )
+            }
+
+        suspend fun oidcCreateConnection(
+            displayName: String? = null,
+        ): StytchResult<B2BSSOOIDCCreateConnectionResponseData> =
+            safeB2BApiCall {
+                apiService.ssoOidcCreate(
+                    B2BRequests.SSO.OIDCCreateRequest(
                         displayName = displayName,
                     ),
                 )

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
+import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailInvites
@@ -636,6 +637,11 @@ internal object StytchB2BApi {
                         codeVerifier = codeVerifier,
                     ),
                 )
+            }
+
+        suspend fun getConnections(): StytchResult<B2BSSOGetConnectionsResponseData> =
+            safeB2BApiCall {
+                apiService.ssoGetConnections()
             }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -11,11 +11,14 @@ import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailInvites
 import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
+import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberDeleteAuthenticationFactorData
@@ -659,6 +662,32 @@ internal object StytchB2BApi {
                 apiService.ssoSamlCreate(
                     B2BRequests.SSO.SAMLCreateRequest(
                         displayName = displayName,
+                    ),
+                )
+            }
+
+        suspend fun samlUpdateConnection(
+            connectionId: String,
+            idpEntityId: String? = null,
+            displayName: String? = null,
+            attributeMapping: Map<String, String>? = null,
+            idpSsoUrl: String? = null,
+            x509Certificate: String? = null,
+            samlConnectionImplicitRoleAssignment: List<ConnectionRoleAssignment>? = null,
+            samlGroupImplicitRoleAssignment: List<GroupRoleAssignment>? = null,
+        ): StytchResult<B2BSSOSAMLUpdateConnectionResponseData> =
+            safeB2BApiCall {
+                apiService.ssoSamlUpdate(
+                    connectionId = connectionId,
+                    B2BRequests.SSO.SAMLUpdateRequest(
+                        connectionId = connectionId,
+                        idpEntityId = idpEntityId,
+                        displayName = displayName,
+                        attributeMapping = attributeMapping,
+                        idpSsoUrl = idpSsoUrl,
+                        x509Certificate = x509Certificate,
+                        samlConnectionImplicitRoleAssignment = samlConnectionImplicitRoleAssignment,
+                        samlGroupImplicitRoleAssignment = samlGroupImplicitRoleAssignment,
                     ),
                 )
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -10,6 +10,7 @@ import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
@@ -679,16 +680,17 @@ internal object StytchB2BApi {
             safeB2BApiCall {
                 apiService.ssoSamlUpdate(
                     connectionId = connectionId,
-                    B2BRequests.SSO.SAMLUpdateRequest(
-                        connectionId = connectionId,
-                        idpEntityId = idpEntityId,
-                        displayName = displayName,
-                        attributeMapping = attributeMapping,
-                        idpSsoUrl = idpSsoUrl,
-                        x509Certificate = x509Certificate,
-                        samlConnectionImplicitRoleAssignment = samlConnectionImplicitRoleAssignment,
-                        samlGroupImplicitRoleAssignment = samlGroupImplicitRoleAssignment,
-                    ),
+                    request =
+                        B2BRequests.SSO.SAMLUpdateRequest(
+                            connectionId = connectionId,
+                            idpEntityId = idpEntityId,
+                            displayName = displayName,
+                            attributeMapping = attributeMapping,
+                            idpSsoUrl = idpSsoUrl,
+                            x509Certificate = x509Certificate,
+                            samlConnectionImplicitRoleAssignment = samlConnectionImplicitRoleAssignment,
+                            samlGroupImplicitRoleAssignment = samlGroupImplicitRoleAssignment,
+                        ),
                 )
             }
 
@@ -700,6 +702,35 @@ internal object StytchB2BApi {
                     B2BRequests.SSO.OIDCCreateRequest(
                         displayName = displayName,
                     ),
+                )
+            }
+
+        suspend fun oidcUpdateConnection(
+            connectionId: String,
+            displayName: String? = null,
+            issuer: String? = null,
+            clientId: String? = null,
+            clientSecret: String? = null,
+            authorizationUrl: String? = null,
+            tokenUrl: String? = null,
+            userInfoUrl: String? = null,
+            jwksUrl: String? = null,
+        ): StytchResult<B2BSSOOIDCUpdateConnectionResponseData> =
+            safeB2BApiCall {
+                apiService.ssoOidcUpdate(
+                    connectionId = connectionId,
+                    request =
+                        B2BRequests.SSO.OIDCUpdateRequest(
+                            connectionId = connectionId,
+                            displayName = displayName,
+                            issuer = issuer,
+                            clientId = clientId,
+                            clientSecret = clientSecret,
+                            authorizationUrl = authorizationUrl,
+                            tokenUrl = tokenUrl,
+                            userInfoUrl = userInfoUrl,
+                            jwksUrl = jwksUrl,
+                        ),
                 )
             }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -187,6 +187,11 @@ internal interface StytchB2BApiService : ApiService {
 
     @GET("b2b/sso")
     suspend fun ssoGetConnections(): B2BResponses.SSO.B2BSSOGetConnectionsResponse
+
+    @DELETE("b2b/sso/{connectionId}")
+    suspend fun ssoDeleteConnection(
+        @Path(value = "connectionId") connectionId: String,
+    ): B2BResponses.SSO.B2BSSODeleteConnectionResponse
     //endregion SSO
 
     //region Bootstrap

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -204,6 +204,12 @@ internal interface StytchB2BApiService : ApiService {
         @Body request: B2BRequests.SSO.SAMLUpdateRequest,
     ): B2BResponses.SSO.B2BSSOSAMLUpdateConnectionResponse
 
+    @PUT("b2b/sso/saml/{connectionId}/url")
+    suspend fun ssoSamlUpdateByUrl(
+        @Path(value = "connectionId") connectionId: String,
+        @Body request: B2BRequests.SSO.B2BSSOSAMLUpdateConnectionByURLRequest,
+    ): B2BResponses.SSO.B2BSSOSAMLUpdateConnectionByURLResponse
+
     @POST("b2b/sso/oidc")
     suspend fun ssoOidcCreate(
         @Body request: B2BRequests.SSO.OIDCCreateRequest,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -192,6 +192,11 @@ internal interface StytchB2BApiService : ApiService {
     suspend fun ssoDeleteConnection(
         @Path(value = "connectionId") connectionId: String,
     ): B2BResponses.SSO.B2BSSODeleteConnectionResponse
+
+    @POST("b2b/sso/saml")
+    suspend fun ssoSamlCreate(
+        @Body request: B2BRequests.SSO.SAMLCreateRequest,
+    ): B2BResponses.SSO.B2BSSOSAMLCreateConnectionResponse
     //endregion SSO
 
     //region Bootstrap

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -197,6 +197,11 @@ internal interface StytchB2BApiService : ApiService {
     suspend fun ssoSamlCreate(
         @Body request: B2BRequests.SSO.SAMLCreateRequest,
     ): B2BResponses.SSO.B2BSSOSAMLCreateConnectionResponse
+
+    @POST("b2b/sso/oidc")
+    suspend fun ssoOidcCreate(
+        @Body request: B2BRequests.SSO.OIDCCreateRequest,
+    ): B2BResponses.SSO.B2BSSOOIDCCreateConnectionResponse
     //endregion SSO
 
     //region Bootstrap

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -210,6 +210,12 @@ internal interface StytchB2BApiService : ApiService {
         @Body request: B2BRequests.SSO.B2BSSOSAMLUpdateConnectionByURLRequest,
     ): B2BResponses.SSO.B2BSSOSAMLUpdateConnectionByURLResponse
 
+    @DELETE("b2b/sso/saml/{connectionId}/verification_certificates/{certificateId}")
+    suspend fun ssoSamlDeleteVerificationCertificate(
+        @Path(value = "connectionId") connectionId: String,
+        @Path(value = "certificateId") certificateId: String,
+    ): B2BResponses.SSO.B2BSSOSAMLDeleteVerificationCertificateResponse
+
     @POST("b2b/sso/oidc")
     suspend fun ssoOidcCreate(
         @Body request: B2BRequests.SSO.OIDCCreateRequest,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -198,6 +198,12 @@ internal interface StytchB2BApiService : ApiService {
         @Body request: B2BRequests.SSO.SAMLCreateRequest,
     ): B2BResponses.SSO.B2BSSOSAMLCreateConnectionResponse
 
+    @PUT("b2b/sso/saml/{connectionId}")
+    suspend fun ssoSamlUpdate(
+        @Path(value = "connectionId") connectionId: String,
+        @Body request: B2BRequests.SSO.SAMLUpdateRequest,
+    ): B2BResponses.SSO.B2BSSOSAMLUpdateConnectionResponse
+
     @POST("b2b/sso/oidc")
     suspend fun ssoOidcCreate(
         @Body request: B2BRequests.SSO.OIDCCreateRequest,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -184,6 +184,9 @@ internal interface StytchB2BApiService : ApiService {
     suspend fun ssoAuthenticate(
         @Body request: B2BRequests.SSO.AuthenticateRequest,
     ): B2BResponses.SSO.AuthenticateResponse
+
+    @GET("b2b/sso")
+    suspend fun ssoGetConnections(): B2BResponses.SSO.B2BSSOGetConnectionsResponse
     //endregion SSO
 
     //region Bootstrap

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -208,6 +208,12 @@ internal interface StytchB2BApiService : ApiService {
     suspend fun ssoOidcCreate(
         @Body request: B2BRequests.SSO.OIDCCreateRequest,
     ): B2BResponses.SSO.B2BSSOOIDCCreateConnectionResponse
+
+    @PUT("b2b/sso/oidc/{connectionId}")
+    suspend fun ssoOidcUpdate(
+        @Path(value = "connectionId") connectionId: String,
+        @Body request: B2BRequests.SSO.OIDCUpdateRequest,
+    ): B2BResponses.SSO.B2BSSOOIDCUpdateConnectionResponse
     //endregion SSO
 
     //region Bootstrap

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -234,6 +234,14 @@ internal object B2BRequests {
         )
 
         @JsonClass(generateAdapter = true)
+        data class B2BSSOSAMLDeleteVerificationCertificateRequest(
+            @Json(name = "connection_id")
+            val connectionId: String,
+            @Json(name = "certificate_id")
+            val certificateId: String,
+        )
+
+        @JsonClass(generateAdapter = true)
         data class OIDCCreateRequest(
             @Json(name = "display_name")
             val displayName: String? = null,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -226,6 +226,14 @@ internal object B2BRequests {
         )
 
         @JsonClass(generateAdapter = true)
+        data class B2BSSOSAMLUpdateConnectionByURLRequest(
+            @Json(name = "connection_id")
+            val connectionId: String,
+            @Json(name = "metadata_url")
+            val metadataUrl: String,
+        )
+
+        @JsonClass(generateAdapter = true)
         data class OIDCCreateRequest(
             @Json(name = "display_name")
             val displayName: String? = null,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -204,6 +204,12 @@ internal object B2BRequests {
             @Json(name = "display_name")
             val displayName: String? = null,
         )
+
+        @JsonClass(generateAdapter = true)
+        data class OIDCCreateRequest(
+            @Json(name = "display_name")
+            val displayName: String? = null,
+        )
     }
 
     object Session {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -206,6 +206,26 @@ internal object B2BRequests {
         )
 
         @JsonClass(generateAdapter = true)
+        data class SAMLUpdateRequest(
+            @Json(name = "connection_id")
+            val connectionId: String,
+            @Json(name = "idp_entity_id")
+            val idpEntityId: String? = null,
+            @Json(name = "display_name")
+            val displayName: String? = null,
+            @Json(name = "attribute_mapping")
+            val attributeMapping: Map<String, String>? = null,
+            @Json(name = "idp_sso_url")
+            val idpSsoUrl: String? = null,
+            @Json(name = "x509_certificate")
+            val x509Certificate: String? = null,
+            @Json(name = "saml_connection_implicit_role_assignments")
+            val samlConnectionImplicitRoleAssignment: List<ConnectionRoleAssignment>? = null,
+            @Json(name = "saml_group_implicit_role_assignments")
+            val samlGroupImplicitRoleAssignment: List<GroupRoleAssignment>? = null,
+        )
+
+        @JsonClass(generateAdapter = true)
         data class OIDCCreateRequest(
             @Json(name = "display_name")
             val displayName: String? = null,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -230,6 +230,27 @@ internal object B2BRequests {
             @Json(name = "display_name")
             val displayName: String? = null,
         )
+
+        @JsonClass(generateAdapter = true)
+        data class OIDCUpdateRequest(
+            @Json(name = "connection_id")
+            val connectionId: String,
+            @Json(name = "display_name")
+            val displayName: String? = null,
+            val issuer: String? = null,
+            @Json(name = "client_id")
+            val clientId: String? = null,
+            @Json(name = "client_secret")
+            val clientSecret: String? = null,
+            @Json(name = "authorization_url")
+            val authorizationUrl: String? = null,
+            @Json(name = "token_url")
+            val tokenUrl: String? = null,
+            @Json(name = "userinfo_url")
+            val userInfoUrl: String? = null,
+            @Json(name = "jwks_url")
+            val jwksUrl: String? = null,
+        )
     }
 
     object Session {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -198,6 +198,12 @@ internal object B2BRequests {
             @Json(name = "pkce_code_verifier")
             val codeVerifier: String,
         )
+
+        @JsonClass(generateAdapter = true)
+        data class SAMLCreateRequest(
+            @Json(name = "display_name")
+            val displayName: String? = null,
+        )
     }
 
     object Session {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -703,3 +703,9 @@ public data class B2BSSODeleteConnectionResponseData(
 public data class B2BSSOSAMLCreateConnectionResponseData(
     val connection: SAMLConnection,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOOIDCCreateConnectionResponseData(
+    val connection: OIDCConnection,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -697,3 +697,9 @@ public data class B2BSSODeleteConnectionResponseData(
     @Json(name = "connection_id")
     val connectionId: String,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOSAMLCreateConnectionResponseData(
+    val connection: SAMLConnection,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -709,3 +709,9 @@ public data class B2BSSOSAMLCreateConnectionResponseData(
 public data class B2BSSOOIDCCreateConnectionResponseData(
     val connection: OIDCConnection,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOSAMLUpdateConnectionResponseData(
+    val connection: SAMLConnection,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -715,3 +715,10 @@ public data class B2BSSOOIDCCreateConnectionResponseData(
 public data class B2BSSOSAMLUpdateConnectionResponseData(
     val connection: SAMLConnection,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOOIDCUpdateConnectionResponseData(
+    val connection: OIDCConnection,
+    val warning: String? = null,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -728,3 +728,10 @@ public data class B2BSSOOIDCUpdateConnectionResponseData(
 public data class B2BSSOSAMLUpdateConnectionByURLResponseData(
     val connection: SAMLConnection,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOSAMLDeleteVerificationCertificateResponseData(
+    @Json(name = "certificate_id")
+    val certificateId: String,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -591,7 +591,7 @@ public data class OAuthProviderValues(
     @Json(name = "id_token")
     val idToken: String,
     @Json(name = "refresh_token")
-    val refreshToken: String,
+    val refreshToken: String? = null,
     val scopes: List<String> = emptyList(),
 ) : Parcelable
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -722,3 +722,9 @@ public data class B2BSSOOIDCUpdateConnectionResponseData(
     val connection: OIDCConnection,
     val warning: String? = null,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOSAMLUpdateConnectionByURLResponseData(
+    val connection: SAMLConnection,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -690,3 +690,10 @@ public data class OIDCConnection(
     @Json(name = "jwks_url")
     val jwksUrl: String,
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSODeleteConnectionResponseData(
+    @Json(name = "connection_id")
+    val connectionId: String,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -131,7 +131,7 @@ public data class OrganizationData(
     @Json(name = "organization_id")
     val organizationId: String,
     @Json(name = "organization_name")
-    val organizatioName: String,
+    val organizationName: String,
     @Json(name = "organization_slug")
     val organizationSlug: String,
     @Json(name = "organization_logo_url")
@@ -593,4 +593,100 @@ public data class OAuthProviderValues(
     @Json(name = "refresh_token")
     val refreshToken: String,
     val scopes: List<String> = emptyList(),
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSSOGetConnectionsResponseData(
+    @Json(name = "saml_connections")
+    val samlConnections: List<SAMLConnection>,
+    @Json(name = "oidc_connections")
+    val oidcConnections: List<OIDCConnection>,
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class SAMLConnection(
+    @Json(name = "organization_id")
+    val organizationId: String,
+    @Json(name = "connection_id")
+    val connectionId: String,
+    val status: String,
+    @Json(name = "attribute_mapping")
+    val attributeMapping: Map<String, String>,
+    @Json(name = "idp_entity_id")
+    val idpEntityId: String,
+    @Json(name = "display_name")
+    val displayName: String,
+    @Json(name = "idp_sso_url")
+    val idpSSOUrl: String,
+    @Json(name = "acs_url")
+    val acsUrl: String,
+    @Json(name = "audience_uri")
+    val audienceUri: String,
+    @Json(name = "signing_certificates")
+    val signingCertificate: List<X509Certificate>,
+    @Json(name = "verification_certificates")
+    val verificationCertificates: List<X509Certificate>,
+    @Json(name = "saml_connection_implicit_role_assignments")
+    val samlConnectionImplicitRoleAssignments: List<ConnectionRoleAssignment>,
+    @Json(name = "saml_group_implicit_role_assignments")
+    val samlGroupImplicitRoleAssignments: List<GroupRoleAssignment>,
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class X509Certificate(
+    @Json(name = "certificate_id")
+    val certificateId: String,
+    @Json(name = "certificate")
+    val certificate: String,
+    @Json(name = "issuer")
+    val issuer: String,
+    @Json(name = "created_at")
+    val createdAt: String? = null,
+    @Json(name = "expires_at")
+    val expiresAt: String? = null,
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class ConnectionRoleAssignment(
+    @Json(name = "role_id")
+    val roleId: String,
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class GroupRoleAssignment(
+    @Json(name = "role_id")
+    val roleId: String,
+    val group: String,
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class OIDCConnection(
+    @Json(name = "organization_id")
+    val organizationId: String,
+    @Json(name = "connection_id")
+    val connectionId: String,
+    val status: String,
+    @Json(name = "display_name")
+    val displayName: String,
+    @Json(name = "redirect_url")
+    val redirectUrl: String,
+    val issuer: String,
+    @Json(name = "client_id")
+    val clientId: String,
+    @Json(name = "client_secret")
+    val clientSecret: String,
+    @Json(name = "authorization_url")
+    val authorizationUrl: String,
+    @Json(name = "token_url")
+    val tokenUrl: String,
+    @Json(name = "userinfo_url")
+    val userInfoUrl: String,
+    @Json(name = "jwks_url")
+    val jwksUrl: String,
 ) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -167,6 +167,11 @@ internal object B2BResponses {
         class B2BSSOOIDCUpdateConnectionResponse(
             data: B2BSSOOIDCUpdateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOOIDCUpdateConnectionResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOSAMLUpdateConnectionByURLResponse(
+            data: B2BSSOSAMLUpdateConnectionByURLResponseData,
+        ) : StytchDataResponse<B2BSSOSAMLUpdateConnectionByURLResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -142,6 +142,11 @@ internal object B2BResponses {
         class B2BSSOGetConnectionsResponse(
             data: B2BSSOGetConnectionsResponseData,
         ) : StytchDataResponse<B2BSSOGetConnectionsResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSODeleteConnectionResponse(
+            data: B2BSSODeleteConnectionResponseData,
+        ) : StytchDataResponse<B2BSSODeleteConnectionResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -137,6 +137,11 @@ internal object B2BResponses {
         class AuthenticateResponse(
             data: SSOAuthenticateResponseData,
         ) : StytchDataResponse<SSOAuthenticateResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOGetConnectionsResponse(
+            data: B2BSSOGetConnectionsResponseData,
+        ) : StytchDataResponse<B2BSSOGetConnectionsResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -157,6 +157,11 @@ internal object B2BResponses {
         class B2BSSOOIDCCreateConnectionResponse(
             data: B2BSSOOIDCCreateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOOIDCCreateConnectionResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOSAMLUpdateConnectionResponse(
+            data: B2BSSOSAMLUpdateConnectionResponseData,
+        ) : StytchDataResponse<B2BSSOSAMLUpdateConnectionResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -152,6 +152,11 @@ internal object B2BResponses {
         class B2BSSOSAMLCreateConnectionResponse(
             data: B2BSSOSAMLCreateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOSAMLCreateConnectionResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOOIDCCreateConnectionResponse(
+            data: B2BSSOOIDCCreateConnectionResponseData,
+        ) : StytchDataResponse<B2BSSOOIDCCreateConnectionResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -172,6 +172,11 @@ internal object B2BResponses {
         class B2BSSOSAMLUpdateConnectionByURLResponse(
             data: B2BSSOSAMLUpdateConnectionByURLResponseData,
         ) : StytchDataResponse<B2BSSOSAMLUpdateConnectionByURLResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOSAMLDeleteVerificationCertificateResponse(
+            data: B2BSSOSAMLDeleteVerificationCertificateResponseData,
+        ) : StytchDataResponse<B2BSSOSAMLDeleteVerificationCertificateResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -162,6 +162,11 @@ internal object B2BResponses {
         class B2BSSOSAMLUpdateConnectionResponse(
             data: B2BSSOSAMLUpdateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOSAMLUpdateConnectionResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOOIDCUpdateConnectionResponse(
+            data: B2BSSOOIDCUpdateConnectionResponseData,
+        ) : StytchDataResponse<B2BSSOOIDCUpdateConnectionResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -147,6 +147,11 @@ internal object B2BResponses {
         class B2BSSODeleteConnectionResponse(
             data: B2BSSODeleteConnectionResponseData,
         ) : StytchDataResponse<B2BSSODeleteConnectionResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2BSSOSAMLCreateConnectionResponse(
+            data: B2BSSOSAMLCreateConnectionResponseData,
+        ) : StytchDataResponse<B2BSSOSAMLCreateConnectionResponseData>(data)
     }
 
     object OTP {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -30,7 +30,7 @@ internal class OAuthImpl(
     override val discovery: OAuth.Discovery = DiscoveryImpl()
 
     override suspend fun authenticate(parameters: OAuth.AuthenticateParameters): OAuthAuthenticateResponse =
-        withContext(dispatchers.ui) {
+        withContext(dispatchers.io) {
             val pkce =
                 storageHelper.retrieveCodeVerifier()
                     ?: run {
@@ -113,7 +113,7 @@ internal class OAuthImpl(
         override suspend fun authenticate(
             parameters: OAuth.Discovery.DiscoveryAuthenticateParameters,
         ): OAuthDiscoveryAuthenticateResponse =
-            withContext(dispatchers.ui) {
+            withContext(dispatchers.io) {
                 val pkce =
                     storageHelper.retrieveCodeVerifier()
                         ?: run {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
@@ -210,7 +210,7 @@ internal class OrganizationImpl(
         override suspend fun search(
             parameters: Organization.OrganizationMembers.SearchParameters,
         ): MemberSearchResponse =
-            withContext(dispatchers.ui) {
+            withContext(dispatchers.io) {
                 api.search(
                     cursor = parameters.cursor,
                     limit = parameters.limit,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -5,7 +5,10 @@ import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
+import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
+import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
 import com.stytch.sdk.common.Constants
 
 /**
@@ -138,6 +141,53 @@ public interface SSO {
         public fun createConnection(
             parameters: CreateParameters,
             callback: (B2BSSOSAMLCreateConnectionResponse) -> Unit,
+        )
+
+        /**
+         * Data class used for wrapping the parameters for a SAML update request
+         * @property connectionId Globally unique UUID that identifies a specific SAML Connection.
+         * @property idpEntityId A globally unique name for the IdP. This will be provided by the IdP.
+         * @property displayName A human-readable display name for the connection.
+         * @property attributeMapping An object that represents the attributes used to identify a Member. This object
+         * will map the IdP-defined User attributes to Stytch-specific values. Required attributes: `email` and one of
+         * `full_name` or `first_name` and `last_name`
+         * @property idpSsoUrl The URL for which assertions for login requests will be sent. This will be provided by
+         * the IdP.
+         * @property x509Certificate A certificate that Stytch will use to verify the sign-in assertion sent by the IdP,
+         * in {@link https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail PEM} format.
+         * @property samlConnectionImplicitRoleAssignment An array of implicit role assignments granted to members in
+         * this organization who log in with this SAML connection.
+         * @property samlGroupImplicitRoleAssignment An array of implicit role assignments granted to members in this
+         * organization who log in with this SAML connection and belong to the specified group. Before adding any group
+         * implicit role assignments, you must add a "groups" key to your SAML connection's attribute_mapping. Make sure
+         * that your IdP is configured to correctly send the group information.
+         */
+        public data class UpdateParameters(
+            val connectionId: String,
+            val idpEntityId: String? = null,
+            val displayName: String? = null,
+            val attributeMapping: Map<String, String>? = null,
+            val idpSsoUrl: String? = null,
+            val x509Certificate: String? = null,
+            val samlConnectionImplicitRoleAssignment: List<ConnectionRoleAssignment>? = null,
+            val samlGroupImplicitRoleAssignment: List<GroupRoleAssignment>? = null,
+        )
+
+        /**
+         * Update a SAML Connection.
+         * @param parameters The parameters required to update SAML connection
+         * @return [B2BSSOSAMLUpdateConnectionResponse]
+         */
+        public suspend fun updateConnection(parameters: UpdateParameters): B2BSSOSAMLUpdateConnectionResponse
+
+        /**
+         * Update a SAML Connection.
+         * @param parameters The parameters required to update SAML connection
+         * @param callback a callback that receives a [B2BSSOSAMLUpdateConnectionResponse]
+         */
+        public fun updateConnection(
+            parameters: UpdateParameters,
+            callback: (B2BSSOSAMLUpdateConnectionResponse) -> Unit,
         )
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import android.app.Activity
+import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.common.Constants
@@ -89,4 +90,21 @@ public interface SSO {
      *  @param callback a callback that receives a [B2BSSOGetConnectionsResponse]
      */
     public fun getConnections(callback: (B2BSSOGetConnectionsResponse) -> Unit)
+
+    /**
+     * Delete an existing SSO connection.
+     * @param connectionId The ID of the connection to delete
+     * @return [B2BSSODeleteConnectionResponse]
+     */
+    public suspend fun deleteConnection(connectionId: String): B2BSSODeleteConnectionResponse
+
+    /**
+     * Delete an existing SSO connection.
+     * @param connectionId The ID of the connection to delete
+     * @param callback a callback that receives a [B2BSSODeleteConnectionResponse]
+     */
+    public fun deleteConnection(
+        connectionId: String,
+        callback: (B2BSSODeleteConnectionResponse) -> Unit,
+    )
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLDeleteVerificationCertificateResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionByURLResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
@@ -219,6 +220,39 @@ public interface SSO {
         public fun updateConnectionByUrl(
             parameters: UpdateByURLParameters,
             callback: (B2BSSOSAMLUpdateConnectionByURLResponse) -> Unit,
+        )
+
+        /**
+         * Data class used for wrapping the parameters to delete a SAML verification certificate
+         * @property connectionId Globally unique UUID that identifies a specific SAML Connection.
+         * @property certificateId The ID of the certificate to be deleted.
+         */
+        public data class DeleteVerificationCertificateParameters(
+            val connectionId: String,
+            val certificateId: String,
+        )
+
+        /**
+         * Delete a SAML verification certificate.
+         * You may need to do this when rotating certificates from your IdP, since Stytch allows a maximum of 5
+         * certificates per connection. There must always be at least one certificate per active connection.
+         * @param parameters The parameters required to delete a SAML verification certificate.
+         * @return [B2BSSOSAMLDeleteVerificationCertificateResponse]
+         */
+        public suspend fun deleteVerificationCertificate(
+            parameters: DeleteVerificationCertificateParameters,
+        ): B2BSSOSAMLDeleteVerificationCertificateResponse
+
+        /**
+         * Delete a SAML verification certificate.
+         * You may need to do this when rotating certificates from your IdP, since Stytch allows a maximum of 5
+         * certificates per connection. There must always be at least one certificate per active connection.
+         * @param parameters The parameters required to delete a SAML verification certificate.
+         * @param callback a callback that receives a [B2BSSOSAMLDeleteVerificationCertificateResponse]
+         */
+        public fun deleteVerificationCertificate(
+            parameters: DeleteVerificationCertificateParameters,
+            callback: (B2BSSOSAMLDeleteVerificationCertificateResponse) -> Unit,
         )
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import android.app.Activity
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
+import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.common.Constants
@@ -111,9 +112,11 @@ public interface SSO {
 
     public val saml: SAML
 
+    public val oidc: OIDC
+
     public interface SAML {
         /**
-         * Data class used for wrapping the parameters for an SSO SAML creation request
+         * Data class used for wrapping the parameters for a SAML creation request
          * @property displayName A human-readable display name for the connection.
          */
         public data class CreateParameters(
@@ -135,6 +138,33 @@ public interface SSO {
         public fun createConnection(
             parameters: CreateParameters,
             callback: (B2BSSOSAMLCreateConnectionResponse) -> Unit,
+        )
+    }
+
+    public interface OIDC {
+        /**
+         * Data class used for wrapping the parameters for an OIDC creation request
+         * @property displayName A human-readable display name for the connection.
+         */
+        public data class CreateParameters(
+            val displayName: String? = null,
+        )
+
+        /**
+         * Create a new OIDC Connection.
+         * @param parameters The parameters required to create a new OIDC connection
+         * @return [B2BSSOOIDCCreateConnectionResponse]
+         */
+        public suspend fun createConnection(parameters: CreateParameters): B2BSSOOIDCCreateConnectionResponse
+
+        /**
+         * Create a new OIDC Connection.
+         * @param parameters The parameters required to create a new OIDC connection
+         * @param callback a callback that receives a [B2BSSOOIDCCreateConnectionResponse]
+         */
+        public fun createConnection(
+            parameters: CreateParameters,
+            callback: (B2BSSOOIDCCreateConnectionResponse) -> Unit,
         )
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionByURLResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
@@ -189,6 +190,35 @@ public interface SSO {
         public fun updateConnection(
             parameters: UpdateParameters,
             callback: (B2BSSOSAMLUpdateConnectionResponse) -> Unit,
+        )
+
+        /**
+         * Data class used for wrapping the parameters for a SAML update by URL request
+         * @property connectionId Globally unique UUID that identifies a specific SAML Connection.
+         * @property metadataUrl A URL that points to the IdP metadata. This will be provided by the IdP.
+         */
+        public data class UpdateByURLParameters(
+            val connectionId: String,
+            val metadataUrl: String,
+        )
+
+        /**
+         * Update a SAML Connection by URL.
+         * @param parameters The parameters required to update a SAML connection by URL
+         * @return [B2BSSOSAMLUpdateConnectionByURLResponse]
+         */
+        public suspend fun updateConnectionByUrl(
+            parameters: UpdateByURLParameters,
+        ): B2BSSOSAMLUpdateConnectionByURLResponse
+
+        /**
+         * Update a SAML Connection by URL.
+         * @param parameters The parameters required to update a SAML connection by URL
+         * @param callback a callback that receives a [B2BSSOSAMLUpdateConnectionByURLResponse]
+         */
+        public fun updateConnectionByUrl(
+            parameters: UpdateByURLParameters,
+            callback: (B2BSSOSAMLUpdateConnectionByURLResponse) -> Unit,
         )
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
@@ -215,6 +216,53 @@ public interface SSO {
         public fun createConnection(
             parameters: CreateParameters,
             callback: (B2BSSOOIDCCreateConnectionResponse) -> Unit,
+        )
+
+        /**
+         * Data class used for wrapping the parameters for an OIDC update request
+         * @property connectionId Globally unique UUID that identifies a specific OIDC Connection.
+         * @property displayName  A human-readable display name for the connection.
+         * @property issuer A case-sensitive `https://` URL that uniquely identifies the IdP. This will be provided by
+         * the IdP.
+         * @property clientId The OAuth2.0 client ID used to authenticate login attempts. This will be provided by the
+         * IdP.
+         * @property clientSecret The secret belonging to the OAuth2.0 client used to authenticate login attempts. This
+         * will be provided by the IdP.
+         * @property authorizationUrl The location of the URL that starts an OAuth login at the IdP. This will be
+         * provided by the IdP.
+         * @property tokenUrl The location of the URL that issues OAuth2.0 access tokens and OIDC ID tokens. This will
+         * be provided by the IdP.
+         * @property userInfoUrl The location of the IDP's UserInfo Endpoint. This will be provided by the IdP.
+         * @property jwksUrl The location of the IdP's JSON Web Key Set, used to verify credentials issued by the IdP.
+         * This will be provided by the IdP.
+         */
+        public data class UpdateParameters(
+            val connectionId: String,
+            val displayName: String? = null,
+            val issuer: String? = null,
+            val clientId: String? = null,
+            val clientSecret: String? = null,
+            val authorizationUrl: String? = null,
+            val tokenUrl: String? = null,
+            val userInfoUrl: String? = null,
+            val jwksUrl: String? = null,
+        )
+
+        /**
+         * Update an OIDC Connection.
+         * @param parameters The parameters required to update an OIDC connection
+         * @return [B2BSSOOIDCUpdateConnectionResponse]
+         */
+        public suspend fun updateConnection(parameters: UpdateParameters): B2BSSOOIDCUpdateConnectionResponse
+
+        /**
+         * Update an OIDC Connection.
+         * @param parameters The parameters required to update an OIDC connection
+         * @param callback a callback that receives a [B2BSSOOIDCUpdateConnectionResponse]
+         */
+        public fun updateConnection(
+            parameters: UpdateParameters,
+            callback: (B2BSSOOIDCUpdateConnectionResponse) -> Unit,
         )
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import android.app.Activity
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.common.Constants
 
@@ -107,4 +108,33 @@ public interface SSO {
         connectionId: String,
         callback: (B2BSSODeleteConnectionResponse) -> Unit,
     )
+
+    public val saml: SAML
+
+    public interface SAML {
+        /**
+         * Data class used for wrapping the parameters for an SSO SAML creation request
+         * @property displayName A human-readable display name for the connection.
+         */
+        public data class CreateParameters(
+            val displayName: String? = null,
+        )
+
+        /**
+         * Create a new SAML Connection.
+         * @param parameters The parameters required to create a new SAML connection
+         * @return [B2BSSOSAMLCreateConnectionResponse]
+         */
+        public suspend fun createConnection(parameters: CreateParameters): B2BSSOSAMLCreateConnectionResponse
+
+        /**
+         * Create a new SAML Connection.
+         * @param parameters The parameters required to create a new SAML connection
+         * @param callback a callback that receives a [B2BSSOSAMLCreateConnectionResponse]
+         */
+        public fun createConnection(
+            parameters: CreateParameters,
+            callback: (B2BSSOSAMLCreateConnectionResponse) -> Unit,
+        )
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import android.app.Activity
+import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.common.Constants
 
@@ -70,4 +71,22 @@ public interface SSO {
         params: AuthenticateParams,
         callback: (SSOAuthenticateResponse) -> Unit,
     )
+
+    /**
+     *  Get all SSO Connections owned by the organization.
+     *  This method wraps the {@link https://stytch.com/docs/b2b/api/get-sso-connections Get SSO Connections} API
+     *  endpoint.
+     *  The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+     *  @return [B2BSSOGetConnectionsResponse]
+     */
+    public suspend fun getConnections(): B2BSSOGetConnectionsResponse
+
+    /**
+     *  Get all SSO Connections owned by the organization.
+     *  This method wraps the {@link https://stytch.com/docs/b2b/api/get-sso-connections Get SSO Connections} API
+     *  endpoint.
+     *  The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+     *  @param callback a callback that receives a [B2BSSOGetConnectionsResponse]
+     */
+    public fun getConnections(callback: (B2BSSOGetConnectionsResponse) -> Unit)
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import android.net.Uri
+import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -82,6 +83,17 @@ internal class SSOImpl(
         externalScope.launch(dispatchers.ui) {
             val result = authenticate(params)
             callback(result)
+        }
+    }
+
+    override suspend fun getConnections(): B2BSSOGetConnectionsResponse =
+        withContext(dispatchers.io) {
+            api.getConnections()
+        }
+
+    override fun getConnections(callback: (B2BSSOGetConnectionsResponse) -> Unit) {
+        externalScope.launch(dispatchers.ui) {
+            callback(getConnections())
         }
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLDeleteVerificationCertificateResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionByURLResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
@@ -178,6 +179,25 @@ internal class SSOImpl(
         ) {
             externalScope.launch(dispatchers.ui) {
                 callback(updateConnectionByUrl(parameters))
+            }
+        }
+
+        override suspend fun deleteVerificationCertificate(
+            parameters: SSO.SAML.DeleteVerificationCertificateParameters,
+        ): B2BSSOSAMLDeleteVerificationCertificateResponse =
+            withContext(dispatchers.ui) {
+                api.samlDeleteVerificationCertificate(
+                    connectionId = parameters.connectionId,
+                    certificateId = parameters.certificateId,
+                )
+            }
+
+        override fun deleteVerificationCertificate(
+            parameters: SSO.SAML.DeleteVerificationCertificateParameters,
+            callback: (B2BSSOSAMLDeleteVerificationCertificateResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                callback(deleteVerificationCertificate(parameters))
             }
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -18,6 +19,7 @@ import com.stytch.sdk.common.sso.SSOManagerActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.x509Certificate
 
 internal class SSOImpl(
     private val externalScope: CoroutineScope,
@@ -132,6 +134,31 @@ internal class SSOImpl(
         ) {
             externalScope.launch(dispatchers.ui) {
                 callback(createConnection(parameters))
+            }
+        }
+
+        override suspend fun updateConnection(
+            parameters: SSO.SAML.UpdateParameters,
+        ): B2BSSOSAMLUpdateConnectionResponse =
+            withContext(dispatchers.ui) {
+                api.samlUpdateConnection(
+                    connectionId = parameters.connectionId,
+                    idpEntityId = parameters.idpEntityId,
+                    displayName = parameters.displayName,
+                    attributeMapping = parameters.attributeMapping,
+                    idpSsoUrl = parameters.idpSsoUrl,
+                    x509Certificate = parameters.x509Certificate,
+                    samlConnectionImplicitRoleAssignment = parameters.samlConnectionImplicitRoleAssignment,
+                    samlGroupImplicitRoleAssignment = parameters.samlGroupImplicitRoleAssignment,
+                )
+            }
+
+        override fun updateConnection(
+            parameters: SSO.SAML.UpdateParameters,
+            callback: (B2BSSOSAMLUpdateConnectionResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                callback(updateConnection(parameters))
             }
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -141,7 +141,7 @@ internal class SSOImpl(
         override suspend fun updateConnection(
             parameters: SSO.SAML.UpdateParameters,
         ): B2BSSOSAMLUpdateConnectionResponse =
-            withContext(dispatchers.ui) {
+            withContext(dispatchers.io) {
                 api.samlUpdateConnection(
                     connectionId = parameters.connectionId,
                     idpEntityId = parameters.idpEntityId,
@@ -185,7 +185,7 @@ internal class SSOImpl(
         override suspend fun deleteVerificationCertificate(
             parameters: SSO.SAML.DeleteVerificationCertificateParameters,
         ): B2BSSOSAMLDeleteVerificationCertificateResponse =
-            withContext(dispatchers.ui) {
+            withContext(dispatchers.io) {
                 api.samlDeleteVerificationCertificate(
                     connectionId = parameters.connectionId,
                     certificateId = parameters.certificateId,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionByURLResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -158,6 +159,25 @@ internal class SSOImpl(
         ) {
             externalScope.launch(dispatchers.ui) {
                 callback(updateConnection(parameters))
+            }
+        }
+
+        override suspend fun updateConnectionByUrl(
+            parameters: SSO.SAML.UpdateByURLParameters,
+        ): B2BSSOSAMLUpdateConnectionByURLResponse =
+            withContext(dispatchers.io) {
+                api.samlUpdateByUrl(
+                    connectionId = parameters.connectionId,
+                    metadataUrl = parameters.metadataUrl,
+                )
+            }
+
+        override fun updateConnectionByUrl(
+            parameters: SSO.SAML.UpdateByURLParameters,
+            callback: (B2BSSOSAMLUpdateConnectionByURLResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                callback(updateConnectionByUrl(parameters))
             }
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import android.net.Uri
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -109,6 +110,26 @@ internal class SSOImpl(
     ) {
         externalScope.launch(dispatchers.ui) {
             callback(deleteConnection(connectionId))
+        }
+    }
+
+    override val saml: SSO.SAML = SAMLImpl()
+
+    internal inner class SAMLImpl : SSO.SAML {
+        override suspend fun createConnection(
+            parameters: SSO.SAML.CreateParameters,
+        ): B2BSSOSAMLCreateConnectionResponse =
+            withContext(dispatchers.io) {
+                api.samlCreateConnection(displayName = parameters.displayName)
+            }
+
+        override fun createConnection(
+            parameters: SSO.SAML.CreateParameters,
+            callback: (B2BSSOSAMLCreateConnectionResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                callback(createConnection(parameters))
+            }
         }
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
@@ -118,8 +119,6 @@ internal class SSOImpl(
 
     override val saml: SSO.SAML = SAMLImpl()
 
-    override val oidc: SSO.OIDC = OIDCImpl()
-
     internal inner class SAMLImpl : SSO.SAML {
         override suspend fun createConnection(
             parameters: SSO.SAML.CreateParameters,
@@ -163,6 +162,8 @@ internal class SSOImpl(
         }
     }
 
+    override val oidc: SSO.OIDC = OIDCImpl()
+
     internal inner class OIDCImpl : SSO.OIDC {
         override suspend fun createConnection(
             parameters: SSO.OIDC.CreateParameters,
@@ -177,6 +178,32 @@ internal class SSOImpl(
         ) {
             externalScope.launch(dispatchers.ui) {
                 callback(createConnection(parameters))
+            }
+        }
+
+        override suspend fun updateConnection(
+            parameters: SSO.OIDC.UpdateParameters,
+        ): B2BSSOOIDCUpdateConnectionResponse =
+            withContext(dispatchers.io) {
+                api.oidcUpdateConnection(
+                    connectionId = parameters.connectionId,
+                    displayName = parameters.displayName,
+                    issuer = parameters.issuer,
+                    clientId = parameters.clientId,
+                    clientSecret = parameters.clientSecret,
+                    authorizationUrl = parameters.authorizationUrl,
+                    tokenUrl = parameters.tokenUrl,
+                    userInfoUrl = parameters.userInfoUrl,
+                    jwksUrl = parameters.jwksUrl,
+                )
+            }
+
+        override fun updateConnection(
+            parameters: SSO.OIDC.UpdateParameters,
+            callback: (B2BSSOOIDCUpdateConnectionResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                callback(updateConnection(parameters))
             }
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import android.net.Uri
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
+import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -115,6 +116,8 @@ internal class SSOImpl(
 
     override val saml: SSO.SAML = SAMLImpl()
 
+    override val oidc: SSO.OIDC = OIDCImpl()
+
     internal inner class SAMLImpl : SSO.SAML {
         override suspend fun createConnection(
             parameters: SSO.SAML.CreateParameters,
@@ -126,6 +129,24 @@ internal class SSOImpl(
         override fun createConnection(
             parameters: SSO.SAML.CreateParameters,
             callback: (B2BSSOSAMLCreateConnectionResponse) -> Unit,
+        ) {
+            externalScope.launch(dispatchers.ui) {
+                callback(createConnection(parameters))
+            }
+        }
+    }
+
+    internal inner class OIDCImpl : SSO.OIDC {
+        override suspend fun createConnection(
+            parameters: SSO.OIDC.CreateParameters,
+        ): B2BSSOOIDCCreateConnectionResponse =
+            withContext(dispatchers.io) {
+                api.oidcCreateConnection(displayName = parameters.displayName)
+            }
+
+        override fun createConnection(
+            parameters: SSO.OIDC.CreateParameters,
+            callback: (B2BSSOOIDCCreateConnectionResponse) -> Unit,
         ) {
             externalScope.launch(dispatchers.ui) {
                 callback(createConnection(parameters))

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import android.net.Uri
+import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -94,6 +95,20 @@ internal class SSOImpl(
     override fun getConnections(callback: (B2BSSOGetConnectionsResponse) -> Unit) {
         externalScope.launch(dispatchers.ui) {
             callback(getConnections())
+        }
+    }
+
+    override suspend fun deleteConnection(connectionId: String): B2BSSODeleteConnectionResponse =
+        withContext(dispatchers.io) {
+            api.deleteConnection(connectionId = connectionId)
+        }
+
+    override fun deleteConnection(
+        connectionId: String,
+        callback: (B2BSSODeleteConnectionResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            callback(deleteConnection(connectionId))
         }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -789,6 +789,17 @@ internal class StytchB2BApiServiceTest {
             )
         }
     }
+
+    @Test
+    fun `check SSO getConnections request`() {
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.ssoGetConnections()
+            }.verifyGet(
+                expectedPath = "/b2b/sso",
+            )
+        }
+    }
     //endregion
 
     // region Bootstrap

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -832,6 +832,26 @@ internal class StytchB2BApiServiceTest {
             )
         }
     }
+
+    @Test
+    fun `check SSO OIDC createConnection request`() {
+        runBlocking {
+            val displayName = "my cool oidc connection name"
+            requestIgnoringResponseException {
+                apiService.ssoOidcCreate(
+                    B2BRequests.SSO.OIDCCreateRequest(
+                        displayName = displayName,
+                    ),
+                )
+            }.verifyPost(
+                expectedPath = "/b2b/sso/oidc",
+                expectedBody =
+                    mapOf(
+                        "display_name" to displayName,
+                    ),
+            )
+        }
+    }
     //endregion
 
     // region Bootstrap

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -812,6 +812,26 @@ internal class StytchB2BApiServiceTest {
             )
         }
     }
+
+    @Test
+    fun `check SSO SAML createConnection request`() {
+        runBlocking {
+            val displayName = "my cool saml connection name"
+            requestIgnoringResponseException {
+                apiService.ssoSamlCreate(
+                    B2BRequests.SSO.SAMLCreateRequest(
+                        displayName = displayName,
+                    ),
+                )
+            }.verifyPost(
+                expectedPath = "/b2b/sso/saml",
+                expectedBody =
+                    mapOf(
+                        "display_name" to displayName,
+                    ),
+            )
+        }
+    }
     //endregion
 
     // region Bootstrap

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -905,6 +905,22 @@ internal class StytchB2BApiServiceTest {
     }
 
     @Test
+    fun `check SSO SAML ssoSamlDeleteVerificationCertificate request`() {
+        runBlocking {
+            val connectionId = "my-connection-id"
+            val certificateId = "my-certificate-id"
+            requestIgnoringResponseException {
+                apiService.ssoSamlDeleteVerificationCertificate(
+                    connectionId = connectionId,
+                    certificateId = certificateId,
+                )
+            }.verifyDelete(
+                expectedPath = "/b2b/sso/saml/$connectionId/verification_certificates/$certificateId",
+            )
+        }
+    }
+
+    @Test
     fun `check SSO OIDC createConnection request`() {
         runBlocking {
             val displayName = "my cool oidc connection name"

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -800,6 +800,18 @@ internal class StytchB2BApiServiceTest {
             )
         }
     }
+
+    @Test
+    fun `check SSO deleteConnection request`() {
+        runBlocking {
+            val connectionId = "my-connection-id"
+            requestIgnoringResponseException {
+                apiService.ssoDeleteConnection(connectionId = connectionId)
+            }.verifyDelete(
+                expectedPath = "/b2b/sso/$connectionId",
+            )
+        }
+    }
     //endregion
 
     // region Bootstrap

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -884,6 +884,27 @@ internal class StytchB2BApiServiceTest {
     }
 
     @Test
+    fun `check SSO Saml updateConnectionByUrl request`() {
+        runBlocking {
+            val parameters =
+                B2BRequests.SSO.B2BSSOSAMLUpdateConnectionByURLRequest(
+                    connectionId = "my-connection-id",
+                    metadataUrl = "metadata.url",
+                )
+            requestIgnoringResponseException {
+                apiService.ssoSamlUpdateByUrl(connectionId = parameters.connectionId, request = parameters)
+            }.verifyPut(
+                expectedPath = "/b2b/sso/saml/${parameters.connectionId}/url",
+                expectedBody =
+                    mapOf(
+                        "connection_id" to parameters.connectionId,
+                        "metadata_url" to parameters.metadataUrl,
+                    ),
+            )
+        }
+    }
+
+    @Test
     fun `check SSO OIDC createConnection request`() {
         runBlocking {
             val displayName = "my cool oidc connection name"

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -902,6 +902,41 @@ internal class StytchB2BApiServiceTest {
             )
         }
     }
+
+    @Test
+    fun `check SSO OIDC updateConnection request`() {
+        runBlocking {
+            val parameters =
+                B2BRequests.SSO.OIDCUpdateRequest(
+                    connectionId = "my-connection-id",
+                    displayName = "display name",
+                    issuer = "issuer",
+                    clientId = "client-id",
+                    clientSecret = "client-secret",
+                    authorizationUrl = "authorization.url",
+                    tokenUrl = "token.url",
+                    userInfoUrl = "userInfo.url",
+                    jwksUrl = "jwks.url",
+                )
+            requestIgnoringResponseException {
+                apiService.ssoOidcUpdate(parameters.connectionId, parameters)
+            }.verifyPut(
+                expectedPath = "/b2b/sso/oidc/${parameters.connectionId}",
+                expectedBody =
+                    mapOf(
+                        "connection_id" to parameters.connectionId,
+                        "display_name" to parameters.displayName,
+                        "issuer" to parameters.issuer,
+                        "client_id" to parameters.clientId,
+                        "client_secret" to parameters.clientSecret,
+                        "authorization_url" to parameters.authorizationUrl,
+                        "token_url" to parameters.tokenUrl,
+                        "userinfo_url" to parameters.userInfoUrl,
+                        "jwks_url" to parameters.jwksUrl,
+                    ),
+            )
+        }
+    }
     //endregion
 
     // region Bootstrap

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -516,6 +516,18 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO SAML updateConnection calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoSamlUpdate(any(), any()) } returns mockk(relaxed = true)
+            val connectionId = "my-connection-id"
+            StytchB2BApi.SSO.samlUpdateConnection(connectionId = connectionId)
+            coVerify {
+                StytchB2BApi.apiService.ssoSamlUpdate(connectionId = connectionId, any())
+            }
+        }
+
+    @Test
     fun `StytchB2BApi SSO OIDC createConnection calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -541,6 +541,30 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO SAML samlDeleteVerificationCertificate calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery {
+                StytchB2BApi.apiService.ssoSamlDeleteVerificationCertificate(
+                    any(),
+                    any(),
+                )
+            } returns mockk(relaxed = true)
+            val connectionId = "my-connection-id"
+            val certificateId = "mt-certificate-id"
+            StytchB2BApi.SSO.samlDeleteVerificationCertificate(
+                connectionId = connectionId,
+                certificateId = certificateId,
+            )
+            coVerify {
+                StytchB2BApi.apiService.ssoSamlDeleteVerificationCertificate(
+                    connectionId = connectionId,
+                    certificateId = certificateId,
+                )
+            }
+        }
+
+    @Test
     fun `StytchB2BApi SSO OIDC createConnection calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -483,6 +483,15 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO getConnections calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoGetConnections() } returns mockk(relaxed = true)
+            StytchB2BApi.SSO.getConnections()
+            coVerify { StytchB2BApi.apiService.ssoGetConnections() }
+        }
+
+    @Test
     fun `StytchB2BApi Bootstrap getBootstrapData calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -492,6 +492,16 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO deleteConnection calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoDeleteConnection(any()) } returns mockk(relaxed = true)
+            val connectionId = "my-connection-id"
+            StytchB2BApi.SSO.deleteConnection(connectionId = connectionId)
+            coVerify { StytchB2BApi.apiService.ssoDeleteConnection(connectionId) }
+        }
+
+    @Test
     fun `StytchB2BApi Bootstrap getBootstrapData calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -528,6 +528,19 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO SAML updateConnectionByUrl calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoSamlUpdateByUrl(any(), any()) } returns mockk(relaxed = true)
+            val connectionId = "my-connection-id"
+            val metadataUrl = "metadata.url"
+            StytchB2BApi.SSO.samlUpdateByUrl(connectionId = connectionId, metadataUrl = metadataUrl)
+            coVerify {
+                StytchB2BApi.apiService.ssoSamlUpdateByUrl(connectionId = connectionId, any())
+            }
+        }
+
+    @Test
     fun `StytchB2BApi SSO OIDC createConnection calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -516,6 +516,20 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO OIDC createConnection calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoOidcCreate(any()) } returns mockk(relaxed = true)
+            val displayName = "my cool oidc connection"
+            StytchB2BApi.SSO.oidcCreateConnection(displayName = displayName)
+            coVerify {
+                StytchB2BApi.apiService.ssoOidcCreate(
+                    B2BRequests.SSO.OIDCCreateRequest(displayName = displayName),
+                )
+            }
+        }
+
+    @Test
     fun `StytchB2BApi Bootstrap getBootstrapData calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -502,6 +502,20 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO SAML createConnection calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoSamlCreate(any()) } returns mockk(relaxed = true)
+            val displayName = "my cool saml connection"
+            StytchB2BApi.SSO.samlCreateConnection(displayName = displayName)
+            coVerify {
+                StytchB2BApi.apiService.ssoSamlCreate(
+                    B2BRequests.SSO.SAMLCreateRequest(displayName = displayName),
+                )
+            }
+        }
+
+    @Test
     fun `StytchB2BApi Bootstrap getBootstrapData calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -542,6 +542,21 @@ internal class StytchB2BApiTest {
         }
 
     @Test
+    fun `StytchB2BApi SSO OIDC updateConnection calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.ssoOidcUpdate(any(), any()) } returns mockk(relaxed = true)
+            val connectionId = "my-cool-oidc-connection"
+            StytchB2BApi.SSO.oidcUpdateConnection(connectionId = connectionId)
+            coVerify {
+                StytchB2BApi.apiService.ssoOidcUpdate(
+                    connectionId = connectionId,
+                    request = B2BRequests.SSO.OIDCUpdateRequest(connectionId = connectionId),
+                )
+            }
+        }
+
+    @Test
     fun `StytchB2BApi Bootstrap getBootstrapData calls appropriate apiService method`() =
         runTest {
             every { StytchB2BApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionByURLResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -172,6 +173,33 @@ internal class SSOImplTest {
         val parameters = SSO.SAML.UpdateParameters(connectionId = "connection-id")
         val mockCallback = spyk<(B2BSSOSAMLUpdateConnectionResponse) -> Unit>()
         impl.saml.updateConnection(parameters, mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO saml updateConnectionByUrl delegates to api`() =
+        runTest {
+            coEvery { mockApi.samlUpdateByUrl(any(), any()) } returns mockk(relaxed = true)
+            val parameters =
+                SSO.SAML.UpdateByURLParameters(
+                    connectionId = "connection-id",
+                    metadataUrl = "metadata.url",
+                )
+            impl.saml.updateConnectionByUrl(parameters)
+            coVerify {
+                mockApi.samlUpdateByUrl(
+                    connectionId = parameters.connectionId,
+                    metadataUrl = parameters.metadataUrl,
+                )
+            }
+        }
+
+    @Test
+    fun `SSO saml updateByUrl with callback calls callback method`() {
+        coEvery { mockApi.samlUpdateByUrl(any(), any()) } returns mockk(relaxed = true)
+        val parameters = SSO.SAML.UpdateByURLParameters(connectionId = "connection-id", metadataUrl = "metadata.url")
+        val mockCallback = spyk<(B2BSSOSAMLUpdateConnectionByURLResponse) -> Unit>()
+        impl.saml.updateConnectionByUrl(parameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLDeleteVerificationCertificateResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionByURLResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
@@ -200,6 +201,37 @@ internal class SSOImplTest {
         val parameters = SSO.SAML.UpdateByURLParameters(connectionId = "connection-id", metadataUrl = "metadata.url")
         val mockCallback = spyk<(B2BSSOSAMLUpdateConnectionByURLResponse) -> Unit>()
         impl.saml.updateConnectionByUrl(parameters, mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO saml deleteVerificationCertificate delegates to api`() =
+        runTest {
+            coEvery { mockApi.samlDeleteVerificationCertificate(any(), any()) } returns mockk(relaxed = true)
+            val parameters =
+                SSO.SAML.DeleteVerificationCertificateParameters(
+                    connectionId = "connection-id",
+                    certificateId = "certificate-id",
+                )
+            impl.saml.deleteVerificationCertificate(parameters)
+            coVerify {
+                mockApi.samlDeleteVerificationCertificate(
+                    connectionId = parameters.connectionId,
+                    certificateId = parameters.certificateId,
+                )
+            }
+        }
+
+    @Test
+    fun `SSO saml deleteVerificationCertificate with callback calls callback method`() {
+        coEvery { mockApi.samlDeleteVerificationCertificate(any(), any()) } returns mockk(relaxed = true)
+        val parameters =
+            SSO.SAML.DeleteVerificationCertificateParameters(
+                connectionId = "connection-id",
+                certificateId = "certificate-id",
+            )
+        val mockCallback = spyk<(B2BSSOSAMLDeleteVerificationCertificateResponse) -> Unit>()
+        impl.saml.deleteVerificationCertificate(parameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
@@ -188,6 +189,24 @@ internal class SSOImplTest {
         coEvery { mockApi.oidcCreateConnection(any()) } returns mockk(relaxed = true)
         val mockCallback = spyk<(B2BSSOOIDCCreateConnectionResponse) -> Unit>()
         impl.oidc.createConnection(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO oidc update delegates to api`() =
+        runTest {
+            coEvery { mockApi.oidcUpdateConnection(any()) } returns mockk(relaxed = true)
+            val parameters = SSO.OIDC.UpdateParameters(connectionId = "connection-id")
+            impl.oidc.updateConnection(parameters)
+            coVerify { mockApi.oidcUpdateConnection(connectionId = parameters.connectionId) }
+        }
+
+    @Test
+    fun `SSO oidc update with callback calls callback method`() {
+        coEvery { mockApi.oidcUpdateConnection(any()) } returns mockk(relaxed = true)
+        val parameters = SSO.OIDC.UpdateParameters(connectionId = "connection-id")
+        val mockCallback = spyk<(B2BSSOOIDCUpdateConnectionResponse) -> Unit>()
+        impl.oidc.updateConnection(parameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLUpdateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -152,6 +153,24 @@ internal class SSOImplTest {
         coEvery { mockApi.samlCreateConnection(any()) } returns mockk(relaxed = true)
         val mockCallback = spyk<(B2BSSOSAMLCreateConnectionResponse) -> Unit>()
         impl.saml.createConnection(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO saml update delegates to api`() =
+        runTest {
+            coEvery { mockApi.samlUpdateConnection(any()) } returns mockk(relaxed = true)
+            val parameters = SSO.SAML.UpdateParameters(connectionId = "connection-id")
+            impl.saml.updateConnection(parameters)
+            coVerify { mockApi.samlUpdateConnection(connectionId = parameters.connectionId) }
+        }
+
+    @Test
+    fun `SSO saml update with callback calls callback method`() {
+        coEvery { mockApi.samlUpdateConnection(any()) } returns mockk(relaxed = true)
+        val parameters = SSO.SAML.UpdateParameters(connectionId = "connection-id")
+        val mockCallback = spyk<(B2BSSOSAMLUpdateConnectionResponse) -> Unit>()
+        impl.saml.updateConnection(parameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.sso
 
+import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -98,6 +99,22 @@ internal class SSOImplTest {
     fun `SSO authenticate with callback calls callback method`() {
         val mockCallback = spyk<(SSOAuthenticateResponse) -> Unit>()
         impl.authenticate(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO getConnections delegates to api`() =
+        runTest {
+            coEvery { mockApi.getConnections() } returns mockk(relaxed = true)
+            impl.getConnections()
+            coVerify { mockApi.getConnections() }
+        }
+
+    @Test
+    fun `SSO getconnections with callback calls callback method`() {
+        coEvery { mockApi.getConnections() } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSSOGetConnectionsResponse) -> Unit>()
+        impl.getConnections(mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.sso
 
+import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -115,6 +116,23 @@ internal class SSOImplTest {
         coEvery { mockApi.getConnections() } returns mockk(relaxed = true)
         val mockCallback = spyk<(B2BSSOGetConnectionsResponse) -> Unit>()
         impl.getConnections(mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO deleteConnection delegates to api`() =
+        runTest {
+            coEvery { mockApi.deleteConnection(any()) } returns mockk(relaxed = true)
+            val connectionId = "my-connection-id"
+            impl.deleteConnection(connectionId)
+            coVerify { mockApi.deleteConnection(connectionId) }
+        }
+
+    @Test
+    fun `SSO deleteConnection with callback calls callback method`() {
+        coEvery { mockApi.deleteConnection(any()) } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSSODeleteConnectionResponse) -> Unit>()
+        impl.deleteConnection("", mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.sso
 
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
+import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -133,6 +134,23 @@ internal class SSOImplTest {
         coEvery { mockApi.deleteConnection(any()) } returns mockk(relaxed = true)
         val mockCallback = spyk<(B2BSSODeleteConnectionResponse) -> Unit>()
         impl.deleteConnection("", mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO saml create delegates to api`() =
+        runTest {
+            coEvery { mockApi.samlCreateConnection(any()) } returns mockk(relaxed = true)
+            val parameters = SSO.SAML.CreateParameters(displayName = "my cool display name")
+            impl.saml.createConnection(parameters)
+            coVerify { mockApi.samlCreateConnection(displayName = parameters.displayName) }
+        }
+
+    @Test
+    fun `SSO saml create with callback calls callback method`() {
+        coEvery { mockApi.samlCreateConnection(any()) } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSSOSAMLCreateConnectionResponse) -> Unit>()
+        impl.saml.createConnection(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.sso
 
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
+import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOSAMLCreateConnectionResponse
 import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -151,6 +152,23 @@ internal class SSOImplTest {
         coEvery { mockApi.samlCreateConnection(any()) } returns mockk(relaxed = true)
         val mockCallback = spyk<(B2BSSOSAMLCreateConnectionResponse) -> Unit>()
         impl.saml.createConnection(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO oidc create delegates to api`() =
+        runTest {
+            coEvery { mockApi.oidcCreateConnection(any()) } returns mockk(relaxed = true)
+            val parameters = SSO.OIDC.CreateParameters(displayName = "my cool display name")
+            impl.oidc.createConnection(parameters)
+            coVerify { mockApi.oidcCreateConnection(displayName = parameters.displayName) }
+        }
+
+    @Test
+    fun `SSO oidc create with callback calls callback method`() {
+        coEvery { mockApi.oidcCreateConnection(any()) } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSSOOIDCCreateConnectionResponse) -> Unit>()
+        impl.oidc.createConnection(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
+++ b/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.utils
 
+import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonParser
@@ -39,7 +40,9 @@ private fun compare(
             JsonArray(expectedValue.size).apply {
                 expectedValue.forEach {
                     if (it is Map<*, *>) {
-                        add(JsonParser.parseString(it.toString()))
+                        val gson = GsonBuilder().create()
+                        val json = gson.toJson(it)
+                        add(JsonParser.parseString(json))
                     } else {
                         add(it.toString())
                     }


### PR DESCRIPTION
Linear Ticket: [SDK-1463](https://linear.app/stytch/issue/SDK-1463)

## Changes:

1. Add SSO.getConnections
2. Add SSO.deleteConnection
3. Add SSO.saml.createConnection
4. Add SSO.saml.updateConnection
5. Add SSO.saml.updateConnectionByURL
6. Add SSO.saml.deleteVerificationCertificate
7. Add SSO.oidc.createConnection
8. Add SSO.oidc.updateConnection
9. Fix oauth token test, now that B2B Oauth is supported
10. Fix typo in response data (`organizatioName` -> `organizationName`)
11. Fix potentially null refreshToken in B2B OAuth response
12. Fix a few instances of incorrect dispatcher use (was processing data on UI instead of IO dispatcher)
13. Update workbench with all new methods, and verify functionality

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A