### PR TITLE
SDK-1996 Fix crashing when encoding list and map types in oauth start URLs

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/OAuthViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/OAuthViewModel.kt
@@ -29,6 +29,8 @@ class OAuthViewModel : ViewModel() {
                     organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
                     loginRedirectUrl = "app://b2bexampleapp.com/",
                     signupRedirectUrl = "app://b2bexampleapp.com/",
+                    providerParams = mapOf("param_1" to "value_1", "param_2" to "value_2"),
+                    customScopes = listOf("scope_1", "scope_2")
                 ),
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -1,7 +1,5 @@
 package com.stytch.sdk.b2b.oauth
 
-import android.net.Uri
-import com.google.gson.JsonParser
 import com.stytch.sdk.b2b.OAuthAuthenticateResponse
 import com.stytch.sdk.b2b.OAuthDiscoveryAuthenticateResponse
 import com.stytch.sdk.b2b.StytchB2BClient
@@ -14,6 +12,7 @@ import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
+import com.stytch.sdk.common.utils.buildUri
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -151,22 +150,4 @@ internal class OAuthImpl(
             }
         }
     }
-
-    private fun buildUri(
-        url: String,
-        parameters: Map<String, Any?>,
-    ): Uri =
-        Uri.parse(url)
-            .buildUpon()
-            .apply {
-                parameters.forEach {
-                    if (it.value != null) {
-                        when (it.value) {
-                            is String -> appendQueryParameter(it.key, it.value.toString())
-                            else -> appendQueryParameter(it.key, JsonParser.parseString(it.value.toString()).asString)
-                        }
-                    }
-                }
-            }
-            .build()
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/utils/URIHelpers.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/utils/URIHelpers.kt
@@ -1,0 +1,27 @@
+package com.stytch.sdk.common.utils
+
+import android.net.Uri
+
+internal fun buildUri(
+    url: String,
+    parameters: Map<String, Any?>,
+): Uri =
+    Uri.parse(url)
+        .buildUpon()
+        .apply {
+            parameters.forEach {
+                if (it.value != null) {
+                    when (it.value) {
+                        is String -> appendQueryParameter(it.key, it.value.toString())
+                        is List<*> -> appendQueryParameter(it.key, (it.value as List<*>).joinToString(" "))
+                        is Map<*, *> -> {
+                            // map type is only used for provider_params
+                            (it.value as Map<*, *>).entries.forEach { entry ->
+                                appendQueryParameter("provider_${entry.key}", entry.value.toString())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .build()

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
@@ -177,7 +177,8 @@ public interface OAuth {
          * This should be a url that redirects back to your app. If this value is not passed, the default sign-up
          * redirect URL set in the Stytch Dashboard is used. If you have not set a default sign-up redirect URL, an
          * error is returned.
-         * @property customScopes Any additional scopes to be requested from the identity provider.
+         * @property customScopes Any additional scopes to be requested from the identity provider
+         * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
          */
         public data class StartParameters(
             val context: Activity,
@@ -185,6 +186,7 @@ public interface OAuth {
             val loginRedirectUrl: String? = null,
             val signupRedirectUrl: String? = null,
             val customScopes: List<String>? = null,
+            val providerParams: Map<String, String>? = null,
         )
 
         /**

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
@@ -1,10 +1,10 @@
 package com.stytch.sdk.consumer.oauth
 
-import android.net.Uri
 import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.sso.SSOManagerActivity.Companion.URI_KEY
+import com.stytch.sdk.common.utils.buildUri
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.StytchApi
 
@@ -12,25 +12,6 @@ internal class ThirdPartyOAuthImpl(
     private val pkcePairManager: PKCEPairManager,
     override val providerName: String,
 ) : OAuth.ThirdParty {
-    internal fun buildUri(
-        host: String,
-        parameters: Map<String, String?>,
-        pkce: String,
-        token: String,
-    ): Uri =
-        Uri.parse("${host}public/oauth/$providerName/start")
-            .buildUpon()
-            .apply {
-                appendQueryParameter("code_challenge", pkce)
-                appendQueryParameter("public_token", token)
-                parameters.forEach {
-                    if (it.value != null) {
-                        appendQueryParameter(it.key, it.value)
-                    }
-                }
-            }
-            .build()
-
     override fun start(parameters: OAuth.ThirdParty.StartParameters) {
         val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
         val token = StytchApi.publicToken
@@ -38,13 +19,16 @@ internal class ThirdPartyOAuthImpl(
             StytchClient.bootstrapData.cnameDomain?.let {
                 "https://$it/v1/"
             } ?: if (StytchApi.isTestToken) Constants.TEST_API_URL else Constants.LIVE_API_URL
+        val baseUrl = "${host}public/oauth/$providerName/start"
         val potentialParameters =
             mapOf(
+                "public_token" to token,
+                "code_challenge" to pkce,
                 "login_redirect_url" to parameters.loginRedirectUrl,
                 "signup_redirect_url" to parameters.signupRedirectUrl,
-                "custom_scopes" to parameters.customScopes?.joinToString(" "),
+                "custom_scopes" to parameters.customScopes,
             )
-        val requestUri = buildUri(host, potentialParameters, pkce, token)
+        val requestUri = buildUri(baseUrl, potentialParameters)
         val intent = SSOManagerActivity.createBaseIntent(parameters.context)
         intent.putExtra(URI_KEY, requestUri.toString())
         parameters.context.startActivityForResult(intent, parameters.oAuthRequestIdentifier)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
@@ -27,6 +27,7 @@ internal class ThirdPartyOAuthImpl(
                 "login_redirect_url" to parameters.loginRedirectUrl,
                 "signup_redirect_url" to parameters.signupRedirectUrl,
                 "custom_scopes" to parameters.customScopes,
+                "provider_params" to parameters.providerParams,
             )
         val requestUri = buildUri(baseUrl, potentialParameters)
         val intent = SSOManagerActivity.createBaseIntent(parameters.context)


### PR DESCRIPTION
Linear Ticket: [SDK-1996](https://linear.app/stytch/issue/SDK-1996)

## Changes:

1. Extract buildUri function for reuse between B2B and consumer
2. Correctly encode list and map types

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A