### PR TITLE
SDK-1825 SDK-1828 PKCE lifecycle fixes

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -29,21 +29,11 @@ internal class B2BMagicLinksImpl internal constructor(
     override suspend fun authenticate(parameters: B2BMagicLinks.AuthParameters): EMLAuthenticateResponse {
         var result: EMLAuthenticateResponse
         withContext(dispatchers.io) {
-            val codeVerifier: String
-
-            try {
-                codeVerifier = storageHelper.retrieveCodeVerifier()!!
-            } catch (ex: Exception) {
-                result = StytchResult.Error(StytchMissingPKCEError(ex))
-                return@withContext
-            }
-
-            // call backend endpoint
             result =
                 emailApi.authenticate(
                     token = parameters.token,
                     sessionDurationMinutes = parameters.sessionDurationMinutes,
-                    codeVerifier = codeVerifier,
+                    codeVerifier = storageHelper.retrieveCodeVerifier(),
                     intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
                     storageHelper.clearPKCE()

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -46,6 +46,7 @@ internal class B2BMagicLinksImpl internal constructor(
                     codeVerifier = codeVerifier,
                     intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
+                    storageHelper.clearPKCE()
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }
@@ -80,7 +81,9 @@ internal class B2BMagicLinksImpl internal constructor(
                 discoveryApi.authenticate(
                     token = parameters.token,
                     codeVerifier = codeVerifier,
-                )
+                ).apply {
+                    storageHelper.clearPKCE()
+                }
         }
         return result
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -183,7 +183,7 @@ internal object StytchB2BApi {
             suspend fun authenticate(
                 token: String,
                 sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
-                codeVerifier: String,
+                codeVerifier: String? = null,
                 intermediateSessionToken: String? = null,
             ): StytchResult<B2BEMLAuthenticateData> =
                 safeB2BApiCall {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -75,7 +75,7 @@ internal object B2BRequests {
             @Json(name = "magic_links_token")
             val token: String,
             @Json(name = "pkce_code_verifier")
-            val codeVerifier: String,
+            val codeVerifier: String? = null,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
             @Json(name = "intermediate_session_token")

--- a/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -44,6 +44,7 @@ internal class OAuthImpl(
                 pkceCodeVerifier = pkce,
                 intermediateSessionToken = sessionStorage.intermediateSessionToken,
             ).apply {
+                storageHelper.clearPKCE()
                 when (this) {
                     is StytchResult.Success -> StytchB2BClient.events.logEvent("b2b_oauth_success")
                     is StytchResult.Error -> StytchB2BClient.events.logEvent("b2b_oauth_failure", null, this.exception)
@@ -128,6 +129,7 @@ internal class OAuthImpl(
                     pkceCodeVerifier = pkce,
                     discoveryOauthToken = parameters.discoveryOauthToken,
                 ).apply {
+                    storageHelper.clearPKCE()
                     when (this) {
                         is StytchResult.Success -> StytchB2BClient.events.logEvent("b2b_discovery_oauth_success")
                         is StytchResult.Error ->

--- a/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -103,6 +103,7 @@ internal class PasswordsImpl internal constructor(
                     codeVerifier = codeVerifier,
                     intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
+                    storageHelper.clearPKCE()
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -82,6 +82,7 @@ internal class SSOImpl(
                     codeVerifier = codeVerifier,
                     intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
+                    storageHelper.clearPKCE()
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -96,6 +96,11 @@ internal object StorageHelper {
 
     internal fun retrieveCodeVerifier(): String? = loadValue(PREFERENCES_CODE_VERIFIER)
 
+    internal fun clearPKCE() {
+        saveValue(PREFERENCES_CODE_CHALLENGE, null)
+        saveValue(PREFERENCES_CODE_VERIFIER, null)
+    }
+
     internal fun getPKCECodePair(): PKCECodePair =
         PKCECodePair(
             codeChallenge = loadValue(PREFERENCES_CODE_CHALLENGE),

--- a/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
@@ -42,6 +42,7 @@ internal class MagicLinksImpl internal constructor(
                     parameters.sessionDurationMinutes,
                     codeVerifier,
                 ).apply {
+                    storageHelper.clearPKCE()
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
@@ -60,6 +60,7 @@ internal class OAuthImpl(
                 sessionDurationMinutes = parameters.sessionDurationMinutes,
                 codeVerifier = pkce,
             ).apply {
+                storageHelper.clearPKCE()
                 when (this) {
                     is StytchResult.Success -> StytchClient.events.logEvent("oauth_success")
                     is StytchResult.Error -> StytchClient.events.logEvent("oauth_failure", null, this.exception)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -136,6 +136,7 @@ internal class PasswordsImpl internal constructor(
                     parameters.sessionDurationMinutes,
                     codeVerifier,
                 ).apply {
+                    storageHelper.clearPKCE()
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -71,6 +71,7 @@ internal class B2BMagicLinksImplTest {
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockB2BSessionStorage.intermediateSessionToken } returns ""
+        every { mockStorageHelper.clearPKCE() } just runs
         impl =
             B2BMagicLinksImpl(
                 externalScope = TestScope(),
@@ -105,6 +106,7 @@ internal class B2BMagicLinksImplTest {
             assert(response is StytchResult.Success)
             coVerify { mockEmailApi.authenticate(any(), any(), any(), any()) }
             verify { successfulAuthResponse.launchSessionUpdater(any(), any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test
@@ -199,6 +201,7 @@ internal class B2BMagicLinksImplTest {
             coEvery { mockDiscoveryApi.authenticate(any(), any()) } returns mockk(relaxed = true)
             impl.discoveryAuthenticate(mockk(relaxed = true))
             coVerify { mockDiscoveryApi.authenticate(any(), any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
@@ -58,6 +58,7 @@ internal class OAuthImplTest {
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockStorageHelper.loadValue(any()) } returns ""
         every { mockStorageHelper.saveValue(any(), any()) } just runs
+        every { mockStorageHelper.clearPKCE() } just runs
         mockkObject(StytchB2BApi)
         every { StytchB2BApi.isInitialized } returns true
         every { mockSessionStorage.intermediateSessionToken } returns null
@@ -100,6 +101,7 @@ internal class OAuthImplTest {
             require(result is StytchResult.Error)
             assert(result.exception is StytchAPIError)
             coVerify { mockApi.authenticate(any(), any(), any(), "code-challenge", any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test
@@ -113,6 +115,7 @@ internal class OAuthImplTest {
             val result = impl.authenticate(mockk(relaxed = true))
             require(result is StytchResult.Success)
             coVerify { mockApi.authenticate(any(), any(), any(), "code-challenge", any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -69,6 +69,7 @@ internal class PasswordsImplTest {
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         MockKAnnotations.init(this, true, true)
         every { mockSessionStorage.intermediateSessionToken } returns ""
+        every { mockStorageHelper.clearPKCE() } just runs
         impl =
             PasswordsImpl(
                 externalScope = TestScope(),
@@ -172,6 +173,7 @@ internal class PasswordsImplTest {
             assert(response is StytchResult.Success)
             coVerify { mockApi.resetByEmail(any(), any(), any(), any(), any()) }
             verify { mockkResponse.launchSessionUpdater(any(), any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test
@@ -183,6 +185,7 @@ internal class PasswordsImplTest {
         impl.resetByEmail(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }
         verify { mockkResponse.launchSessionUpdater(any(), any()) }
+        verify(exactly = 1) { mockStorageHelper.clearPKCE() }
     }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -67,6 +67,7 @@ internal class SSOImplTest {
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockB2BSessionStorage.intermediateSessionToken } returns ""
+        every { mockStorageHelper.clearPKCE() } just runs
         impl =
             SSOImpl(
                 externalScope = TestScope(),
@@ -101,6 +102,7 @@ internal class SSOImplTest {
             assert(response is StytchResult.Success)
             coVerify { mockApi.authenticate(any(), any(), any(), any()) }
             verify { mockResponse.launchSessionUpdater(any(), any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
@@ -65,6 +65,7 @@ internal class MagicLinksImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockStorageHelper.clearPKCE() } just runs
         impl =
             MagicLinksImpl(
                 externalScope = TestScope(),
@@ -98,6 +99,7 @@ internal class MagicLinksImplTest {
             assert(response is StytchResult.Success)
             coVerify { mockApi.authenticate(any(), any(), any()) }
             verify { successfulAuthResponse.launchSessionUpdater(any(), any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -58,6 +58,7 @@ internal class OAuthImplTest {
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockStorageHelper.loadValue(any()) } returns ""
         every { mockStorageHelper.saveValue(any(), any()) } just runs
+        every { mockStorageHelper.clearPKCE() } just runs
         mockkObject(StytchApi)
         every { StytchApi.isInitialized } returns true
         StytchClient.deviceInfo = mockk(relaxed = true)
@@ -126,6 +127,7 @@ internal class OAuthImplTest {
             require(result is StytchResult.Error)
             assert(result.exception is StytchAPIError)
             coVerify { mockApi.authenticateWithThirdPartyToken(any(), any(), "code-challenge") }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test
@@ -139,6 +141,7 @@ internal class OAuthImplTest {
             val result = impl.authenticate(mockk(relaxed = true))
             require(result is StytchResult.Success)
             coVerify { mockApi.authenticateWithThirdPartyToken(any(), any(), "code-challenge") }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -79,6 +79,7 @@ internal class PasswordsImplTest {
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         MockKAnnotations.init(this, true, true)
+        every { mockStorageHelper.clearPKCE() } just runs
         impl =
             PasswordsImpl(
                 externalScope = TestScope(),
@@ -186,6 +187,7 @@ internal class PasswordsImplTest {
             impl.resetByEmail(resetByEmailParameters)
             coVerify { mockApi.resetByEmail(any(), any(), any(), any()) }
             verify { successfulAuthResponse.launchSessionUpdater(any(), any()) }
+            verify(exactly = 1) { mockStorageHelper.clearPKCE() }
         }
 
     @Test


### PR DESCRIPTION
[SDK-1825](https://linear.app/stytch/issue/SDK-1825)
[SDK-1828](https://linear.app/stytch/issue/SDK-1828)

## Changes:

1. Clear the local PKCE values every time they are used to prevent storing/retrieving outdated tokens, or passing them to endpoints that don't expect them (ie: B2B magic links authenticate during an invite flow)
2. Make the PKCE code verifier optional for B2B magic links authenticate

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A