### PR TITLE
SDK-1558 fix docs workflow

### DIFF
--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -71,8 +71,8 @@ jobs:
 
     - name: Zip docs site
       run: |
-        cd main/sdk/build/dokka/htmlPartial
-        zip -r ../../../../../Docs.zip .
+        cd main/docs
+        zip -r ../../Docs.zip .
         cd -
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Zip docs site
       run: |
-        cd main/sdk/build/dokka/html
+        cd main/sdk/build/dokka/htmlPartial
         zip -r ../../../../../Docs.zip .
         cd -
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -67,7 +67,7 @@ jobs:
         STYTCH_UI_PUBLIC_TOKEN: 'abc123'
         UI_GOOGLE_CLIENT_ID: 'abc123'
       working-directory: main
-      run: ./gradlew sdk:dokkaHtmlMultiModule
+      run: ./gradlew dokkaHtmlMultiModule
 
     - name: Zip docs site
       run: |


### PR DESCRIPTION
Linear Ticket: [SDK-1558](https://linear.app/stytch/issue/SDK-1558)

## Changes:

1. Just two small changes to account for using multi-module dokka instead of versioned docs

## Notes:

- This gets us documentation for both Headless and UI (multi-module) but we lose the versioning support. Older versions (0.18.1 and older) can still be accessed at https://stytchauth.github.io/stytch-android/older/[VERSION]/index.html, but going forward, the docs will only be for the latest versions

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A