### PR TITLE
SDK-1727 require non null session token and session jwt in updatesession

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.23.0'
+  PUBLISH_VERSION = '0.24.0'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -86,13 +86,13 @@ public interface B2BSessions {
     )
 
     /**
-     * Updates the current session with a sessionToken and/or sessionJwt
+     * Updates the current session with a sessionToken and sessionJwt
      * @param sessionToken
      * @param sessionJwt
      */
     public fun updateSession(
-        sessionToken: String?,
-        sessionJwt: String?,
+        sessionToken: String,
+        sessionJwt: String,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
@@ -116,8 +116,8 @@ internal class B2BSessionsImpl internal constructor(
      * @throws StytchInternalError if failed to save data
      */
     override fun updateSession(
-        sessionToken: String?,
-        sessionJwt: String?,
+        sessionToken: String,
+        sessionJwt: String,
     ) {
         try {
             sessionStorage.updateSession(sessionToken = sessionToken, sessionJwt = sessionJwt)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
@@ -90,12 +90,12 @@ public interface Sessions {
     )
 
     /**
-     * Updates the current session with a sessionToken and/or sessionJwt
+     * Updates the current session with a sessionToken and sessionJwt
      * @param sessionToken
      * @param sessionJwt
      */
     public fun updateSession(
-        sessionToken: String?,
-        sessionJwt: String?,
+        sessionToken: String,
+        sessionJwt: String,
     )
 }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
@@ -119,8 +119,8 @@ internal class SessionsImpl internal constructor(
      * @throws StytchInternalError if failed to save data
      */
     override fun updateSession(
-        sessionToken: String?,
-        sessionJwt: String?,
+        sessionToken: String,
+        sessionJwt: String,
     ) {
         try {
             sessionStorage.updateSession(sessionToken, sessionJwt)


### PR DESCRIPTION
Linear Ticket: [SDK-1727](https://linear.app/stytch/issue/SDK-1727)

## Changes:

1. Requires a non-null session token and JWT to manually update/hydrate a session

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A