### PR TITLE
SDK-1525 Support MFA/IST correctly

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
@@ -27,18 +27,15 @@ class DiscoveryViewModel : ViewModel() {
     fun organizations() {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
-                StytchB2BClient.discovery.listOrganizations(
-                    Discovery.DiscoverOrganizationsParameters(),
-                ).toFriendlyDisplay()
+                StytchB2BClient.discovery.listOrganizations().toFriendlyDisplay()
         }
     }
 
-    fun createOrganization(intermediateSessionToken: String) {
+    fun createOrganization() {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
                 StytchB2BClient.discovery.createOrganization(
                     Discovery.CreateOrganizationParameters(
-                        intermediateSessionToken = intermediateSessionToken,
                         ssoJitProvisioning = SsoJitProvisioning.ALL_ALLOWED,
                         emailJitProvisioning = EmailJitProvisioning.RESTRICTED,
                         emailInvites = EmailInvites.ALL_ALLOWED,

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/AppScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/AppScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -66,7 +65,6 @@ fun AppScreen(
     oAuthViewModel: OAuthViewModel,
 ) {
     val navController = rememberNavController()
-    val intermediateSessionTokenValue = homeViewModel.intermediateSessionToken.collectAsState()
     Scaffold(
         modifier =
             Modifier
@@ -106,12 +104,7 @@ fun AppScreen(
             NavHost(navController, startDestination = Screen.Main.route, Modifier.padding(padding)) {
                 composable(Screen.Main.route) { MainScreen(viewModel = homeViewModel) }
                 composable(Screen.Passwords.route) { PasswordsScreen(viewModel = passwordsViewModel) }
-                composable(Screen.Discovery.route) {
-                    DiscoveryScreen(
-                        viewModel = discoveryViewModel,
-                        intermediateSessionToken = intermediateSessionTokenValue.value,
-                    )
-                }
+                composable(Screen.Discovery.route) { DiscoveryScreen(viewModel = discoveryViewModel) }
                 composable(Screen.SSO.route) { SSOScreen(viewModel = ssoViewModel) }
                 composable(Screen.Member.route) { MemberScreen(viewModel = memberViewModel) }
                 composable(Screen.Organization.route) { OrganizationScreen(viewModel = organizationViewModel) }

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/DiscoveryScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/DiscoveryScreen.kt
@@ -17,10 +17,7 @@ import com.stytch.exampleapp.b2b.DiscoveryViewModel
 import com.stytch.exampleapp.b2b.R
 
 @Composable
-fun DiscoveryScreen(
-    viewModel: DiscoveryViewModel,
-    intermediateSessionToken: String = "",
-) {
+fun DiscoveryScreen(viewModel: DiscoveryViewModel) {
     val responseState = viewModel.currentResponse.collectAsState()
     val loading = viewModel.loadingState.collectAsState()
     Column(
@@ -40,7 +37,7 @@ fun DiscoveryScreen(
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.create_organization),
-                onClick = { viewModel.createOrganization(intermediateSessionToken) },
+                onClick = { viewModel.createOrganization() },
             )
         }
         Column(

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -270,6 +270,7 @@ public object StytchB2BClient {
         DiscoveryImpl(
             externalScope,
             dispatchers,
+            sessionStorage,
             StytchB2BApi.Discovery,
         )
         get() {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -413,7 +413,7 @@ public object StytchB2BClient {
         return withContext(dispatchers.io) {
             val token = uri.getQueryParameter(Constants.QUERY_TOKEN)
             if (token.isNullOrEmpty()) {
-                return@withContext DeeplinkHandledStatus.NotHandled(StytchDeeplinkMissingTokenError)
+                return@withContext DeeplinkHandledStatus.NotHandled(StytchDeeplinkMissingTokenError())
             }
             when (val tokenType = B2BTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
                 B2BTokenType.MULTI_TENANT_MAGIC_LINKS -> {
@@ -480,7 +480,7 @@ public object StytchB2BClient {
                 }
                 else -> {
                     events.logEvent("deeplink_handled_failure", details = mapOf("token_type" to tokenType))
-                    DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError)
+                    DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError())
                 }
             }
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b
 
+import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
@@ -13,7 +14,6 @@ import com.stytch.sdk.b2b.network.models.B2BSearchOrganizationResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
-import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberDeleteAuthenticationFactorData
 import com.stytch.sdk.b2b.network.models.MemberResponseCommonData
@@ -25,23 +25,22 @@ import com.stytch.sdk.b2b.network.models.OrganizationDeleteResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationMemberDeleteResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationUpdateResponseData
+import com.stytch.sdk.b2b.network.models.PasswordResetByExistingPasswordResponseData
+import com.stytch.sdk.b2b.network.models.PasswordsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.RecoveryCodeGetResponseData
 import com.stytch.sdk.b2b.network.models.RecoveryCodeRecoverResponseData
 import com.stytch.sdk.b2b.network.models.RecoveryCodeRotateResponseData
+import com.stytch.sdk.b2b.network.models.SMSAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SSOAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.SessionResetResponseData
+import com.stytch.sdk.b2b.network.models.SessionsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.StrengthCheckResponseData
 import com.stytch.sdk.b2b.network.models.TOTPAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.TOTPCreateResponseData
 import com.stytch.sdk.b2b.network.models.UpdateMemberResponseData
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.network.models.BasicData
-
-/**
- * Type alias for StytchResult<IB2BAuthData> used for authentication responses
- */
-public typealias AuthResponse = StytchResult<IB2BAuthData>
 
 /**
  * Type alias for StytchResult<OrganizationResponseData> used for organization.get() responses
@@ -161,3 +160,13 @@ public typealias B2BSSOOIDCUpdateConnectionResponse = StytchResult<B2BSSOOIDCUpd
 public typealias B2BSearchOrganizationResponse = StytchResult<B2BSearchOrganizationResponseData>
 
 public typealias B2BSearchMemberResponse = StytchResult<B2BSearchMemberResponseData>
+
+public typealias PasswordsAuthenticateResponse = StytchResult<PasswordsAuthenticateResponseData>
+
+public typealias PasswordResetByExistingPasswordResponse = StytchResult<PasswordResetByExistingPasswordResponseData>
+
+public typealias SessionsAuthenticateResponse = StytchResult<SessionsAuthenticateResponseData>
+
+public typealias SMSAuthenticateResponse = StytchResult<SMSAuthenticateResponseData>
+
+public typealias EMLAuthenticateResponse = StytchResult<B2BEMLAuthenticateData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -31,39 +31,23 @@ import com.stytch.sdk.common.Constants
  */
 public interface Discovery {
     /**
-     * Data class used for wrapping parameters used with Discovering organizations
-     * @property intermediateSessionToken is the unique sequence of characters used to authenticate a member. If this
-     * is not provided the existing session token will be used.
-     */
-    public data class DiscoverOrganizationsParameters(
-        val intermediateSessionToken: String? = null,
-    )
-
-    /**
      * Discover a member's available organizations
-     * @param parameters required for retrieving a member's available organizations
      * @return [DiscoverOrganizationsResponse]
      */
-    public suspend fun listOrganizations(parameters: DiscoverOrganizationsParameters): DiscoverOrganizationsResponse
+    public suspend fun listOrganizations(): DiscoverOrganizationsResponse
 
     /**
      * Discover a member's available organizations
-     * @param parameters required for retrieving a member's available organizations
      * @param callback a callback that receives a [DiscoverOrganizationsResponse]
      */
-    public fun listOrganizations(
-        parameters: DiscoverOrganizationsParameters,
-        callback: (DiscoverOrganizationsResponse) -> Unit,
-    )
+    public fun listOrganizations(callback: (DiscoverOrganizationsResponse) -> Unit)
 
     /**
      * Data class used for wrapping parameters used with exchanging sessions between organizations.
-     * @property intermediateSessionToken is the unique sequence of characters used to authenticate a member
      * @property organizationId is the organization ID of the desired organization
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
     public data class SessionExchangeParameters(
-        val intermediateSessionToken: String,
         val organizationId: String,
         val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
     )
@@ -93,7 +77,6 @@ public interface Discovery {
 
     /**
      * A data class used for wrapping parameters used with creating organizations
-     * @property intermediateSessionToken is the unique sequence of characters used to authenticate a member
      * @property organizationName is the name of the new organization
      * @property organizationSlug is the desired slug of the new organization
      * @property organizationLogoUrl is the optional URL of the new organization's logo
@@ -127,7 +110,6 @@ public interface Discovery {
      * is set to RESTRICTED. The list's accepted values are: sso , magic_link , and password .
      */
     public data class CreateOrganizationParameters(
-        val intermediateSessionToken: String,
         val organizationName: String? = null,
         val organizationSlug: String? = null,
         val organizationLogoUrl: String? = null,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.DiscoverOrganizationsResponse
 import com.stytch.sdk.b2b.IntermediateSessionExchangeResponse
 import com.stytch.sdk.b2b.OrganizationCreateResponse
 import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.StytchDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -12,23 +13,18 @@ import kotlinx.coroutines.withContext
 internal class DiscoveryImpl(
     private val externalScope: CoroutineScope,
     private val dispatchers: StytchDispatchers,
+    private val sessionStorage: B2BSessionStorage,
     private val api: StytchB2BApi.Discovery,
 ) : Discovery {
-    override suspend fun listOrganizations(
-        parameters: Discovery.DiscoverOrganizationsParameters,
-    ): DiscoverOrganizationsResponse {
+    override suspend fun listOrganizations(): DiscoverOrganizationsResponse {
         return withContext(dispatchers.io) {
-            api.discoverOrganizations(parameters.intermediateSessionToken)
+            api.discoverOrganizations(sessionStorage.intermediateSessionToken)
         }
     }
 
-    override fun listOrganizations(
-        parameters: Discovery.DiscoverOrganizationsParameters,
-        callback: (DiscoverOrganizationsResponse) -> Unit,
-    ) {
+    override fun listOrganizations(callback: (DiscoverOrganizationsResponse) -> Unit) {
         externalScope.launch(dispatchers.ui) {
-            val result = listOrganizations(parameters)
-            callback(result)
+            callback(listOrganizations())
         }
     }
 
@@ -37,7 +33,7 @@ internal class DiscoveryImpl(
     ): IntermediateSessionExchangeResponse {
         return withContext(dispatchers.io) {
             api.exchangeSession(
-                intermediateSessionToken = parameters.intermediateSessionToken,
+                intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 organizationId = parameters.organizationId,
                 sessionDurationMinutes = parameters.sessionDurationMinutes,
             )
@@ -59,7 +55,7 @@ internal class DiscoveryImpl(
     ): OrganizationCreateResponse {
         return withContext(dispatchers.io) {
             api.createOrganization(
-                intermediateSessionToken = parameters.intermediateSessionToken,
+                intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 organizationName = parameters.organizationName,
                 organizationSlug = parameters.organizationSlug,
                 organizationLogoUrl = parameters.organizationLogoUrl,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.magicLinks
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
+import com.stytch.sdk.b2b.EMLAuthenticateResponse
 import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.Constants
@@ -46,20 +46,20 @@ public interface B2BMagicLinks {
      * previously used. Provide a value for session_duration_minutes to receive a Session. If the Member’s status is
      * pending, they will be updated to active.
      * @param parameters required to authenticate
-     * @return [AuthResponse]
+     * @return [EMLAuthenticateResponse]
      */
-    public suspend fun authenticate(parameters: AuthParameters): AuthResponse
+    public suspend fun authenticate(parameters: AuthParameters): EMLAuthenticateResponse
 
     /**
      * Authenticate a Member with a Magic Link. This endpoint requires a Magic Link token that is not expired or
      * previously used. Provide a value for session_duration_minutes to receive a Session. If the Member’s status is
      * pending, they will be updated to active.
      * @param parameters required to authenticate
-     * @param callback A callback that receives an [AuthResponse]
+     * @param callback A callback that receives an [EMLAuthenticateResponse]
      */
     public fun authenticate(
         parameters: AuthParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: EMLAuthenticateResponse) -> Unit,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -41,9 +41,10 @@ internal class B2BMagicLinksImpl internal constructor(
             // call backend endpoint
             result =
                 emailApi.authenticate(
-                    parameters.token,
-                    parameters.sessionDurationMinutes,
-                    codeVerifier,
+                    token = parameters.token,
+                    sessionDurationMinutes = parameters.sessionDurationMinutes,
+                    codeVerifier = codeVerifier,
+                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.magicLinks
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
+import com.stytch.sdk.b2b.EMLAuthenticateResponse
 import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -26,8 +26,8 @@ internal class B2BMagicLinksImpl internal constructor(
 ) : B2BMagicLinks {
     override val email: B2BMagicLinks.EmailMagicLinks = EmailMagicLinksImpl()
 
-    override suspend fun authenticate(parameters: B2BMagicLinks.AuthParameters): AuthResponse {
-        var result: AuthResponse
+    override suspend fun authenticate(parameters: B2BMagicLinks.AuthParameters): EMLAuthenticateResponse {
+        var result: EMLAuthenticateResponse
         withContext(dispatchers.io) {
             val codeVerifier: String
 
@@ -54,7 +54,7 @@ internal class B2BMagicLinksImpl internal constructor(
 
     override fun authenticate(
         parameters: B2BMagicLinks.AuthParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: EMLAuthenticateResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
             val result = authenticate(parameters)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -184,6 +184,7 @@ internal object StytchB2BApi {
                 token: String,
                 sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
                 codeVerifier: String,
+                intermediateSessionToken: String? = null,
             ): StytchResult<B2BEMLAuthenticateData> =
                 safeB2BApiCall {
                     apiService.authenticate(
@@ -191,6 +192,7 @@ internal object StytchB2BApi {
                             token = token,
                             codeVerifier = codeVerifier,
                             sessionDurationMinutes = sessionDurationMinutes.toInt(),
+                            intermediateSessionToken = intermediateSessionToken,
                         ),
                     )
                 }
@@ -476,6 +478,7 @@ internal object StytchB2BApi {
             emailAddress: String,
             password: String,
             sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
+            intermediateSessionToken: String? = null,
         ): StytchResult<PasswordsAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.authenticatePassword(
@@ -484,6 +487,7 @@ internal object StytchB2BApi {
                         emailAddress = emailAddress,
                         password = password,
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -517,6 +521,7 @@ internal object StytchB2BApi {
             password: String,
             sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
             codeVerifier: String,
+            intermediateSessionToken: String? = null,
         ): StytchResult<EmailResetResponseData> =
             safeB2BApiCall {
                 apiService.resetPasswordByEmail(
@@ -525,6 +530,7 @@ internal object StytchB2BApi {
                         password = password,
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
                         codeVerifier = codeVerifier,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -588,7 +594,7 @@ internal object StytchB2BApi {
             }
 
         suspend fun exchangeSession(
-            intermediateSessionToken: String,
+            intermediateSessionToken: String? = null,
             organizationId: String,
             sessionDurationMinutes: UInt,
         ): StytchResult<IntermediateSessionExchangeResponseData> =
@@ -604,7 +610,7 @@ internal object StytchB2BApi {
 
         @Suppress("LongParameterList")
         suspend fun createOrganization(
-            intermediateSessionToken: String,
+            intermediateSessionToken: String? = null,
             sessionDurationMinutes: UInt,
             organizationName: String?,
             organizationSlug: String?,
@@ -640,6 +646,7 @@ internal object StytchB2BApi {
             ssoToken: String,
             sessionDurationMinutes: UInt,
             codeVerifier: String,
+            intermediateSessionToken: String? = null,
         ): StytchResult<SSOAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.ssoAuthenticate(
@@ -647,6 +654,7 @@ internal object StytchB2BApi {
                         ssoToken = ssoToken,
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
                         codeVerifier = codeVerifier,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -836,6 +844,7 @@ internal object StytchB2BApi {
             memberId: String,
             mfaPhoneNumber: String? = null,
             locale: String? = null,
+            intermediateSessionToken: String? = null,
         ): StytchResult<BasicData> =
             safeB2BApiCall {
                 apiService.sendSMSOTP(
@@ -844,6 +853,7 @@ internal object StytchB2BApi {
                         memberId = memberId,
                         mfaPhoneNumber = mfaPhoneNumber,
                         locale = locale,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -854,6 +864,7 @@ internal object StytchB2BApi {
             code: String,
             setMFAEnrollment: SetMFAEnrollment? = null,
             sessionDurationMinutes: Int,
+            intermediateSessionToken: String? = null,
         ): StytchResult<SMSAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.authenticateSMSOTP(
@@ -863,6 +874,7 @@ internal object StytchB2BApi {
                         code = code,
                         setMFAEnrollment = setMFAEnrollment,
                         sessionDurationMinutes = sessionDurationMinutes,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -873,6 +885,7 @@ internal object StytchB2BApi {
             organizationId: String,
             memberId: String,
             expirationMinutes: Int? = null,
+            intermediateSessionToken: String? = null,
         ): StytchResult<TOTPCreateResponseData> =
             safeB2BApiCall {
                 apiService.createTOTP(
@@ -880,6 +893,7 @@ internal object StytchB2BApi {
                         organizationId = organizationId,
                         memberId = memberId,
                         expirationMinutes = expirationMinutes,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -891,6 +905,7 @@ internal object StytchB2BApi {
             setMFAEnrollment: SetMFAEnrollment? = null,
             setDefaultMfaMethod: Boolean? = null,
             sessionDurationMinutes: Int,
+            intermediateSessionToken: String? = null,
         ): StytchResult<TOTPAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.authenticateTOTP(
@@ -901,6 +916,7 @@ internal object StytchB2BApi {
                         setMFAEnrollment = setMFAEnrollment,
                         setDefaultMfaMethod = setDefaultMfaMethod,
                         sessionDurationMinutes = sessionDurationMinutes,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }
@@ -922,6 +938,7 @@ internal object StytchB2BApi {
             memberId: String,
             sessionDurationMinutes: Int,
             recoveryCode: String,
+            intermediateSessionToken: String? = null,
         ): StytchResult<RecoveryCodeRecoverResponseData> =
             safeB2BApiCall {
                 apiService.recoverRecoveryCodes(
@@ -930,6 +947,7 @@ internal object StytchB2BApi {
                         memberId = memberId,
                         sessionDurationMinutes = sessionDurationMinutes,
                         recoveryCode = recoveryCode,
+                        intermediateSessionToken = intermediateSessionToken,
                     ),
                 )
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -4,7 +4,6 @@ import androidx.annotation.VisibleForTesting
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.AuthMethods
-import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
@@ -24,7 +23,6 @@ import com.stytch.sdk.b2b.network.models.EmailInvites
 import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
-import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberDeleteAuthenticationFactorData
 import com.stytch.sdk.b2b.network.models.MemberResponseCommonData
@@ -39,13 +37,16 @@ import com.stytch.sdk.b2b.network.models.OrganizationDeleteResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationMemberDeleteResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationUpdateResponseData
+import com.stytch.sdk.b2b.network.models.PasswordResetByExistingPasswordResponseData
 import com.stytch.sdk.b2b.network.models.PasswordsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.RecoveryCodeGetResponseData
 import com.stytch.sdk.b2b.network.models.RecoveryCodeRecoverResponseData
 import com.stytch.sdk.b2b.network.models.RecoveryCodeRotateResponseData
+import com.stytch.sdk.b2b.network.models.SMSAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SSOAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.SessionResetResponseData
+import com.stytch.sdk.b2b.network.models.SessionsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.b2b.network.models.StrengthCheckResponseData
@@ -252,7 +253,7 @@ internal object StytchB2BApi {
     }
 
     internal object Sessions {
-        suspend fun authenticate(sessionDurationMinutes: UInt? = null): StytchResult<IB2BAuthData> =
+        suspend fun authenticate(sessionDurationMinutes: UInt? = null): StytchResult<SessionsAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.authenticateSessions(
                     CommonRequests.Sessions.AuthenticateRequest(
@@ -534,7 +535,7 @@ internal object StytchB2BApi {
             existingPassword: String,
             newPassword: String,
             sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
-        ): StytchResult<B2BAuthData> =
+        ): StytchResult<PasswordResetByExistingPasswordResponseData> =
             safeB2BApiCall {
                 apiService.resetPasswordByExisting(
                     B2BRequests.Passwords.ResetByExistingPasswordRequest(
@@ -853,7 +854,7 @@ internal object StytchB2BApi {
             code: String,
             setMFAEnrollment: SetMFAEnrollment? = null,
             sessionDurationMinutes: Int,
-        ): StytchResult<B2BAuthData> =
+        ): StytchResult<SMSAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.authenticateSMSOTP(
                     B2BRequests.OTP.SMS.AuthenticateRequest(

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -78,6 +78,8 @@ internal object B2BRequests {
             val codeVerifier: String,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
     }
 
@@ -92,6 +94,8 @@ internal object B2BRequests {
             val password: String,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
 
         @Keep
@@ -123,6 +127,8 @@ internal object B2BRequests {
             val sessionDurationMinutes: Int,
             @Json(name = "code_verifier")
             val codeVerifier: String,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
 
         @Keep
@@ -168,7 +174,7 @@ internal object B2BRequests {
         @JsonClass(generateAdapter = true)
         data class SessionExchangeRequest(
             @Json(name = "intermediate_session_token")
-            val intermediateSessionToken: String,
+            val intermediateSessionToken: String? = null,
             @Json(name = "organization_id")
             val organizationId: String,
             @Json(name = "session_duration_minutes")
@@ -179,7 +185,7 @@ internal object B2BRequests {
         @JsonClass(generateAdapter = true)
         data class CreateRequest(
             @Json(name = "intermediate_session_token")
-            val intermediateSessionToken: String,
+            val intermediateSessionToken: String? = null,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
             @Json(name = "organization_name")
@@ -213,6 +219,8 @@ internal object B2BRequests {
             val sessionDurationMinutes: Int,
             @Json(name = "pkce_code_verifier")
             val codeVerifier: String,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
 
         @Keep
@@ -437,6 +445,8 @@ internal object B2BRequests {
                 @Json(name = "mfa_phone_number")
                 val mfaPhoneNumber: String? = null,
                 val locale: String? = null,
+                @Json(name = "intermediate_session_token")
+                val intermediateSessionToken: String? = null,
             )
 
             @Keep
@@ -451,6 +461,8 @@ internal object B2BRequests {
                 val setMFAEnrollment: SetMFAEnrollment? = null,
                 @Json(name = "session_duration_minutes")
                 val sessionDurationMinutes: Int,
+                @Json(name = "intermediate_session_token")
+                val intermediateSessionToken: String? = null,
             )
         }
     }
@@ -465,6 +477,8 @@ internal object B2BRequests {
             val memberId: String,
             @Json(name = "expiration_minutes")
             val expirationMinutes: Int? = null,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
 
         @Keep
@@ -481,6 +495,8 @@ internal object B2BRequests {
             val setDefaultMfaMethod: Boolean? = null,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
     }
 
@@ -496,6 +512,8 @@ internal object B2BRequests {
             val sessionDurationMinutes: Int,
             @Json(name = "recovery_code")
             val recoveryCode: String,
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
         )
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -19,9 +19,58 @@ public interface IB2BAuthData : CommonAuthenticationData {
 }
 
 @Keep
+public interface IB2BAuthDataWithMFA : CommonAuthenticationData {
+    public val memberId: String
+    public override val sessionToken: String
+    public override val sessionJwt: String
+    public val member: MemberData
+    public val organization: OrganizationData
+    public val memberSession: B2BSessionData?
+    public val memberAuthenticated: Boolean
+    public val intermediateSessionToken: String?
+    public val mfaRequired: MFARequired?
+}
+
+@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
-public data class B2BAuthData(
+public data class MFARequired(
+    @Json(name = "member_options")
+    val memberOptions: MemberOptions? = null,
+    @Json(name = "secondary_auth_initiated")
+    val secondaryAuthInitiated: String? = null,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class MemberOptions(
+    @Json(name = "mfa_phone_number")
+    val mfaPhoneNumber: String,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class SessionsAuthenticateResponseData(
+    @Json(name = "status_code")
+    val statusCode: Int,
+    @Json(name = "request_id")
+    val requestId: String,
+    @Json(name = "member_session")
+    override val memberSession: B2BSessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val member: MemberData,
+    override val organization: OrganizationData,
+) : IB2BAuthData, Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class SMSAuthenticateResponseData(
     @Json(name = "status_code")
     val statusCode: Int,
     @Json(name = "request_id")
@@ -50,11 +99,19 @@ public data class B2BEMLAuthenticateData(
     @Json(name = "session_jwt")
     override val sessionJwt: String,
     @Json(name = "member_session")
-    override val memberSession: B2BSessionData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "reset_sessions")
     val resetSessions: Boolean,
+    @Json(name = "member_id")
+    override val memberId: String,
     override val organization: OrganizationData,
-) : IB2BAuthData, Parcelable
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -188,18 +245,22 @@ public data class PasswordsAuthenticateResponseData(
     @Json(name = "request_id")
     val requestId: String,
     @Json(name = "member_session")
-    override val memberSession: B2BSessionData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "session_jwt")
     override val sessionJwt: String,
     @Json(name = "session_token")
     override val sessionToken: String,
+    @Json(name = "member_id")
+    override val memberId: String,
     override val member: MemberData,
     override val organization: OrganizationData,
-    @Json(name = "member_id")
-    val memberId: String,
-    @Json(name = "organization_id")
-    val organizationId: String,
-) : IB2BAuthData, Parcelable
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -217,13 +278,45 @@ public data class EmailResetResponseData(
     override val sessionToken: String,
     override val member: MemberData,
     override val organization: OrganizationData,
-    @Json(name = "member_id")
-    val memberId: String,
-    @Json(name = "organization_id")
-    val organizationId: String,
     @Json(name = "member_email_id")
     val memberEmailId: String,
-) : IB2BAuthData, Parcelable
+    @Json(name = "member_id")
+    override val memberId: String,
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class PasswordResetByExistingPasswordResponseData(
+    @Json(name = "status_code")
+    val statusCode: Int,
+    @Json(name = "request_id")
+    val requestId: String,
+    @Json(name = "member_session")
+    override val memberSession: B2BSessionData?,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val member: MemberData,
+    override val organization: OrganizationData,
+    @Json(name = "member_email_id")
+    val memberEmailId: String,
+    @Json(name = "member_id")
+    override val memberId: String,
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -331,12 +424,22 @@ public data class IntermediateSessionExchangeResponseData(
     @Json(name = "request_id")
     val requestId: String,
     @Json(name = "member_session")
-    val memberSession: B2BSessionData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "session_jwt")
-    val sessionJwt: String,
+    override val sessionJwt: String,
     @Json(name = "session_token")
-    val sessionToken: String,
-) : Parcelable
+    override val sessionToken: String,
+    @Json(name = "member_id")
+    override val memberId: String,
+    override val member: MemberData,
+    override val organization: OrganizationData,
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -347,12 +450,22 @@ public data class OrganizationCreateResponseData(
     @Json(name = "request_id")
     val requestId: String,
     @Json(name = "member_session")
-    val memberSession: B2BSessionData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "session_jwt")
-    val sessionJwt: String,
+    override val sessionJwt: String,
     @Json(name = "session_token")
-    val sessionToken: String,
-) : Parcelable
+    override val sessionToken: String,
+    @Json(name = "member_id")
+    override val memberId: String,
+    override val member: MemberData,
+    override val organization: OrganizationData,
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -370,9 +483,6 @@ public data class DiscoveryAuthenticateResponseData(
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SSOAuthenticateResponseData(
-    @Json(name = "member_id")
-    val memberId: String,
-    override val member: MemberData,
     @Json(name = "organization_id")
     val organizationId: String,
     @Json(name = "method_id")
@@ -382,11 +492,20 @@ public data class SSOAuthenticateResponseData(
     @Json(name = "session_token")
     override val sessionToken: String,
     @Json(name = "session")
-    override val memberSession: B2BSessionData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "reset_session")
     val resetSession: Boolean,
+    @Json(name = "member_id")
+    override val memberId: String,
+    override val member: MemberData,
     override val organization: OrganizationData,
-) : IB2BAuthData, Parcelable
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -397,18 +516,22 @@ public data class SessionExchangeResponseData(
     @Json(name = "request_id")
     val requestId: String,
     @Json(name = "member_session")
-    override val memberSession: B2BSessionData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "session_jwt")
     override val sessionJwt: String,
     @Json(name = "session_token")
     override val sessionToken: String,
+    @Json(name = "member_id")
+    override val memberId: String,
     override val member: MemberData,
     override val organization: OrganizationData,
     @Json(name = "member_authenticated")
-    val memberAuthenticated: Boolean,
+    override val memberAuthenticated: Boolean,
     @Json(name = "intermediate_session_token")
-    val intermediateSessionToken: String,
-) : IB2BAuthData, Parcelable
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -611,19 +734,25 @@ public data class OAuthAuthenticateResponseData(
     val statusCode: Int,
     @Json(name = "request_id")
     val requestId: String,
-    @Json(name = "member_id")
-    val memberId: String,
     @Json(name = "session_token")
     override val sessionToken: String,
     @Json(name = "session_jwt")
     override val sessionJwt: String,
     @Json(name = "member_session")
-    override val memberSession: B2BSessionData,
-    override val member: MemberData,
-    override val organization: OrganizationData,
+    override val memberSession: B2BSessionData?,
     @Json(name = "provider_values")
     val providerValues: OAuthProviderValues,
-) : IB2BAuthData, Parcelable
+    @Json(name = "member_id")
+    override val memberId: String,
+    override val member: MemberData,
+    override val organization: OrganizationData,
+    @Json(name = "member_authenticated")
+    override val memberAuthenticated: Boolean,
+    @Json(name = "intermediate_session_token")
+    override val intermediateSessionToken: String?,
+    @Json(name = "mfa_required")
+    override val mfaRequired: MFARequired?,
+) : IB2BAuthDataWithMFA, Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -26,7 +26,9 @@ internal object B2BResponses {
     object Sessions {
         @Keep
         @JsonClass(generateAdapter = true)
-        class AuthenticateResponse(data: B2BAuthData) : StytchDataResponse<B2BAuthData>(data)
+        class AuthenticateResponse(
+            data: SessionsAuthenticateResponseData,
+        ) : StytchDataResponse<SessionsAuthenticateResponseData>(data)
 
         @Keep
         @JsonClass(generateAdapter = true)
@@ -123,7 +125,9 @@ internal object B2BResponses {
 
         @Keep
         @JsonClass(generateAdapter = true)
-        class ResetByExistingPasswordResponse(data: B2BAuthData) : StytchDataResponse<B2BAuthData>(data)
+        class ResetByExistingPasswordResponse(
+            data: PasswordResetByExistingPasswordResponseData,
+        ) : StytchDataResponse<PasswordResetByExistingPasswordResponseData>(data)
 
         @Keep
         @JsonClass(generateAdapter = true)
@@ -225,8 +229,8 @@ internal object B2BResponses {
             @Keep
             @JsonClass(generateAdapter = true)
             class AuthenticateResponse(
-                data: B2BAuthData,
-            ) : StytchDataResponse<B2BAuthData>(data)
+                data: SMSAuthenticateResponseData,
+            ) : StytchDataResponse<SMSAuthenticateResponseData>(data)
         }
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
@@ -85,7 +85,7 @@ internal class OrganizationImpl(
                 if (this is StytchResult.Success) {
                     sessionStorage.organization = null
                     sessionStorage.member = null
-                    sessionStorage.updateSession(null, null, null)
+                    sessionStorage.updateSession(null, null, null, null)
                 }
             }
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.otp
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.BasicResponse
+import com.stytch.sdk.b2b.SMSAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.common.Constants
 
@@ -72,18 +72,18 @@ public interface OTP {
         /**
          * Authenticate a one-time passcode (OTP) sent to a user via SMS.
          * @param parameters required to authenticate an SMS OTP
-         * @return [AuthResponse]
+         * @return [SMSAuthenticateResponse]
          */
-        public suspend fun authenticate(parameters: AuthenticateParameters): AuthResponse
+        public suspend fun authenticate(parameters: AuthenticateParameters): SMSAuthenticateResponse
 
         /**
          * Authenticate a one-time passcode (OTP) sent to a user via SMS.
          * @param parameters required to authenticate an SMS OTP
-         * @param callback a callback that receives a [AuthResponse]
+         * @param callback a callback that receives a [SMSAuthenticateResponse]
          */
         public fun authenticate(
             parameters: AuthenticateParameters,
-            callback: (AuthResponse) -> Unit,
+            callback: (SMSAuthenticateResponse) -> Unit,
         )
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
@@ -26,6 +26,7 @@ internal class OTPImpl(
                     memberId = parameters.memberId,
                     mfaPhoneNumber = parameters.mfaPhoneNumber,
                     locale = parameters.locale,
+                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 )
             }
 
@@ -46,6 +47,7 @@ internal class OTPImpl(
                     code = parameters.code,
                     setMFAEnrollment = parameters.setMFAEnrollment,
                     sessionDurationMinutes = parameters.sessionDurationMinutes.toInt(),
+                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.otp
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.BasicResponse
+import com.stytch.sdk.b2b.SMSAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
@@ -38,7 +38,7 @@ internal class OTPImpl(
             }
         }
 
-        override suspend fun authenticate(parameters: OTP.SMS.AuthenticateParameters): AuthResponse =
+        override suspend fun authenticate(parameters: OTP.SMS.AuthenticateParameters): SMSAuthenticateResponse =
             withContext(dispatchers.io) {
                 api.authenticateSMSOTP(
                     organizationId = parameters.organizationId,
@@ -53,7 +53,7 @@ internal class OTPImpl(
 
         override fun authenticate(
             parameters: OTP.SMS.AuthenticateParameters,
-            callback: (AuthResponse) -> Unit,
+            callback: (SMSAuthenticateResponse) -> Unit,
         ) {
             externalScope.launch(dispatchers.ui) {
                 callback(authenticate(parameters))

--- a/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
@@ -1,8 +1,9 @@
 package com.stytch.sdk.b2b.passwords
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.EmailResetResponse
+import com.stytch.sdk.b2b.PasswordResetByExistingPasswordResponse
 import com.stytch.sdk.b2b.PasswordStrengthCheckResponse
+import com.stytch.sdk.b2b.PasswordsAuthenticateResponse
 import com.stytch.sdk.b2b.SessionResetResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.Constants
@@ -49,9 +50,9 @@ public interface Passwords {
      * order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack
      * account-takeover attack.
      * @param parameters required to authenticate
-     * @return [AuthResponse]
+     * @return [PasswordsAuthenticateResponse]
      */
-    public suspend fun authenticate(parameters: AuthParameters): AuthResponse
+    public suspend fun authenticate(parameters: AuthParameters): PasswordsAuthenticateResponse
 
     /**
      * Authenticate a member with their email address and password. This endpoint verifies that the member has a
@@ -67,11 +68,11 @@ public interface Passwords {
      * order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack
      * account-takeover attack.
      * @param parameters required to authenticate
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [PasswordsAuthenticateResponse]
      */
     public fun authenticate(
         parameters: AuthParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (PasswordsAuthenticateResponse) -> Unit,
     )
 
     /**
@@ -170,9 +171,11 @@ public interface Passwords {
      * advance with the password strength endpoint. If the password and accompanying parameters are accepted, the
      * password is securely stored for future authentication and the member is authenticated.
      * @param parameters required to reset a member's password
-     * @return [AuthResponse]
+     * @return [PasswordResetByExistingPasswordResponse]
      */
-    public suspend fun resetByExisting(parameters: ResetByExistingPasswordParameters): AuthResponse
+    public suspend fun resetByExisting(
+        parameters: ResetByExistingPasswordParameters,
+    ): PasswordResetByExistingPasswordResponse
 
     /**
      * Reset the member’s password and authenticate them. This endpoint checks that the existing password matches the
@@ -180,11 +183,11 @@ public interface Passwords {
      * advance with the password strength endpoint. If the password and accompanying parameters are accepted, the
      * password is securely stored for future authentication and the member is authenticated.
      * @param parameters required to reset a member's password
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [PasswordResetByExistingPasswordResponse]
      */
     public fun resetByExisting(
         parameters: ResetByExistingPasswordParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (PasswordResetByExistingPasswordResponse) -> Unit,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -1,8 +1,9 @@
 package com.stytch.sdk.b2b.passwords
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.EmailResetResponse
+import com.stytch.sdk.b2b.PasswordResetByExistingPasswordResponse
 import com.stytch.sdk.b2b.PasswordStrengthCheckResponse
+import com.stytch.sdk.b2b.PasswordsAuthenticateResponse
 import com.stytch.sdk.b2b.SessionResetResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -25,7 +26,7 @@ internal class PasswordsImpl internal constructor(
     private val storageHelper: StorageHelper,
     private val api: StytchB2BApi.Passwords,
 ) : Passwords {
-    override suspend fun authenticate(parameters: Passwords.AuthParameters): AuthResponse {
+    override suspend fun authenticate(parameters: Passwords.AuthParameters): PasswordsAuthenticateResponse {
         return withContext(dispatchers.io) {
             api.authenticate(
                 organizationId = parameters.organizationId,
@@ -40,7 +41,7 @@ internal class PasswordsImpl internal constructor(
 
     override fun authenticate(
         parameters: Passwords.AuthParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (PasswordsAuthenticateResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
             val result = authenticate(parameters)
@@ -116,7 +117,9 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
-    override suspend fun resetByExisting(parameters: Passwords.ResetByExistingPasswordParameters): AuthResponse {
+    override suspend fun resetByExisting(
+        parameters: Passwords.ResetByExistingPasswordParameters,
+    ): PasswordResetByExistingPasswordResponse {
         return withContext(dispatchers.io) {
             api.resetByExisting(
                 organizationId = parameters.organizationId,
@@ -132,7 +135,7 @@ internal class PasswordsImpl internal constructor(
 
     override fun resetByExisting(
         parameters: Passwords.ResetByExistingPasswordParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (PasswordResetByExistingPasswordResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
             val result = resetByExisting(parameters)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -33,6 +33,7 @@ internal class PasswordsImpl internal constructor(
                 emailAddress = parameters.emailAddress,
                 password = parameters.password,
                 sessionDurationMinutes = parameters.sessionDurationMinutes,
+                intermediateSessionToken = sessionStorage.intermediateSessionToken,
             ).apply {
                 launchSessionUpdater(dispatchers, sessionStorage)
             }
@@ -100,6 +101,7 @@ internal class PasswordsImpl internal constructor(
                     password = parameters.password,
                     sessionDurationMinutes = parameters.sessionDurationMinutes,
                     codeVerifier = codeVerifier,
+                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodesImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodesImpl.kt
@@ -47,6 +47,7 @@ internal class RecoveryCodesImpl(
                 memberId = parameters.memberId,
                 sessionDurationMinutes = parameters.sessionDurationMinutes,
                 recoveryCode = parameters.recoveryCode,
+                intermediateSessionToken = sessionStorage.intermediateSessionToken,
             ).apply {
                 if (this is StytchResult.Success) {
                     launchSessionUpdater(dispatchers, sessionStorage)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
@@ -61,11 +61,13 @@ internal class B2BSessionStorage(private val storageHelper: StorageHelper) {
         sessionToken: String?,
         sessionJwt: String?,
         session: B2BSessionData? = null,
+        intermediateSessionToken: String? = null,
     ) {
         synchronized(this) {
             this.sessionToken = sessionToken
             this.sessionJwt = sessionJwt
             this.memberSession = session
+            this.intermediateSessionToken = intermediateSessionToken
         }
     }
 
@@ -78,6 +80,7 @@ internal class B2BSessionStorage(private val storageHelper: StorageHelper) {
             sessionJwt = null
             memberSession = null
             member = null
+            intermediateSessionToken = null
         }
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.sessions
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.SessionExchangeResponse
+import com.stytch.sdk.b2b.SessionsAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.B2BSessionData
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
@@ -41,19 +41,19 @@ public interface B2BSessions {
      * Authenticates a Session and updates its lifetime by the specified session_duration_minutes.
      * If the session_duration_minutes is not specified, a Session will not be extended
      * @param authParams required to authenticate
-     * @return [AuthResponse]
+     * @return [SessionsAuthenticateResponse]
      */
-    public suspend fun authenticate(authParams: AuthParams): AuthResponse
+    public suspend fun authenticate(authParams: AuthParams): SessionsAuthenticateResponse
 
     /**
      * Authenticates a Session and updates its lifetime by the specified session_duration_minutes.
      * If the session_duration_minutes is not specified, a Session will not be extended
      * @param authParams required to authenticate
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [SessionsAuthenticateResponse]
      */
     public fun authenticate(
         authParams: AuthParams,
-        callback: (AuthResponse) -> Unit,
+        callback: (SessionsAuthenticateResponse) -> Unit,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.sessions
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.SessionExchangeResponse
+import com.stytch.sdk.b2b.SessionsAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.network.models.B2BSessionData
@@ -38,8 +38,8 @@ internal class B2BSessionsImpl internal constructor(
             }
         }
 
-    override suspend fun authenticate(authParams: B2BSessions.AuthParams): AuthResponse {
-        val result: AuthResponse
+    override suspend fun authenticate(authParams: B2BSessions.AuthParams): SessionsAuthenticateResponse {
+        val result: SessionsAuthenticateResponse
         withContext(dispatchers.io) {
             // do not revoke session here since we using stored data to authenticate
             // call backend endpoint
@@ -55,7 +55,7 @@ internal class B2BSessionsImpl internal constructor(
 
     override fun authenticate(
         authParams: B2BSessions.AuthParams,
-        callback: (AuthResponse) -> Unit,
+        callback: (SessionsAuthenticateResponse) -> Unit,
     ) {
         // call endpoint in IO thread
         externalScope.launch(dispatchers.ui) {
@@ -101,7 +101,7 @@ internal class B2BSessionsImpl internal constructor(
         sessionJwt: String?,
     ) {
         try {
-            sessionStorage.updateSession(sessionToken, sessionJwt)
+            sessionStorage.updateSession(sessionToken = sessionToken, sessionJwt = sessionJwt)
         } catch (ex: Exception) {
             throw StytchInternalError(ex)
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -80,6 +80,7 @@ internal class SSOImpl(
                     ssoToken = params.ssoToken,
                     sessionDurationMinutes = params.sessionDurationMinutes,
                     codeVerifier = codeVerifier,
+                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTPImpl.kt
@@ -22,6 +22,7 @@ internal class TOTPImpl(
                 organizationId = parameters.organizationId,
                 memberId = parameters.memberId,
                 expirationMinutes = parameters.expirationMinutes?.toInt(),
+                intermediateSessionToken = sessionStorage.intermediateSessionToken,
             )
         }
 
@@ -43,6 +44,7 @@ internal class TOTPImpl(
                 setMFAEnrollment = parameters.setMFAEnrollment,
                 setDefaultMfaMethod = parameters.setDefaultMFAMethod,
                 sessionDurationMinutes = parameters.sessionDurationMinutes.toInt(),
+                intermediateSessionToken = sessionStorage.intermediateSessionToken,
             ).apply {
                 launchSessionUpdater(dispatchers, sessionStorage)
             }

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/ActivityProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/ActivityProvider.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import java.lang.ref.WeakReference
 
 internal class ActivityProvider(application: Application) : Application.ActivityLifecycleCallbacks {
-    @Suppress("ktlint:standard:backing-property-naming")
     private var _currentActivity = WeakReference<Activity>(null)
     internal val currentActivity: Activity?
         get() = _currentActivity.get()

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -406,7 +406,7 @@ public object StytchClient {
         return withContext(dispatchers.io) {
             val token = uri.getQueryParameter(Constants.QUERY_TOKEN)
             if (token.isNullOrEmpty()) {
-                return@withContext DeeplinkHandledStatus.NotHandled(StytchDeeplinkMissingTokenError)
+                return@withContext DeeplinkHandledStatus.NotHandled(StytchDeeplinkMissingTokenError())
             }
             when (val tokenType = ConsumerTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
                 ConsumerTokenType.MAGIC_LINKS -> {
@@ -431,7 +431,7 @@ public object StytchClient {
                 }
                 else -> {
                     events.logEvent("deeplink_handled_failure", details = mapOf("token_type" to tokenType))
-                    DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError)
+                    DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError())
                 }
             }
         }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
@@ -113,7 +113,7 @@ internal class BiometricsImpl internal constructor(
         withContext(dispatchers.io) {
             try {
                 if (!isUsingKeystore() && !parameters.allowFallbackToCleartext) {
-                    throw StytchKeystoreUnavailableError
+                    throw StytchKeystoreUnavailableError()
                 }
                 if (isRegistrationAvailable(parameters.context)) {
                     removeRegistration()
@@ -181,7 +181,7 @@ internal class BiometricsImpl internal constructor(
                 try {
                     require(isRegistrationAvailable(parameters.context) && encryptedPrivateKey != null && iv != null)
                 } catch (e: IllegalArgumentException) {
-                    throw StytchNoBiometricsRegistrationError
+                    throw StytchNoBiometricsRegistrationError()
                 }
                 val cipher =
                     withContext(dispatchers.ui) {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
@@ -94,7 +94,7 @@ internal class PasskeysImpl internal constructor(
         get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
 
     override suspend fun register(parameters: Passkeys.RegisterParameters): WebAuthnRegisterResponse {
-        if (!isSupported) return StytchResult.Error(StytchPasskeysNotSupportedError)
+        if (!isSupported) return StytchResult.Error(StytchPasskeysNotSupportedError())
         return try {
             withContext(dispatchers.io) {
                 val startResponse =
@@ -132,7 +132,7 @@ internal class PasskeysImpl internal constructor(
     }
 
     override suspend fun authenticate(parameters: Passkeys.AuthenticateParameters): AuthResponse {
-        if (!isSupported) return StytchResult.Error(StytchPasskeysNotSupportedError)
+        if (!isSupported) return StytchResult.Error(StytchPasskeysNotSupportedError())
         return try {
             withContext(dispatchers.io) {
                 val startResponse =

--- a/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
@@ -78,7 +78,7 @@ internal class ConsumerSessionStorage(private val storageHelper: StorageHelper) 
 
     fun ensureSessionIsValidOrThrow() {
         if (sessionToken == null && sessionJwt == null) {
-            throw StytchNoCurrentSessionError
+            throw StytchNoCurrentSessionError()
         }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -7,7 +7,7 @@ import com.google.android.recaptcha.Recaptcha
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.magicLinks.B2BMagicLinks
 import com.stytch.sdk.b2b.network.StytchB2BApi
-import com.stytch.sdk.b2b.network.models.IB2BAuthData
+import com.stytch.sdk.b2b.network.models.SessionsAuthenticateResponseData
 import com.stytch.sdk.b2b.oauth.OAuth
 import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeeplinkResponse
@@ -161,7 +161,7 @@ internal class StytchB2BClientTest {
     @Test
     fun `should validate persisted sessions if applicable when calling StytchB2BClient configure`() {
         runBlocking {
-            val mockResponse: StytchResult<IB2BAuthData> =
+            val mockResponse: StytchResult<SessionsAuthenticateResponseData> =
                 mockk {
                     every { launchSessionUpdater(any(), any()) } just runs
                 }
@@ -182,7 +182,7 @@ internal class StytchB2BClientTest {
     @Test
     fun `should report the initialization state after configuration and initialization is complete`() {
         runTest {
-            val mockResponse: StytchResult<IB2BAuthData> =
+            val mockResponse: StytchResult<SessionsAuthenticateResponseData> =
                 mockk {
                     every { launchSessionUpdater(any(), any()) } just runs
                 }
@@ -369,7 +369,7 @@ internal class StytchB2BClientTest {
                 mockk<Uri> {
                     every { getQueryParameter(any()) } returns "MULTI_TENANT_MAGIC_LINKS"
                 }
-            val mockAuthResponse = mockk<AuthResponse>()
+            val mockAuthResponse = mockk<EMLAuthenticateResponse>()
             coEvery { mockMagicLinks.authenticate(any()) } returns mockAuthResponse
             val response = StytchB2BClient.handle(mockUri, 30U)
             coVerify { mockMagicLinks.authenticate(any()) }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
@@ -5,22 +5,13 @@ import org.junit.Test
 
 internal class DiscoveryTest {
     @Test
-    fun `Discovery DiscoverOrganizationsParameters have correct default values`() {
-        val params = Discovery.DiscoverOrganizationsParameters()
-        val expected = Discovery.DiscoverOrganizationsParameters(intermediateSessionToken = null)
-        assert(params == expected)
-    }
-
-    @Test
     fun `Discovery SessionExchangeParameters have correct default values`() {
         val params =
             Discovery.SessionExchangeParameters(
-                intermediateSessionToken = "intermediate-session-token",
                 organizationId = "organization-id",
             )
         val expected =
             Discovery.SessionExchangeParameters(
-                intermediateSessionToken = "intermediate-session-token",
                 organizationId = "organization-id",
                 sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
             )
@@ -29,13 +20,9 @@ internal class DiscoveryTest {
 
     @Test
     fun `Discovery CreateOrganizationParameters have correct default values`() {
-        val params =
-            Discovery.CreateOrganizationParameters(
-                intermediateSessionToken = "intermediate-session-token",
-            )
+        val params = Discovery.CreateOrganizationParameters()
         val expected =
             Discovery.CreateOrganizationParameters(
-                intermediateSessionToken = "intermediate-session-token",
                 organizationName = null,
                 organizationSlug = null,
                 organizationLogoUrl = null,

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.b2b.magicLinks
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
+import com.stytch.sdk.b2b.EMLAuthenticateResponse
 import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
@@ -108,7 +108,7 @@ internal class B2BMagicLinksImplTest {
 
     @Test
     fun `MagicLinksImpl authenticate with callback calls callback method`() {
-        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        val mockCallback = spyk<(EMLAuthenticateResponse) -> Unit>()
         impl.authenticate(authParameters, mockCallback)
         verify { mockCallback.invoke(any()) }
     }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -70,6 +70,7 @@ internal class B2BMagicLinksImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockB2BSessionStorage.intermediateSessionToken } returns ""
         impl =
             B2BMagicLinksImpl(
                 externalScope = TestScope(),
@@ -99,10 +100,10 @@ internal class B2BMagicLinksImplTest {
     fun `MagicLinksImpl authenticate delegates to api`() =
         runTest {
             every { mockStorageHelper.retrieveCodeVerifier() } returns ""
-            coEvery { mockEmailApi.authenticate(any(), any(), any()) } returns successfulAuthResponse
+            coEvery { mockEmailApi.authenticate(any(), any(), any(), any()) } returns successfulAuthResponse
             val response = impl.authenticate(authParameters)
             assert(response is StytchResult.Success)
-            coVerify { mockEmailApi.authenticate(any(), any(), any()) }
+            coVerify { mockEmailApi.authenticate(any(), any(), any(), any()) }
             verify { successfulAuthResponse.launchSessionUpdater(any(), any()) }
         }
 

--- a/sdk/src/test/java/com/stytch/sdk/b2b/otp/OTPImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/otp/OTPImplTest.kt
@@ -1,10 +1,10 @@
 package com.stytch.sdk.b2b.otp
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.BasicResponse
+import com.stytch.sdk.b2b.SMSAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
-import com.stytch.sdk.b2b.network.models.B2BAuthData
+import com.stytch.sdk.b2b.network.models.SMSAuthenticateResponseData
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
@@ -42,7 +42,7 @@ internal class OTPImplTest {
     private lateinit var impl: OTPImpl
     private val dispatcher = Dispatchers.Unconfined
     private val successfulBaseResponse = StytchResult.Success<BasicData>(mockk(relaxed = true))
-    private val successfulAuthResponse = StytchResult.Success<B2BAuthData>(mockk(relaxed = true))
+    private val successfulAuthResponse = StytchResult.Success<SMSAuthenticateResponseData>(mockk(relaxed = true))
 
     @Before
     fun before() {
@@ -100,7 +100,7 @@ internal class OTPImplTest {
     @Test
     fun `OTP SMS Authenticate with callback calls callback`() {
         coEvery { mockApi.authenticateSMSOTP(any(), any(), any(), any(), any()) } returns successfulAuthResponse
-        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        val mockCallback = spyk<(SMSAuthenticateResponse) -> Unit>()
         impl.sms.authenticate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -1,13 +1,14 @@
 package com.stytch.sdk.b2b.passwords
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.EmailResetResponse
+import com.stytch.sdk.b2b.PasswordResetByExistingPasswordResponse
 import com.stytch.sdk.b2b.PasswordStrengthCheckResponse
+import com.stytch.sdk.b2b.PasswordsAuthenticateResponse
 import com.stytch.sdk.b2b.SessionResetResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
-import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
+import com.stytch.sdk.b2b.network.models.PasswordResetByExistingPasswordResponseData
 import com.stytch.sdk.b2b.network.models.PasswordsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SessionResetResponseData
 import com.stytch.sdk.b2b.network.models.StrengthCheckResponseData
@@ -98,7 +99,7 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl authenticate with callback calls callback method`() {
         val mockkResponse = StytchResult.Success<PasswordsAuthenticateResponseData>(mockk(relaxed = true))
         coEvery { mockApi.authenticate(any(), any(), any(), any()) } returns mockkResponse
-        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        val mockCallback = spyk<(PasswordsAuthenticateResponse) -> Unit>()
         impl.authenticate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }
     }
@@ -186,7 +187,7 @@ internal class PasswordsImplTest {
     @Test
     fun `PasswordsImpl resetByExisting delegates to api`() =
         runTest {
-            val mockkResponse = StytchResult.Success<B2BAuthData>(mockk(relaxed = true))
+            val mockkResponse = StytchResult.Success<PasswordResetByExistingPasswordResponseData>(mockk(relaxed = true))
             coEvery { mockApi.resetByExisting(any(), any(), any(), any(), any()) } returns mockkResponse
             val response = impl.resetByExisting(mockk(relaxed = true))
             assert(response is StytchResult.Success)
@@ -196,9 +197,9 @@ internal class PasswordsImplTest {
 
     @Test
     fun `PasswordsImpl resetByExisting with callback calls callback method`() {
-        val mockkResponse = StytchResult.Success<B2BAuthData>(mockk(relaxed = true))
+        val mockkResponse = StytchResult.Success<PasswordResetByExistingPasswordResponseData>(mockk(relaxed = true))
         coEvery { mockApi.resetByExisting(any(), any(), any(), any(), any()) } returns mockkResponse
-        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        val mockCallback = spyk<(PasswordResetByExistingPasswordResponse) -> Unit>()
         impl.resetByExisting(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }
     }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -68,6 +68,7 @@ internal class PasswordsImplTest {
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         MockKAnnotations.init(this, true, true)
+        every { mockSessionStorage.intermediateSessionToken } returns ""
         impl =
             PasswordsImpl(
                 externalScope = TestScope(),
@@ -88,17 +89,17 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl authenticate delegates to api`() =
         runTest {
             val mockkResponse = StytchResult.Success<PasswordsAuthenticateResponseData>(mockk(relaxed = true))
-            coEvery { mockApi.authenticate(any(), any(), any(), any()) } returns mockkResponse
+            coEvery { mockApi.authenticate(any(), any(), any(), any(), any()) } returns mockkResponse
             val response = impl.authenticate(mockk(relaxed = true))
             assert(response is StytchResult.Success)
-            coVerify { mockApi.authenticate(any(), any(), any(), any()) }
+            coVerify { mockApi.authenticate(any(), any(), any(), any(), any()) }
             verify { mockkResponse.launchSessionUpdater(any(), any()) }
         }
 
     @Test
     fun `PasswordsImpl authenticate with callback calls callback method`() {
         val mockkResponse = StytchResult.Success<PasswordsAuthenticateResponseData>(mockk(relaxed = true))
-        coEvery { mockApi.authenticate(any(), any(), any(), any()) } returns mockkResponse
+        coEvery { mockApi.authenticate(any(), any(), any(), any(), any()) } returns mockkResponse
         val mockCallback = spyk<(PasswordsAuthenticateResponse) -> Unit>()
         impl.authenticate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }
@@ -166,10 +167,10 @@ internal class PasswordsImplTest {
         runTest {
             every { mockStorageHelper.retrieveCodeVerifier() } returns ""
             val mockkResponse = StytchResult.Success<EmailResetResponseData>(mockk(relaxed = true))
-            coEvery { mockApi.resetByEmail(any(), any(), any(), any()) } returns mockkResponse
+            coEvery { mockApi.resetByEmail(any(), any(), any(), any(), any()) } returns mockkResponse
             val response = impl.resetByEmail(mockk(relaxed = true))
             assert(response is StytchResult.Success)
-            coVerify { mockApi.resetByEmail(any(), any(), any(), any()) }
+            coVerify { mockApi.resetByEmail(any(), any(), any(), any(), any()) }
             verify { mockkResponse.launchSessionUpdater(any(), any()) }
         }
 
@@ -177,7 +178,7 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl resetByEmail with callback calls callback method`() {
         every { mockStorageHelper.retrieveCodeVerifier() } returns ""
         val mockkResponse = StytchResult.Success<EmailResetResponseData>(mockk(relaxed = true))
-        coEvery { mockApi.resetByEmail(any(), any(), any(), any()) } returns mockkResponse
+        coEvery { mockApi.resetByEmail(any(), any(), any(), any(), any()) } returns mockkResponse
         val mockCallback = spyk<(EmailResetResponse) -> Unit>()
         impl.resetByEmail(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
@@ -1,12 +1,12 @@
 package com.stytch.sdk.b2b.sessions
 
-import com.stytch.sdk.b2b.AuthResponse
 import com.stytch.sdk.b2b.SessionExchangeResponse
+import com.stytch.sdk.b2b.SessionsAuthenticateResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.network.models.B2BSessionData
-import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.SessionExchangeResponseData
+import com.stytch.sdk.b2b.network.models.SessionsAuthenticateResponseData
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StytchDispatchers
@@ -48,7 +48,7 @@ internal class B2BSessionsImplTest {
     private lateinit var impl: B2BSessionsImpl
     private val dispatcher = Dispatchers.Unconfined
 
-    private val successfulAuthResponse = StytchResult.Success<IB2BAuthData>(mockk(relaxed = true))
+    private val successfulAuthResponse = StytchResult.Success<SessionsAuthenticateResponseData>(mockk(relaxed = true))
     private val authParameters = B2BSessions.AuthParams(sessionDurationMinutes = 30U)
     private val successfulExchangeResponse = StytchResult.Success<SessionExchangeResponseData>(mockk(relaxed = true))
 
@@ -112,7 +112,7 @@ internal class B2BSessionsImplTest {
     @Test
     fun `SessionsImpl authenticate with callback calls callback method`() {
         coEvery { mockApi.authenticate(any()) } returns successfulAuthResponse
-        val mockCallback = spyk<(AuthResponse) -> Unit>()
+        val mockCallback = spyk<(SessionsAuthenticateResponse) -> Unit>()
         impl.authenticate(authParameters, mockCallback)
         verify { mockCallback.invoke(eq(successfulAuthResponse)) }
     }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -66,6 +66,7 @@ internal class SSOImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockB2BSessionStorage.intermediateSessionToken } returns ""
         impl =
             SSOImpl(
                 externalScope = TestScope(),
@@ -95,10 +96,10 @@ internal class SSOImplTest {
         runTest {
             every { mockStorageHelper.retrieveCodeVerifier() } returns ""
             val mockResponse = StytchResult.Success<SSOAuthenticateResponseData>(mockk(relaxed = true))
-            coEvery { mockApi.authenticate(any(), any(), any()) } returns mockResponse
+            coEvery { mockApi.authenticate(any(), any(), any(), any()) } returns mockResponse
             val response = impl.authenticate(SSO.AuthenticateParams(""))
             assert(response is StytchResult.Success)
-            coVerify { mockApi.authenticate(any(), any(), any()) }
+            coVerify { mockApi.authenticate(any(), any(), any(), any()) }
             verify { mockResponse.launchSessionUpdater(any(), any()) }
         }
 

--- a/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
@@ -77,25 +77,25 @@ internal class StytchErrorTests {
 
     @Test
     fun `StytchDeeplinkUnkownTokenTypeError has expected properties`() {
-        val error = StytchDeeplinkUnkownTokenTypeError
+        val error = StytchDeeplinkUnkownTokenTypeError()
         assert(error.message == "The deeplink received has an unknown token type.")
     }
 
     @Test
     fun `StytchDeeplinkMissingTokenError has expected properties`() {
-        val error = StytchDeeplinkMissingTokenError
+        val error = StytchDeeplinkMissingTokenError()
         assert(error.message == "The deeplink received has a missing token value.")
     }
 
     @Test
     fun `StytchNoCurrentSessionError has expected properties`() {
-        val error = StytchNoCurrentSessionError
+        val error = StytchNoCurrentSessionError()
         assert(error.message == "There is no session currently available.")
     }
 
     @Test
     fun `StytchNoBiometricsRegistrationError has expected properties`() {
-        val error = StytchNoBiometricsRegistrationError
+        val error = StytchNoBiometricsRegistrationError()
         assert(
             error.message == "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.",
         )
@@ -103,7 +103,7 @@ internal class StytchErrorTests {
 
     @Test
     fun `StytchKeystoreUnavailableError has expected properties`() {
-        val error = StytchKeystoreUnavailableError
+        val error = StytchKeystoreUnavailableError()
         assert(
             error.message == "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.",
         )
@@ -127,19 +127,19 @@ internal class StytchErrorTests {
 
     @Test
     fun `StytchMissingAuthorizationCredentialIdTokenError has expected properties`() {
-        val error = StytchMissingAuthorizationCredentialIdTokenError
+        val error = StytchMissingAuthorizationCredentialIdTokenError()
         assert(error.message == "The authorization credential is missing an ID token.")
     }
 
     @Test
     fun `StytchInvalidAuthorizationCredentialError has expected properties`() {
-        val error = StytchInvalidAuthorizationCredentialError
+        val error = StytchInvalidAuthorizationCredentialError()
         assert(error.message == "The authorization credential is invalid.")
     }
 
     @Test
     fun `StytchPasskeysNotSupportedError has expected properties`() {
-        val error = StytchPasskeysNotSupportedError
+        val error = StytchPasskeysNotSupportedError()
         assert(error.message == "Passkeys are not supported on this device.")
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/common/extensions/ThrowableExtTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/common/extensions/ThrowableExtTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 internal class ThrowableExtTest {
     @Test
     fun `A StytchError returns the same StytchError`() {
-        val originalException = StytchDeeplinkUnkownTokenTypeError
+        val originalException = StytchDeeplinkUnkownTokenTypeError()
         val returnedException = originalException.toStytchError()
         assert(originalException == returnedException)
     }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -131,7 +131,7 @@ internal class BiometricsImplTest {
             every { mockStorageHelper.preferenceExists(any()) } returns false
             every {
                 mockSessionStorage.ensureSessionIsValidOrThrow()
-            } throws StytchNoCurrentSessionError
+            } throws StytchNoCurrentSessionError()
             val result = impl.register(mockk(relaxed = true))
             require(result is StytchResult.Error)
             assert(result.exception is StytchNoCurrentSessionError)


### PR DESCRIPTION
Linear Ticket: [SDK-1525](https://linear.app/stytch/issue/SDK-1525)

## Changes:

1. Adds IST as property for requests and responses, as appropriate
2. Splits out the authenticate response interface to delineate between Full and MFA responses
3. Auto populates IST in requests where appropriate
4. Correctly persists IST, tokens, and session data
5. Adds a few new endpoint-specific response types to better match JS SDK

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A