### PR TITLE
SDK-1455 Add B2C Password Reset By Existing

### DIFF
--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/PasswordsViewModel.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/PasswordsViewModel.kt
@@ -24,6 +24,7 @@ class PasswordsViewModel(application: Application) : AndroidViewModel(applicatio
 
     var emailTextState by mutableStateOf(TextFieldValue(""))
     var passwordTextState by mutableStateOf(TextFieldValue(""))
+    var newPasswordTextState by mutableStateOf(TextFieldValue(""))
     var tokenTextState by mutableStateOf(TextFieldValue(""))
 
     val emailIsValid
@@ -142,6 +143,23 @@ class PasswordsViewModel(application: Application) : AndroidViewModel(applicatio
                     ),
                 )
             _currentResponse.value = result.toFriendlyDisplay()
+        }.invokeOnCompletion {
+            _loadingState.value = false
+        }
+    }
+
+    fun resetByExisting() {
+        viewModelScope.launch {
+            _loadingState.value = true
+            _currentResponse.value =
+                StytchClient.passwords.resetByExistingPassword(
+                    Passwords.ResetByExistingPasswordParameters(
+                        email = emailTextState.text,
+                        existingPassword = passwordTextState.text,
+                        newPassword = newPasswordTextState.text,
+                        sessionDurationMinutes = 5U,
+                    ),
+                ).toFriendlyDisplay()
         }.invokeOnCompletion {
             _loadingState.value = false
         }

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/ui/PasswordsScreen.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/ui/PasswordsScreen.kt
@@ -64,6 +64,18 @@ fun PasswordsScreen(navController: NavController) {
         )
         TextField(
             modifier = Modifier.fillMaxWidth(),
+            value = viewModel.newPasswordTextState,
+            singleLine = true,
+            label = {
+                Text(text = stringResource(id = R.string.passwords_new))
+            },
+            onValueChange = {
+                viewModel.newPasswordTextState = it
+            },
+            shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
+        )
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
             value = viewModel.tokenTextState,
             singleLine = true,
             label = {
@@ -103,6 +115,11 @@ fun PasswordsScreen(navController: NavController) {
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(id = R.string.passwords_reset_by_session),
             onClick = { viewModel.resetPasswordBySession() },
+        )
+        StytchButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(id = R.string.passwords_reset_by_existing),
+            onClick = viewModel::resetByExisting,
         )
         if (loading.value) {
             CircularProgressIndicator()

--- a/consumerExampleApp/src/main/res/values/strings.xml
+++ b/consumerExampleApp/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="passwords_reset_by_email_start">Reset by email start</string>
     <string name="passwords_reset_by_email">Reset by email (needs token)</string>
     <string name="passwords_reset_by_session">Reset by session</string>
+    <string name="passwords_new">New password</string>
+    <string name="passwords_reset_by_existing">Reset By Existing password</string>
     <string name="deep_link_title">Deep links</string>
     <string name="host">exampleapp.com</string>
     <string name="deeplink_received_toast">Deeplink received</string>

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -451,6 +451,23 @@ internal object StytchApi {
                 )
             }
 
+        suspend fun resetByExisting(
+            email: String,
+            existingPassword: String,
+            newPassword: String,
+            sessionDurationMinutes: UInt,
+        ): StytchResult<AuthData> =
+            safeConsumerApiCall {
+                apiService.resetByExistingPassword(
+                    ConsumerRequests.Passwords.PasswordResetByExistingPasswordRequest(
+                        email = email,
+                        existingPassword = existingPassword,
+                        newPassword = newPassword,
+                        sessionDurationMinutes = sessionDurationMinutes.toInt(),
+                    )
+                )
+            }
+
         suspend fun strengthCheck(
             email: String?,
             password: String,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -464,7 +464,7 @@ internal object StytchApi {
                         existingPassword = existingPassword,
                         newPassword = newPassword,
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
-                    )
+                    ),
                 )
             }
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -125,6 +125,11 @@ internal interface StytchApiService : ApiService {
         @Body request: ConsumerRequests.Passwords.ResetBySessionRequest,
     ): ConsumerResponses.AuthenticateResponse
 
