### PR TITLE
SDK-1834 Fix Dokka issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
         classpath("org.jetbrains.dokka:versioning-plugin:$dokka_version")
-        classpath(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2")) // Force upgrade Dokka dependency
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -84,8 +84,6 @@ tasks.named("dokkaHtmlPartial").configure {
     dependsOn(tasks.named("kaptDebugKotlin"))
     dependsOn(tasks.named("kaptReleaseKotlin"))
     dependencies {
-        dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
-        dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
         dokkaPlugin("org.jetbrains.dokka:versioning-plugin:$dokka_version")
     }
     moduleName.set("Stytch Android")

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -104,8 +104,6 @@ dependencies {
 
 tasks.named("dokkaHtmlPartial").configure {
     dependencies {
-        dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
-        dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
         dokkaPlugin("org.jetbrains.dokka:versioning-plugin:$dokka_version")
     }
     moduleName.set("Stytch Android UI")


### PR DESCRIPTION
Linear Ticket: [SDK-1834](https://linear.app/stytch/issue/SDK-1834)

## Changes:

1. Don't force jackson BOM upgrade, rely on just the woodstox version resolution to hopefully avoid dependabot issues

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A