### PR TITLE
SDK-1548 add search organizations and members functionality

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/MainScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/MainScreen.kt
@@ -51,6 +51,18 @@ fun MainScreen(viewModel: HomeViewModel) {
             )
             TextField(
                 modifier = Modifier.fillMaxWidth(),
+                value = viewModel.orgSlugState,
+                singleLine = true,
+                label = {
+                    Text(text = stringResource(id = R.string.organization_slug))
+                },
+                onValueChange = {
+                    viewModel.orgSlugState = it
+                },
+                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
+            )
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
                 value = viewModel.emailState,
                 isError = viewModel.showEmailError,
                 singleLine = true,
@@ -98,6 +110,16 @@ fun MainScreen(viewModel: HomeViewModel) {
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.revoke_session),
                 onClick = { viewModel.revokeSession() },
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.organization_search),
+                onClick = viewModel::searchOrganizationBySlug,
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.organization_member_search),
+                onClick = viewModel::searchOrganizationMembers,
             )
         }
         Column(

--- a/b2bExampleApp/src/main/res/values/strings.xml
+++ b/b2bExampleApp/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="email">Email</string>
     <string name="please_enter_email">Please enter a valid email you wish to use</string>
     <string name="b2b_org_id">Organization ID</string>
+    <string name="organization_slug">Organization Slug</string>
     <string name="b2b_org_details">Get Organization Details</string>
     <string name="passwords">Passwords</string>
     <string name="existing_password">Existing Password</string>
@@ -68,4 +69,6 @@
     <string name="oauth">OAuth</string>
     <string name="oauth_start">Start Google OAuth flow</string>
     <string name="oauth_discovery_start">Start Google Discovery OAuth flow</string>
+    <string name="organization_search">Search Orgs By Slug</string>
+    <string name="organization_member_search">Search Member By Email &amp; Org Id</string>
 </resources>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -25,6 +25,8 @@ import com.stytch.sdk.b2b.rbac.RBAC
 import com.stytch.sdk.b2b.rbac.RBACImpl
 import com.stytch.sdk.b2b.recoveryCodes.RecoveryCodes
 import com.stytch.sdk.b2b.recoveryCodes.RecoveryCodesImpl
+import com.stytch.sdk.b2b.searchManager.SearchManager
+import com.stytch.sdk.b2b.searchManager.SearchManagerImpl
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.b2b.sessions.B2BSessions
 import com.stytch.sdk.b2b.sessions.B2BSessionsImpl
@@ -373,6 +375,18 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     public var rbac: RBAC = RBACImpl(externalScope, dispatchers, sessionStorage)
+        get() {
+            assertInitialized()
+            return field
+        }
+        internal set
+
+    /**
+     * Exposes an instance of the [SearchManager] interface which provides methods for search organizations and members
+     * @throws [StytchSDKNotConfiguredError] if you attempt to access this property before calling
+     * StytchB2BClient.configure()
+     */
+    public var searchManager: SearchManager = SearchManagerImpl(externalScope, dispatchers, StytchB2BApi.SearchManager)
         get() {
             assertInitialized()
             return field

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -8,6 +8,8 @@ import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLDeleteVerificationCertificateResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionByURLResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSearchMemberResponseData
+import com.stytch.sdk.b2b.network.models.B2BSearchOrganizationResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
@@ -155,3 +157,7 @@ public typealias B2BSSOSAMLDeleteVerificationCertificateResponse =
 public typealias B2BSSOOIDCCreateConnectionResponse = StytchResult<B2BSSOOIDCCreateConnectionResponseData>
 
 public typealias B2BSSOOIDCUpdateConnectionResponse = StytchResult<B2BSSOOIDCUpdateConnectionResponseData>
+
+public typealias B2BSearchOrganizationResponse = StytchResult<B2BSearchOrganizationResponseData>
+
+public typealias B2BSearchMemberResponse = StytchResult<B2BSearchMemberResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -15,6 +15,8 @@ import com.stytch.sdk.b2b.network.models.B2BSSOSAMLCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLDeleteVerificationCertificateResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionByURLResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOSAMLUpdateConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSearchMemberResponseData
+import com.stytch.sdk.b2b.network.models.B2BSearchOrganizationResponseData
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
@@ -961,6 +963,30 @@ internal object StytchB2BApi {
                     B2BRequests.OAuth.DiscoveryAuthenticateRequest(
                         discoveryOauthToken = discoveryOauthToken,
                         pkceCodeVerifier = pkceCodeVerifier,
+                    ),
+                )
+            }
+    }
+
+    internal object SearchManager {
+        suspend fun searchOrganizations(organizationSlug: String): StytchResult<B2BSearchOrganizationResponseData> =
+            safeB2BApiCall {
+                apiService.searchOrganizations(
+                    B2BRequests.SearchManager.SearchOrganization(
+                        organizationSlug = organizationSlug,
+                    ),
+                )
+            }
+
+        suspend fun searchMembers(
+            emailAddress: String,
+            organizationId: String,
+        ): StytchResult<B2BSearchMemberResponseData> =
+            safeB2BApiCall {
+                apiService.searchOrganizationMembers(
+                    B2BRequests.SearchManager.SearchMember(
+                        emailAddress = emailAddress,
+                        organizationId = organizationId,
                     ),
                 )
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -291,4 +291,16 @@ internal interface StytchB2BApiService : ApiService {
         @Body request: B2BRequests.OAuth.DiscoveryAuthenticateRequest,
     ): B2BResponses.OAuth.DiscoveryAuthenticateResponse
     //endregion OAuth
+
+    //region SearchManager
+    @POST("b2b/organizations/search")
+    suspend fun searchOrganizations(
+        @Body request: B2BRequests.SearchManager.SearchOrganization,
+    ): B2BResponses.SearchManager.SearchOrganizationResponse
+
+    @POST("b2b/organizations/members/search")
+    suspend fun searchOrganizationMembers(
+        @Body request: B2BRequests.SearchManager.SearchMember,
+    ): B2BResponses.SearchManager.SearchMemberResponse
+    //endregion SearchManager
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -523,4 +523,22 @@ internal object B2BRequests {
             val pkceCodeVerifier: String,
         )
     }
+
+    object SearchManager {
+        @Keep
+        @JsonClass(generateAdapter = true)
+        data class SearchOrganization(
+            @Json(name = "organization_slug")
+            val organizationSlug: String,
+        )
+
+        @Keep
+        @JsonClass(generateAdapter = true)
+        data class SearchMember(
+            @Json(name = "email_address")
+            val emailAddress: String,
+            @Json(name = "organization_id")
+            val organizationId: String,
+        )
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -795,12 +795,48 @@ public data class B2BSSOSAMLDeleteVerificationCertificateResponseData(
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSearchOrganizationResponseData(
-    val organization: OrganizationData,
+    val organization: InternalOrganizationData? = null,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class InternalOrganizationData(
+    @Json(name = "organization_id")
+    val organizationId: String,
+    @Json(name = "organization_name")
+    val organizationName: String,
+    @Json(name = "organization_logo_url")
+    val organizationLogoUrl: String?,
+    @Json(name = "sso_active_connections")
+    val ssoActiveConnections: List<SSOActiveConnection>?,
+    @Json(name = "sso_default_connection_id")
+    val ssoDefaultConnectionId: String?,
+    @Json(name = "email_allowed_domains")
+    val emailAllowedDomains: List<String>?,
+    @Json(name = "email_jit_provisioning")
+    val emailJitProvisioning: EmailJitProvisioning?,
+    @Json(name = "email_invites")
+    val emailInvites: EmailInvites?,
+    @Json(name = "auth_methods")
+    val authMethods: AuthMethods?,
+    @Json(name = "allowed_auth_methods")
+    val allowedAuthMethods: List<AllowedAuthMethods>?,
 ) : Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSearchMemberResponseData(
-    val member: MemberData,
+    val member: InternalMemberData? = null,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class InternalMemberData(
+    val status: String,
+    val name: String,
+    @Json(name = "member_password_id")
+    val memberPasswordId: String,
 ) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -790,3 +790,17 @@ public data class B2BSSOSAMLDeleteVerificationCertificateResponseData(
     @Json(name = "certificate_id")
     val certificateId: String,
 ) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSearchOrganizationResponseData(
+    val organization: OrganizationData,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BSearchMemberResponseData(
+    val member: MemberData,
+) : Parcelable

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -277,4 +277,18 @@ internal object B2BResponses {
             data: DiscoveryAuthenticateResponseData,
         ) : StytchDataResponse<DiscoveryAuthenticateResponseData>(data)
     }
+
+    object SearchManager {
+        @Keep
+        @JsonClass(generateAdapter = true)
+        class SearchOrganizationResponse(
+            data: B2BSearchOrganizationResponseData,
+        ) : StytchDataResponse<B2BSearchOrganizationResponseData>(data)
+
+        @Keep
+        @JsonClass(generateAdapter = true)
+        class SearchMemberResponse(
+            data: B2BSearchMemberResponseData,
+        ) : StytchDataResponse<B2BSearchMemberResponseData>(data)
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
@@ -1,0 +1,58 @@
+package com.stytch.sdk.b2b.searchManager
+
+import com.stytch.sdk.b2b.B2BSearchMemberResponse
+import com.stytch.sdk.b2b.B2BSearchOrganizationResponse
+
+public interface SearchManager {
+    /**
+     * A data class wrapping the parameters used for a Search Organizations call
+     * @property organizationSlug the slug of the organization to search for
+     */
+    public data class SearchOrganizationParameters(
+        val organizationSlug: String,
+    )
+
+    /**
+     * Search for an organization
+     * @param parameters the parameters needed to make the search request
+     * @return [B2BSearchOrganizationResponse]
+     */
+    public suspend fun searchOrganization(parameters: SearchOrganizationParameters): B2BSearchOrganizationResponse
+
+    /**
+     * Search for an organization
+     * @param parameters the parameters needed to make the search request
+     * @param callback a callback that receives a [B2BSearchOrganizationResponse]
+     */
+    public fun searchOrganization(
+        parameters: SearchOrganizationParameters,
+        callback: (B2BSearchOrganizationResponse) -> Unit,
+    )
+
+    /**
+     * A data class wrapping the parameters used for a Search Members call
+     * @property emailAddress the email address of the member to search for
+     * @property organizationId the id of the organization the member belongs to
+     */
+    public data class SearchMemberParameters(
+        val emailAddress: String,
+        val organizationId: String,
+    )
+
+    /**
+     * Search for an organization member
+     * @param parameters the parameters needed to make the search request
+     * @return [B2BSearchMemberResponse]
+     */
+    public suspend fun searchMember(parameters: SearchMemberParameters): B2BSearchMemberResponse
+
+    /**
+     * Search for an organization member
+     * @param parameters the parameters needed to make the search request
+     * @param callback a callback that receives a [B2BSearchMemberResponse]
+     */
+    public fun searchMember(
+        parameters: SearchMemberParameters,
+        callback: (B2BSearchMemberResponse) -> Unit,
+    )
+}

--- a/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManagerImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManagerImpl.kt
@@ -1,0 +1,50 @@
+package com.stytch.sdk.b2b.searchManager
+
+import com.stytch.sdk.b2b.B2BSearchMemberResponse
+import com.stytch.sdk.b2b.B2BSearchOrganizationResponse
+import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.common.StytchDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal class SearchManagerImpl(
+    private val externalScope: CoroutineScope,
+    private val dispatchers: StytchDispatchers,
+    private val api: StytchB2BApi.SearchManager,
+) : SearchManager {
+    override suspend fun searchOrganization(
+        parameters: SearchManager.SearchOrganizationParameters,
+    ): B2BSearchOrganizationResponse =
+        withContext(dispatchers.io) {
+            api.searchOrganizations(
+                organizationSlug = parameters.organizationSlug,
+            )
+        }
+
+    override fun searchOrganization(
+        parameters: SearchManager.SearchOrganizationParameters,
+        callback: (B2BSearchOrganizationResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            callback(searchOrganization(parameters))
+        }
+    }
+
+    override suspend fun searchMember(parameters: SearchManager.SearchMemberParameters): B2BSearchMemberResponse =
+        withContext(dispatchers.io) {
+            api.searchMembers(
+                emailAddress = parameters.emailAddress,
+                organizationId = parameters.organizationId,
+            )
+        }
+
+    override fun searchMember(
+        parameters: SearchManager.SearchMemberParameters,
+        callback: (B2BSearchMemberResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            callback(searchMember(parameters))
+        }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -1280,6 +1280,48 @@ internal class StytchB2BApiServiceTest {
     }
     //endregion OAuth
 
+    //region SearchManager
+    @Test
+    fun `check SearchManager searchOrganizations request`() {
+        runBlocking {
+            val params =
+                B2BRequests.SearchManager.SearchOrganization(
+                    organizationSlug = "my-organization-slug",
+                )
+            requestIgnoringResponseException {
+                apiService.searchOrganizations(params)
+            }.verifyPost(
+                expectedPath = "/b2b/organizations/search",
+                expectedBody =
+                    mapOf(
+                        "organization_slug" to params.organizationSlug,
+                    ),
+            )
+        }
+    }
+
+    @Test
+    fun `check SearchManager searchOrganizationMembers request`() {
+        runBlocking {
+            val params =
+                B2BRequests.SearchManager.SearchMember(
+                    emailAddress = "email@example.com",
+                    organizationId = "my-organization-id",
+                )
+            requestIgnoringResponseException {
+                apiService.searchOrganizationMembers(params)
+            }.verifyPost(
+                expectedPath = "/b2b/organizations/members/search",
+                expectedBody =
+                    mapOf(
+                        "email_address" to params.emailAddress,
+                        "organization_id" to params.organizationId,
+                    ),
+            )
+        }
+    }
+    //endregion SearchManager
+
     private suspend fun requestIgnoringResponseException(block: suspend () -> Unit): RecordedRequest {
         try {
             block()

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -746,6 +746,24 @@ internal class StytchB2BApiTest {
             coVerify { StytchB2BApi.apiService.oauthDiscoveryAuthenticate(any()) }
         }
 
+    @Test
+    fun `StytchB2BApi SearchManager searchOrganizations calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.searchOrganizations(any()) } returns mockk(relaxed = true)
+            StytchB2BApi.SearchManager.searchOrganizations("organization-slug")
+            coVerify { StytchB2BApi.apiService.searchOrganizations(any()) }
+        }
+
+    @Test
+    fun `StytchB2BApi SearchManager searchOrganizationMembers calls appropriate apiService method`() =
+        runTest {
+            every { StytchB2BApi.isInitialized } returns true
+            coEvery { StytchB2BApi.apiService.searchOrganizationMembers(any()) } returns mockk(relaxed = true)
+            StytchB2BApi.SearchManager.searchMembers("email@example.com", "organization-id")
+            coVerify { StytchB2BApi.apiService.searchOrganizationMembers(any()) }
+        }
+
     @Test(expected = StytchSDKNotConfiguredError::class)
     fun `safeApiCall throws exception when StytchB2BClient is not initialized`() =
         runTest {

--- a/sdk/src/test/java/com/stytch/sdk/b2b/searchManager/SearchManagerImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/searchManager/SearchManagerImplTest.kt
@@ -1,0 +1,77 @@
+package com.stytch.sdk.b2b.searchManager
+
+import com.stytch.sdk.b2b.B2BSearchMemberResponse
+import com.stytch.sdk.b2b.B2BSearchOrganizationResponse
+import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.common.StytchDispatchers
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class SearchManagerImplTest {
+    @MockK
+    private lateinit var mockApi: StytchB2BApi.SearchManager
+    private lateinit var impl: SearchManager
+    private val dispatcher = Dispatchers.Unconfined
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this, true, true)
+        impl =
+            SearchManagerImpl(
+                externalScope = TestScope(),
+                dispatchers = StytchDispatchers(dispatcher, dispatcher),
+                api = mockApi,
+            )
+    }
+
+    @After
+    fun after() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `SearchManager searchOrganizations delegates to the api`() =
+        runTest {
+            coEvery { mockApi.searchOrganizations(any()) } returns mockk(relaxed = true)
+            impl.searchOrganization(mockk(relaxed = true))
+            coVerify { mockApi.searchOrganizations(any()) }
+        }
+
+    @Test
+    fun `SearchManager searchOrganizations with callback calls callback`() {
+        coEvery { mockApi.searchOrganizations(any()) } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSearchOrganizationResponse) -> Unit>()
+        impl.searchOrganization(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SearchManager searchMembers delegates to the api`() =
+        runTest {
+            coEvery { mockApi.searchMembers(any(), any()) } returns mockk(relaxed = true)
+            impl.searchMember(mockk(relaxed = true))
+            coVerify { mockApi.searchMembers(any(), any()) }
+        }
+
+    @Test
+    fun `SearchManager searchMembers with callback calls callback`() {
+        coEvery { mockApi.searchMembers(any(), any()) } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSearchMemberResponse) -> Unit>()
+        impl.searchMember(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1548](https://linear.app/stytch/issue/SDK-1548)

## Changes:

1. Adds searchOrganization (by slug) and searchMember (by email and orgId) methods
2. Updates workbench to test them

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A