### PR TITLE
SDK-1613 Fix uiTest runner

### DIFF
--- a/.github/workflows/uiTests.yml
+++ b/.github/workflows/uiTests.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -21,27 +21,12 @@ jobs:
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-        
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd
 
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: run ui tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
Linear Ticket: [SDK-1613](https://linear.app/stytch/issue/SDK-1613)

## Changes:

1. Removes AVD caching, because that was causing issues previously
2. Switch to ubuntu runner, as that's now the recommended runner

## Notes:

- Not only do the tests run now, they run much faster! Woohoo!

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A