### PR TITLE
More dependency updates

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,6 +1,7 @@
 name: Dependency Submission
 
 on:
+  workflow_dispatch:
   push:
     branches: [ 'main' ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
         classpath("org.jetbrains.dokka:versioning-plugin:$dokka_version")
         classpath(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2")) // Force upgrade Dokka dependency
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
@@ -35,6 +34,8 @@ buildscript {
             classpath("io.netty:netty-codec-http2:4.1.111.Final")
             classpath("org.bouncycastle:bcpkix-jdk18on:1.78.1")
             classpath("com.google.jimfs:jimfs:1.3.0")
+            classpath("io.grpc:grpc-netty:1.65.0")
+            classpath("com.google.guava:guava:32.0.1-jre")
         }
     }
 }
@@ -77,6 +78,14 @@ allprojects {
     ktlint {
         android = true
         version = "1.2.1"
+    }
+    configurations.all {
+        resolutionStrategy {
+            force("com.fasterxml.woodstox:woodstox-core:6.4.0")
+            force("io.grpc:grpc-netty:1.65.0")
+            force("com.google.guava:guava:32.0.1-jre")
+            force("io.netty:netty-codec-http:4.1.111.Final")
+        }
     }
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -84,6 +84,8 @@ tasks.named("dokkaHtmlPartial").configure {
     dependsOn(tasks.named("kaptDebugKotlin"))
     dependsOn(tasks.named("kaptReleaseKotlin"))
     dependencies {
+        dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
+        dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
         dokkaPlugin("org.jetbrains.dokka:versioning-plugin:$dokka_version")
     }
     moduleName.set("Stytch Android")
@@ -152,14 +154,12 @@ dependencies {
     implementation "androidx.credentials:credentials:1.2.2"
     implementation "androidx.credentials:credentials-play-services-auth:1.2.2"
     implementation "com.google.android.libraries.identity.googleid:googleid:1.1.0"
-    dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
-    dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
 
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "io.mockk:mockk:1.13.8"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2'
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:$okhttp_version")
     testImplementation("org.json:json:20231013")
 }
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -89,8 +89,6 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-tooling"
     implementation "com.googlecode.libphonenumber:libphonenumber:8.12.52"
     api project(":sdk")
-    dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
-    dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
     testImplementation 'junit:junit:4.13.2'
     testImplementation "io.mockk:mockk:1.13.8"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2'
@@ -106,6 +104,8 @@ dependencies {
 
 tasks.named("dokkaHtmlPartial").configure {
     dependencies {
+        dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
+        dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
         dokkaPlugin("org.jetbrains.dokka:versioning-plugin:$dokka_version")
     }
     moduleName.set("Stytch Android UI")


### PR DESCRIPTION
Verified that _these_ changes will officially close out all remaining dependabot issues by (temporarily) switching the GH default branch and force running the dependency submission action