### PR TITLE
Add some constraints for gradle plugins that aren't updated with fixes yet

### DIFF
--- a/b2bExampleApp/build.gradle
+++ b/b2bExampleApp/build.gradle
@@ -38,10 +38,9 @@ android {
                 b2bOrganizationId = STYTCH_B2B_ORG_ID
             }
             buildConfigField "String", "STYTCH_B2B_ORG_ID", "\"$b2bOrganizationId\""
-            minifyEnabled true
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/b2bExampleApp/build.gradle
+++ b/b2bExampleApp/build.gradle
@@ -40,7 +40,7 @@ android {
             buildConfigField "String", "STYTCH_B2B_ORG_ID", "\"$b2bOrganizationId\""
         }
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
         classpath("org.jetbrains.dokka:versioning-plugin:$dokka_version")
-        classpath("com.android.tools:r8:8.3.37")
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
             classpath("org.apache.commons:commons-compress:1.26.0")
             classpath("org.bitbucket.b_c:jose4j:0.9.3")
             classpath("io.netty:netty-codec-http2:4.1.100.Final")
+            classpath("org.bouncycastle:bcpkix-jdk18on:1.78.1")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,15 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
         classpath("org.jetbrains.dokka:versioning-plugin:$dokka_version")
-        classpath("com.android.tools:r8:8.2.33")
+        classpath("com.android.tools:r8:8.3.37")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        constraints {
+            classpath("org.apache.commons:commons-compress:1.26.0")
+            classpath("org.bitbucket.b_c:jose4j:0.9.3")
+            classpath("io.netty:netty-codec-http2:4.1.100.Final")
+        }
     }
 }
 

--- a/consumerExampleApp/build.gradle
+++ b/consumerExampleApp/build.gradle
@@ -44,7 +44,6 @@ android {
                 passkeysDomain = PASSKEYS_DOMAIN
             }
             buildConfigField "String", "PASSKEYS_DOMAIN", "\"$passkeysDomain\""
-            minifyEnabled true
         }
         release {
             minifyEnabled false


### PR DESCRIPTION
A handful of the reported vulns are required by and still present in the latest Gradle version. Add some constraints to force using the fixed versions.

Also, don't minify debug builds anymore, that was just for testing.