### PR TITLE
Configure native DFP with DFPPA domain

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -41,6 +41,7 @@ import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.StorageHelper
+import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.CaptchaProviderImpl
@@ -105,6 +106,7 @@ public object StytchB2BClient {
     public fun configure(
         context: Context,
         publicToken: String,
+        options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
         try {
@@ -112,7 +114,12 @@ public object StytchB2BClient {
             appSessionId = "app-session-id-${UUID.randomUUID()}"
             StorageHelper.initialize(context)
             StytchB2BApi.configure(publicToken, deviceInfo)
-            dfpProvider = DFPProviderImpl(context.applicationContext, publicToken)
+            dfpProvider =
+                DFPProviderImpl(
+                    context = context.applicationContext,
+                    publicToken = publicToken,
+                    dfppaDomain = options.endpointOptions.dfppaDomain,
+                )
             externalScope.launch(dispatchers.io) {
                 refreshBootstrapData()
                 StytchB2BApi.configureDFP(

--- a/sdk/src/main/java/com/stytch/sdk/common/EndpointOptions.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/EndpointOptions.kt
@@ -1,0 +1,9 @@
+package com.stytch.sdk.common
+
+/**
+ * Defines custom endpoints used by the SDK
+ * @property dfppaDomain the domain that should be used for DFPPA
+ */
+public data class EndpointOptions(
+    val dfppaDomain: String = "telemetry.stytch.com",
+)

--- a/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
@@ -1,0 +1,9 @@
+package com.stytch.sdk.common
+
+/**
+ * Options for configuring the StytchClient
+ * @property endpointOptions Defines custom endpoints used by the SDK
+ */
+public data class StytchClientOptions(
+    val endpointOptions: EndpointOptions = EndpointOptions(),
+)

--- a/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
@@ -12,12 +12,13 @@ internal interface DFPProvider {
 internal class DFPProviderImpl(
     context: Context,
     publicToken: String,
+    dfppaDomain: String,
 ) : DFPProvider {
     // We have to do this to allow unit tests to work, as they don't load native libs :( Alternatively, we'd need to
     // rewrite all of our affected tests to be instrumented tests, which isn't ideal
     private val dfp: NativeDFP? =
         try {
-            NativeDFP(context = context, publicToken = publicToken)
+            NativeDFP(context = context, publicToken = publicToken, submissionUrl = dfppaDomain)
         } catch (_: UnsatisfiedLinkError) {
             null
         } catch (_: NoClassDefFoundError) {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -10,6 +10,7 @@ import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.StorageHelper
+import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.CaptchaProviderImpl
@@ -107,6 +108,7 @@ public object StytchClient {
     public fun configure(
         context: Context,
         publicToken: String,
+        options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
         try {
@@ -115,7 +117,12 @@ public object StytchClient {
             appSessionId = "app-session-id-${UUID.randomUUID()}"
             StorageHelper.initialize(context)
             StytchApi.configure(publicToken, deviceInfo)
-            dfpProvider = DFPProviderImpl(context.applicationContext, publicToken)
+            dfpProvider =
+                DFPProviderImpl(
+                    context = context.applicationContext,
+                    publicToken = publicToken,
+                    dfppaDomain = options.endpointOptions.dfppaDomain,
+                )
             maybeClearBadSessionToken()
             externalScope.launch(dispatchers.io) {
                 bootstrapData =


### PR DESCRIPTION
Linear Ticket: [AUTH-3810](https://linear.app/stytch/issue/AUTH-3810)

## Changes:

1. Configures native DFP to use a custom domain

## Notes:

- This is the same as #199, just for native DFP

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A