### PR TITLE
Handle IST 10 minute expiration

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
@@ -19,4 +19,6 @@ public object Constants {
     internal const val PREFERENCES_NAME_SESSION_JWT = "session_jwt"
     internal const val PREFERENCES_NAME_SESSION_TOKEN = "session_token"
     internal const val PREFERENCES_NAME_IST = "intermediate_session_token"
+    internal const val PREFERENCES_NAME_IST_EXPIRATION = "intermediate_session_token_expiration"
+    internal const val IST_EXPIRATION_TIME = 10 * 60 * 1000L // 10 minutes
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -51,7 +51,19 @@ internal object StorageHelper {
         }
     }
 
+    internal fun saveLong(
+        name: String,
+        value: Long,
+    ) {
+        with(sharedPreferences.edit()) {
+            putLong(name, value)
+            apply()
+        }
+    }
+
     internal fun getBoolean(name: String): Boolean = sharedPreferences.getBoolean(name, false)
+
+    internal fun getLong(name: String): Long = sharedPreferences.getLong(name, 0L)
 
     /**
      * Load and decrypt value from SharedPreferences

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionStorageTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionStorageTest.kt
@@ -58,6 +58,7 @@ internal class B2BSessionStorageTest {
     @Test
     fun `SessionStorage setters delegate to storageHelper`() {
         every { mockStorageHelper.saveValue(any(), any()) } just runs
+        every { mockStorageHelper.saveLong(any(), any()) } just runs
         storage.updateSession(
             sessionToken = "mySessionToken",
             sessionJwt = "mySessionJwt",
@@ -72,6 +73,7 @@ internal class B2BSessionStorageTest {
     fun `SessionStorage updateSession correctly updates sessionData`() {
         // we're not testing sessiontoken or sessionjwt here, because the getters/setters are already tested above
         every { mockStorageHelper.saveValue(any(), any()) } just runs
+        every { mockStorageHelper.saveLong(any(), any()) } just runs
         val mockedSessionData = mockk<B2BSessionData>(relaxed = true)
         storage.updateSession(
             sessionToken = "mySessionToken",
@@ -85,6 +87,7 @@ internal class B2BSessionStorageTest {
     fun `SessionStorage revoke properly nulls out session data`() {
         // we're not testing sessiontoken or sessionjwt here, because the getters/setters are already tested above
         every { mockStorageHelper.saveValue(any(), any()) } just runs
+        every { mockStorageHelper.saveLong(any(), any()) } just runs
         storage.revoke()
         assert(storage.memberSession == null)
         assert(storage.member == null)


### PR DESCRIPTION
Linear Ticket: [SDK-1716](https://linear.app/stytch/issue/SDK-1716)

## Changes:

1. Add a persisted expiration timestamp for ISTs and enforce that we don't persist/use ISTs after the 10 minute expiration

## Notes:

- This is (basically) the same fix we did for RN. @nidal-stytch this is what I mentioned we'd need to do in iOS, too, when we get to SDK-1526

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A