+    @POST("passwords/existing_password/reset")
+    suspend fun resetByExistingPassword(
+        @Body request: ConsumerRequests.Passwords.PasswordResetByExistingPasswordRequest,
+    ): ConsumerResponses.AuthenticateResponse
+
     @POST("passwords/strength_check")
     suspend fun strengthCheck(
         @Body request: ConsumerRequests.Passwords.StrengthCheckRequest,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.models.NameData
+import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 
 internal object ConsumerRequests {
     object MagicLinks {
@@ -119,6 +120,18 @@ internal object ConsumerRequests {
         data class StrengthCheckRequest(
             val email: String?,
             val password: String,
+        )
+
+        @Keep
+        @JsonClass(generateAdapter = true)
+        data class PasswordResetByExistingPasswordRequest(
+            val email: String,
+            @Json(name = "existing_password")
+            val existingPassword: String,
+            @Json(name = "new_password")
+            val newPassword: String,
+            @Json(name = "session_duration_minutes")
+            val sessionDurationMinutes: Int,
         )
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -4,7 +4,6 @@ import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.models.NameData
-import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 
 internal object ConsumerRequests {
     object MagicLinks {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -92,6 +92,21 @@ public interface Passwords {
     )
 
     /**
+     * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
+     * @property email is the account identifier for the account in the form of an Email address to identify which
+     * account's password you wish to start resetting
+     * @property existingPassword The user's existing password.
+     * @property newPassword The new password for the user.
+     * @property sessionDurationMinutes indicates how long the session should last before it expires
+     */
+    public data class ResetByExistingPasswordParameters(
+        val email: String,
+        val existingPassword: String,
+        val newPassword: String,
+        val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+    )
+
+    /**
      * Reset the user’s password and authenticate them. This endpoint checks that the session is valid and hasn’t
      * expired or been revoked. The provided password needs to meet our password strength requirements, which can be
      * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
@@ -213,6 +228,23 @@ public interface Passwords {
     public fun resetByEmail(
         parameters: ResetByEmailParameters,
         callback: (response: AuthResponse) -> Unit,
+    )
+
+    /**
+     * Reset a user's password and authenticate them
+     * @param parameters required to reset a user's password
+     * @returns [AuthResponse]
+     */
+    public suspend fun resetByExistingPassword(parameters: ResetByExistingPasswordParameters): AuthResponse
+
+    /**
+     * Reset a user's password and authenticate them
+     * @param parameters required to reset a user's password
+     * @param callback a callback that receives an [AuthResponse]
+     */
+    public fun resetByExistingPassword(
+        parameters: ResetByExistingPasswordParameters,
+        callback: (AuthResponse) -> Unit,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -153,6 +153,28 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override suspend fun resetByExistingPassword(parameters: Passwords.ResetByExistingPasswordParameters): AuthResponse {
+        return withContext(dispatchers.io) {
+            api.resetByExisting(
+                email = parameters.email,
+                existingPassword = parameters.existingPassword,
+                newPassword = parameters.newPassword,
+                sessionDurationMinutes = parameters.sessionDurationMinutes
+            ).apply {
+                launchSessionUpdater(dispatchers, sessionStorage)
+            }
+        }
+    }
+
+    override fun resetByExistingPassword(
+        parameters: Passwords.ResetByExistingPasswordParameters,
+        callback: (AuthResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            callback(resetByExistingPassword(parameters))
+        }
+    }
+
     override suspend fun resetBySession(parameters: Passwords.ResetBySessionParameters): AuthResponse {
         return withContext(dispatchers.io) {
             api.resetBySession(

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -159,7 +159,7 @@ internal class PasswordsImpl internal constructor(
                 email = parameters.email,
                 existingPassword = parameters.existingPassword,
                 newPassword = parameters.newPassword,
-                sessionDurationMinutes = parameters.sessionDurationMinutes
+                sessionDurationMinutes = parameters.sessionDurationMinutes,
             ).apply {
                 launchSessionUpdater(dispatchers, sessionStorage)
             }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
@@ -17,4 +17,6 @@ If you have connected your deeplink handler with `StytchClient`, the resulting m
 
 Once you have a password reset token, and have collected the user's new desired password, you can call the `StytchClient.passwords.resetByEmail()` method to finish resetting their password.
 
+Call the `StytchClient.passwords.resetByExistingPassword()` method to reset a user's password using their existing email address and password combination.
+
 Call the `StytchClient.passwords.strengthCheck()` method to check whether or not the user’s provided password is valid, and to provide feedback to the user on how to increase the strength of their password.

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -520,6 +520,31 @@ internal class StytchApiServiceTests {
     }
 
     @Test
+    fun `check Passwords resetByExistingPassword request`() {
+        runBlocking {
+            val parameters =
+                ConsumerRequests.Passwords.PasswordResetByExistingPasswordRequest(
+                    email = "robot@stytch.com",
+                    existingPassword = "old password",
+                    newPassword = "new password",
+                    sessionDurationMinutes = 10,
+                )
+            requestIgnoringResponseException {
+                apiService.resetByExistingPassword(parameters)
+            }.verifyPost(
+                expectedPath = "/passwords/existing_password/reset",
+                expectedBody =
+                    mapOf(
+                        "email" to parameters.email,
+                        "existing_password" to parameters.existingPassword,
+                        "new_password" to parameters.newPassword,
+                        "session_duration_minutes" to parameters.sessionDurationMinutes,
+                    ),
+            )
+        }
+    }
+
+    @Test
     fun `check Passwords authenticate request`() {
         runBlocking {
             val parameters =

--- a/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -260,6 +260,20 @@ internal class StytchApiTest {
         }
 
     @Test
+    fun `StytchApi Passwords resetByExisting calls appropriate apiService method`() =
+        runTest {
+            every { StytchApi.isInitialized } returns true
+            coEvery { StytchApi.apiService.resetByExistingPassword(any()) } returns mockk(relaxed = true)
+            StytchApi.Passwords.resetByExisting(
+                email = "",
+                existingPassword = "",
+                newPassword = "",
+                sessionDurationMinutes = 30U,
+            )
+            coVerify { StytchApi.apiService.resetByExistingPassword(any()) }
+        }
+
+    @Test
     fun `StytchApi Passwords strengthCheck calls appropriate apiService method`() =
         runTest {
             every { StytchApi.isInitialized } returns true

--- a/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -212,6 +212,23 @@ internal class PasswordsImplTest {
     }
 
     @Test
+    fun `PasswordsImpl resetByExistingPassword delegates to api`() =
+        runTest {
+            coEvery { mockApi.resetByExisting(any(), any(), any(), any()) } returns successfulAuthResponse
+            impl.resetByExistingPassword(mockk(relaxed = true))
+            coVerify { mockApi.resetByExisting(any(), any(), any(), any()) }
+            verify { successfulAuthResponse.launchSessionUpdater(any(), any()) }
+        }
+
+    @Test
+    fun `PasswordsImpl resetByExistingPassword with callback calls callback`() {
+        coEvery { mockApi.resetByExisting(any(), any(), any(), any()) } returns successfulAuthResponse
+        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        impl.resetByExistingPassword(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(successfulAuthResponse) }
+    }
+
+    @Test
     fun `PasswordsImpl strengthCheck delegates to api`() =
         runTest {
             coEvery { mockApi.strengthCheck(any(), any()) } returns mockk()


### PR DESCRIPTION
Linear Ticket: [SDK-1455](https://linear.app/stytch/issue/SDK-1455)

## Changes:

1. Adds reset password by existing password method

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A