### PR TITLE
Only show password creation on new user screen if passwords are enabled

### DIFF
--- a/ui/src/androidTest/kotlin/com/stytch/sdk/ui/data/StytchUIConfigTypes.kt
+++ b/ui/src/androidTest/kotlin/com/stytch/sdk/ui/data/StytchUIConfigTypes.kt
@@ -69,6 +69,7 @@ internal val REALISTIC_STYTCH_UI_CONFIG_EML =
                 products =
                     listOf(
                         StytchProduct.EMAIL_MAGIC_LINKS,
+                        StytchProduct.PASSWORDS,
                     ),
                 emailMagicLinksOptions = EmailMagicLinksOptions(),
                 passwordOptions = PasswordOptions(),
@@ -90,6 +91,7 @@ internal val REALISTIC_STYTCH_UI_CONFIG_EOTP =
                 products =
                     listOf(
                         StytchProduct.OTP,
+                        StytchProduct.PASSWORDS,
                     ),
                 emailMagicLinksOptions = EmailMagicLinksOptions(),
                 passwordOptions = PasswordOptions(),

--- a/ui/src/main/kotlin/com/stytch/sdk/ui/screens/NewUserScreen.kt
+++ b/ui/src/main/kotlin/com/stytch/sdk/ui/screens/NewUserScreen.kt
@@ -46,6 +46,7 @@ internal object NewUserScreen : AndroidScreen(), Parcelable {
         val hasEmailOTP =
             productConfig.products.contains(StytchProduct.OTP) &&
                 productConfig.otpOptions.methods.contains(OTPMethods.EMAIL)
+        val hasPasswords = productConfig.products.contains(StytchProduct.PASSWORDS)
         val viewModel =
             viewModel<NewUserScreenViewModel>(
                 factory = NewUserScreenViewModel.factory(context.savedStateHandle),
@@ -70,6 +71,7 @@ internal object NewUserScreen : AndroidScreen(), Parcelable {
             },
             hasEML = hasEML,
             hasEmailOTP = hasEmailOTP,
+            hasPasswords = hasPasswords,
             onSendEML = { viewModel.sendEmailMagicLink(productConfig.emailMagicLinksOptions) },
             onSendEmailOTP = { viewModel.sendEmailOTP(productConfig.otpOptions) },
         )
@@ -85,6 +87,7 @@ private fun NewUserScreenComposable(
     onEmailAndPasswordSubmitted: () -> Unit,
     hasEML: Boolean,
     hasEmailOTP: Boolean,
+    hasPasswords: Boolean,
     onSendEML: () -> Unit,
     onSendEmailOTP: () -> Unit,
 ) {
@@ -105,23 +108,29 @@ private fun NewUserScreenComposable(
                     },
                 onClick = { if (hasEML) onSendEML() else onSendEmailOTP() },
             )
-            Spacer(modifier = Modifier.height(24.dp))
-            DividerWithText(text = stringResource(id = R.string.or))
-            Spacer(modifier = Modifier.height(24.dp))
-            BodyText(text = AnnotatedString(stringResource(id = R.string.finish_creating)))
+            if (hasPasswords) {
+                Spacer(modifier = Modifier.height(24.dp))
+                DividerWithText(text = stringResource(id = R.string.or))
+                Spacer(modifier = Modifier.height(24.dp))
+                BodyText(text = AnnotatedString(stringResource(id = R.string.finish_creating)))
+            }
         } else {
-            PageTitle(
-                text = stringResource(id = R.string.create_account),
-                textAlign = TextAlign.Start,
+            if (hasPasswords) {
+                PageTitle(
+                    text = stringResource(id = R.string.create_account),
+                    textAlign = TextAlign.Start,
+                )
+            }
+        }
+        if (hasPasswords) {
+            EmailAndPasswordEntry(
+                emailState = uiState.emailState,
+                onEmailAddressChanged = onEmailAddressChanged,
+                passwordState = uiState.passwordState,
+                onPasswordChanged = onPasswordChanged,
+                onSubmit = onEmailAndPasswordSubmitted,
             )
         }
-        EmailAndPasswordEntry(
-            emailState = uiState.emailState,
-            onEmailAddressChanged = onEmailAddressChanged,
-            passwordState = uiState.passwordState,
-            onPasswordChanged = onPasswordChanged,
-            onSubmit = onEmailAndPasswordSubmitted,
-        )
     }
     if (uiState.showLoadingDialog) {
         LoadingDialog()


### PR DESCRIPTION
Linear Ticket: [SDK-1490](https://linear.app/stytch/issue/SDK-1490)

## Changes:

1. Only show password creation options on new user screen if passwords are enabled

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A