### PR TITLE
SDK-1548 Add missing B2C user methods

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -562,7 +562,7 @@ internal object StytchApi {
                 apiService.deleteWebAuthnById(id)
             }
 
-        suspend fun deleteTotpByIp(id: String): StytchResult<DeleteAuthenticationFactorData> =
+        suspend fun deleteTotpById(id: String): StytchResult<DeleteAuthenticationFactorData> =
             safeConsumerApiCall {
                 apiService.deleteTOTPById(id)
             }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -562,6 +562,16 @@ internal object StytchApi {
                 apiService.deleteWebAuthnById(id)
             }
 
+        suspend fun deleteTotpByIp(id: String): StytchResult<DeleteAuthenticationFactorData> =
+            safeConsumerApiCall {
+                apiService.deleteTOTPById(id)
+            }
+
+        suspend fun deleteOAuthById(id: String): StytchResult<DeleteAuthenticationFactorData> =
+            safeConsumerApiCall {
+                apiService.deleteOAuthById(id)
+            }
+
         suspend fun updateUser(
             name: NameData?,
             untrustedMetadata: Map<String, Any?>?,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -182,6 +182,16 @@ internal interface StytchApiService : ApiService {
         @Path(value = "id") id: String,
     ): ConsumerResponses.User.DeleteFactorResponse
 
+    @DELETE("users/totps/{id}")
+    suspend fun deleteTOTPById(
+        @Path(value = "id") id: String,
+    ): ConsumerResponses.User.DeleteFactorResponse
+
+    @DELETE("users/oauth/{id}")
+    suspend fun deleteOAuthById(
+        @Path(value = "id") id: String,
+    ): ConsumerResponses.User.DeleteFactorResponse
+
     @PUT("users/me")
     suspend fun updateUser(
         @Body request: ConsumerRequests.User.UpdateRequest,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
@@ -23,8 +23,6 @@ import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 internal interface GoogleCredentialManagerProvider {
     suspend fun getSignInWithGoogleCredential(

--- a/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserAuthenticationFactor.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserAuthenticationFactor.kt
@@ -29,4 +29,14 @@ public sealed class UserAuthenticationFactor(public open val id: String) {
      * Represents a WebAuthn registration associated with a Stytch User
      */
     public data class WebAuthn(override val id: String) : UserAuthenticationFactor(id)
+
+    /**
+     * Represents a TOTP registration associated with a Stytch User
+     */
+    public data class TOTP(override val id: String) : UserAuthenticationFactor(id)
+
+    /**
+     * Represents an OAuth registration associated with a Stytch User
+     */
+    public data class OAuth(override val id: String) : UserAuthenticationFactor(id)
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
@@ -41,7 +41,7 @@ internal class UserManagementImpl(
                 is UserAuthenticationFactor.BiometricRegistration -> api.deleteBiometricRegistrationById(factor.id)
                 is UserAuthenticationFactor.CryptoWallet -> api.deleteCryptoWalletById(factor.id)
                 is UserAuthenticationFactor.WebAuthn -> api.deleteWebAuthnById(factor.id)
-                is UserAuthenticationFactor.TOTP -> api.deleteTotpByIp(factor.id)
+                is UserAuthenticationFactor.TOTP -> api.deleteTotpById(factor.id)
                 is UserAuthenticationFactor.OAuth -> api.deleteOAuthById(factor.id)
             }.apply {
                 if (this is StytchResult.Success) {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
@@ -41,6 +41,8 @@ internal class UserManagementImpl(
                 is UserAuthenticationFactor.BiometricRegistration -> api.deleteBiometricRegistrationById(factor.id)
                 is UserAuthenticationFactor.CryptoWallet -> api.deleteCryptoWalletById(factor.id)
                 is UserAuthenticationFactor.WebAuthn -> api.deleteWebAuthnById(factor.id)
+                is UserAuthenticationFactor.TOTP -> api.deleteTotpByIp(factor.id)
+                is UserAuthenticationFactor.OAuth -> api.deleteOAuthById(factor.id)
             }.apply {
                 if (this is StytchResult.Success) {
                     sessionStorage.user = this.value.user

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -700,6 +700,24 @@ internal class StytchApiServiceTests {
     }
 
     @Test
+    fun `check deleteTOTPById request`() {
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.deleteTOTPById(id = "totp-id")
+            }.verifyDelete("/users/totps/totp-id")
+        }
+    }
+
+    @Test
+    fun `check deleteOAuthById request`() {
+        runBlocking {
+            requestIgnoringResponseException {
+                apiService.deleteOAuthById(id = "oauth-id")
+            }.verifyDelete("/users/oauth/oauth-id")
+        }
+    }
+
+    @Test
     fun `check updateUser request`() {
         val parameters =
             ConsumerRequests.User.UpdateRequest(

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -389,7 +389,7 @@ internal class StytchApiTest {
             coEvery {
                 StytchApi.apiService.deleteTOTPById(any())
             } returns mockk(relaxed = true)
-            StytchApi.UserManagement.deleteTotpByIp("totp-registration-id")
+            StytchApi.UserManagement.deleteTotpById("totp-registration-id")
             coVerify { StytchApi.apiService.deleteTOTPById("totp-registration-id") }
         }
 

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -361,6 +361,50 @@ internal class StytchApiTest {
         }
 
     @Test
+    fun `StytchApi User deleteCryptoWalletById calls appropriate apiService method`() =
+        runTest {
+            every { StytchApi.isInitialized } returns true
+            coEvery {
+                StytchApi.apiService.deleteCryptoWalletById(any())
+            } returns mockk(relaxed = true)
+            StytchApi.UserManagement.deleteCryptoWalletById("crypto-registration-id")
+            coVerify { StytchApi.apiService.deleteCryptoWalletById("crypto-registration-id") }
+        }
+
+    @Test
+    fun `StytchApi User deleteWebAuthnById calls appropriate apiService method`() =
+        runTest {
+            every { StytchApi.isInitialized } returns true
+            coEvery {
+                StytchApi.apiService.deleteWebAuthnById(any())
+            } returns mockk(relaxed = true)
+            StytchApi.UserManagement.deleteWebAuthnById("webauthn-registration-id")
+            coVerify { StytchApi.apiService.deleteWebAuthnById("webauthn-registration-id") }
+        }
+
+    @Test
+    fun `StytchApi User deleteTOTPById calls appropriate apiService method`() =
+        runTest {
+            every { StytchApi.isInitialized } returns true
+            coEvery {
+                StytchApi.apiService.deleteTOTPById(any())
+            } returns mockk(relaxed = true)
+            StytchApi.UserManagement.deleteTotpByIp("totp-registration-id")
+            coVerify { StytchApi.apiService.deleteTOTPById("totp-registration-id") }
+        }
+
+    @Test
+    fun `StytchApi User deleteOAuthById calls appropriate apiService method`() =
+        runTest {
+            every { StytchApi.isInitialized } returns true
+            coEvery {
+                StytchApi.apiService.deleteOAuthById(any())
+            } returns mockk(relaxed = true)
+            StytchApi.UserManagement.deleteOAuthById("oauth-registration-id")
+            coVerify { StytchApi.apiService.deleteOAuthById("oauth-registration-id") }
+        }
+
+    @Test
     fun `StytchApi User updateUser calls appropriate apiService method`() =
         runTest {
             every { StytchApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
@@ -120,7 +120,7 @@ internal class UserManagementImplTest {
             } returns StytchResult.Success(mockk(relaxed = true))
             coEvery { mockApi.deleteCryptoWalletById(any()) } returns StytchResult.Success(mockk(relaxed = true))
             coEvery { mockApi.deleteWebAuthnById(any()) } returns StytchResult.Success(mockk(relaxed = true))
-            coEvery { mockApi.deleteTotpByIp(any()) } returns StytchResult.Success(mockk(relaxed = true))
+            coEvery { mockApi.deleteTotpById(any()) } returns StytchResult.Success(mockk(relaxed = true))
             coEvery { mockApi.deleteOAuthById(any()) } returns StytchResult.Success(mockk(relaxed = true))
             listOf(
                 UserAuthenticationFactor.Email("emailAddressId"),
@@ -136,7 +136,7 @@ internal class UserManagementImplTest {
             coVerify { mockApi.deleteBiometricRegistrationById("biometricsRegistrationId") }
             coVerify { mockApi.deleteCryptoWalletById("cryptoWalletId") }
             coVerify { mockApi.deleteWebAuthnById("webAuthnId") }
-            coVerify { mockApi.deleteTotpByIp("totpId") }
+            coVerify { mockApi.deleteTotpById("totpId") }
             coVerify { mockApi.deleteOAuthById("oauthId") }
         }
 

--- a/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
@@ -120,18 +120,24 @@ internal class UserManagementImplTest {
             } returns StytchResult.Success(mockk(relaxed = true))
             coEvery { mockApi.deleteCryptoWalletById(any()) } returns StytchResult.Success(mockk(relaxed = true))
             coEvery { mockApi.deleteWebAuthnById(any()) } returns StytchResult.Success(mockk(relaxed = true))
+            coEvery { mockApi.deleteTotpByIp(any()) } returns StytchResult.Success(mockk(relaxed = true))
+            coEvery { mockApi.deleteOAuthById(any()) } returns StytchResult.Success(mockk(relaxed = true))
             listOf(
                 UserAuthenticationFactor.Email("emailAddressId"),
                 UserAuthenticationFactor.PhoneNumber("phoneNumberId"),
                 UserAuthenticationFactor.BiometricRegistration("biometricsRegistrationId"),
                 UserAuthenticationFactor.CryptoWallet("cryptoWalletId"),
                 UserAuthenticationFactor.WebAuthn("webAuthnId"),
+                UserAuthenticationFactor.TOTP("totpId"),
+                UserAuthenticationFactor.OAuth("oauthId"),
             ).forEach { impl.deleteFactor(it) }
             coVerify { mockApi.deleteEmailById("emailAddressId") }
             coVerify { mockApi.deletePhoneNumberById("phoneNumberId") }
             coVerify { mockApi.deleteBiometricRegistrationById("biometricsRegistrationId") }
             coVerify { mockApi.deleteCryptoWalletById("cryptoWalletId") }
             coVerify { mockApi.deleteWebAuthnById("webAuthnId") }
+            coVerify { mockApi.deleteTotpByIp("totpId") }
+            coVerify { mockApi.deleteOAuthById("oauthId") }
         }
 
     @Test


### PR DESCRIPTION
Linear Ticket: [SDK-1548](https://linear.app/stytch/issue/SDK-1548)

## Changes:

1. Adds missing deleteFactor methods for TOTP and OAuth registrations
2. Adds some missing tests for webauthn and crypto deletes

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A