### PR TITLE
SDK-1911 Add Locale to supported endpoints

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.EMLAuthenticateResponse
 import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 
 /**
  * The B2BMagicLinks interface provides methods for sending and authenticating users with Email Magic Links.
@@ -106,6 +107,9 @@ public interface B2BMagicLinks {
          * @property signupTemplateId Use a custom template for sign-up emails. By default, it will use your default
          * email template. The template must be a template using our built-in customizations or a custom HTML email for
          * Magic links - Sign-up.
+         * @property locale Used to determine which language to use when sending the user this delivery method.
+         * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+         * if no value is provided, the copy defaults to English.
          */
         public data class Parameters(
             val email: String,
@@ -114,6 +118,7 @@ public interface B2BMagicLinks {
             val signupRedirectUrl: String? = null,
             val loginTemplateId: String? = null,
             val signupTemplateId: String? = null,
+            val locale: Locale? = null,
         )
 
         /**
@@ -143,11 +148,15 @@ public interface B2BMagicLinks {
          * @property loginTemplateId Use a custom template for login emails. By default, it will use your default email
          * template. The template must be a template using our built-in customizations or a custom HTML email for
          * Magic links - Login.
+         * @property locale Used to determine which language to use when sending the user this delivery method.
+         * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+         * if no value is provided, the copy defaults to English.
          */
         public data class DiscoverySendParameters(
             val emailAddress: String,
             val discoveryRedirectUrl: String? = null,
             val loginTemplateId: String? = null,
+            val locale: Locale? = null,
         )
 
         /**
@@ -196,7 +205,7 @@ public interface B2BMagicLinks {
             val inviteTemplateId: String? = null,
             val name: String? = null,
             val untrustedMetadata: Map<String, Any?>? = null,
-            val locale: String? = null,
+            val locale: Locale? = null,
             val roles: List<String>? = null,
         )
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -30,14 +30,15 @@ internal class B2BMagicLinksImpl internal constructor(
         var result: EMLAuthenticateResponse
         withContext(dispatchers.io) {
             result =
-                emailApi.authenticate(
-                    token = parameters.token,
-                    sessionDurationMinutes = parameters.sessionDurationMinutes,
-                    codeVerifier = pkcePairManager.getPKCECodePair()?.codeVerifier,
-                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
-                ).apply {
-                    launchSessionUpdater(dispatchers, sessionStorage)
-                }
+                emailApi
+                    .authenticate(
+                        token = parameters.token,
+                        sessionDurationMinutes = parameters.sessionDurationMinutes,
+                        codeVerifier = pkcePairManager.getPKCECodePair()?.codeVerifier,
+                        intermediateSessionToken = sessionStorage.intermediateSessionToken,
+                    ).apply {
+                        launchSessionUpdater(dispatchers, sessionStorage)
+                    }
             pkcePairManager.clearPKCECodePair()
         }
 
@@ -108,6 +109,7 @@ internal class B2BMagicLinksImpl internal constructor(
                         codeChallenge = challengeCode,
                         loginTemplateId = parameters.loginTemplateId,
                         signupTemplateId = parameters.signupTemplateId,
+                        locale = parameters.locale,
                     )
             }
 
@@ -145,6 +147,7 @@ internal class B2BMagicLinksImpl internal constructor(
                         codeChallenge = challengeCode,
                         loginTemplateId = parameters.loginTemplateId,
                         discoveryRedirectUrl = parameters.discoveryRedirectUrl,
+                        locale = parameters.locale,
                     )
             }
             return result
@@ -160,8 +163,8 @@ internal class B2BMagicLinksImpl internal constructor(
             }
         }
 
-        override suspend fun invite(parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters): MemberResponse {
-            return withContext(dispatchers.io) {
+        override suspend fun invite(parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters): MemberResponse =
+            withContext(dispatchers.io) {
                 emailApi.invite(
                     emailAddress = parameters.emailAddress,
                     inviteRedirectUrl = parameters.inviteRedirectUrl,
@@ -172,7 +175,6 @@ internal class B2BMagicLinksImpl internal constructor(
                     roles = parameters.roles,
                 )
             }
-        }
 
         override fun invite(
             parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -72,6 +72,7 @@ import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.safeApiCall
 
@@ -180,6 +181,7 @@ internal object StytchB2BApi {
                 codeChallenge: String,
                 loginTemplateId: String?,
                 signupTemplateId: String?,
+                locale: Locale? = null,
             ): StytchResult<BasicData> =
                 safeB2BApiCall {
                     apiService.loginOrSignupByEmail(
@@ -191,6 +193,7 @@ internal object StytchB2BApi {
                             codeChallenge = codeChallenge,
                             loginTemplateId = loginTemplateId,
                             signupTemplateId = signupTemplateId,
+                            locale = locale,
                         ),
                     )
                 }
@@ -218,7 +221,7 @@ internal object StytchB2BApi {
                 inviteTemplateId: String? = null,
                 name: String? = null,
                 untrustedMetadata: Map<String, Any?>? = null,
-                locale: String? = null,
+                locale: Locale? = null,
                 roles: List<String>? = null,
             ): StytchResult<MemberResponseData> =
                 safeB2BApiCall {
@@ -242,6 +245,7 @@ internal object StytchB2BApi {
                 discoveryRedirectUrl: String?,
                 codeChallenge: String,
                 loginTemplateId: String?,
+                locale: Locale? = null,
             ): StytchResult<BasicData> =
                 safeB2BApiCall {
                     apiService.sendDiscoveryMagicLink(
@@ -250,6 +254,7 @@ internal object StytchB2BApi {
                             discoveryRedirectUrl = discoveryRedirectUrl,
                             codeChallenge = codeChallenge,
                             loginTemplateId = loginTemplateId,
+                            locale = locale,
                         ),
                     )
                 }
@@ -287,7 +292,7 @@ internal object StytchB2BApi {
         suspend fun exchange(
             organizationId: String,
             sessionDurationMinutes: UInt,
-            locale: String? = null,
+            locale: Locale? = null,
         ): StytchResult<SessionExchangeResponseData> =
             safeB2BApiCall {
                 apiService.exchangeSession(
@@ -492,6 +497,7 @@ internal object StytchB2BApi {
             organizationId: String,
             emailAddress: String,
             password: String,
+            locale: Locale? = null,
             sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
             intermediateSessionToken: String? = null,
         ): StytchResult<PasswordsAuthenticateResponseData> =
@@ -503,6 +509,7 @@ internal object StytchB2BApi {
                         password = password,
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
                         intermediateSessionToken = intermediateSessionToken,
+                        locale = locale,
                     ),
                 )
             }
@@ -537,6 +544,7 @@ internal object StytchB2BApi {
             sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
             codeVerifier: String,
             intermediateSessionToken: String? = null,
+            locale: Locale? = null,
         ): StytchResult<EmailResetResponseData> =
             safeB2BApiCall {
                 apiService.resetPasswordByEmail(
@@ -546,6 +554,7 @@ internal object StytchB2BApi {
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
                         codeVerifier = codeVerifier,
                         intermediateSessionToken = intermediateSessionToken,
+                        locale = locale,
                     ),
                 )
             }
@@ -556,6 +565,7 @@ internal object StytchB2BApi {
             existingPassword: String,
             newPassword: String,
             sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+            locale: Locale? = null,
         ): StytchResult<PasswordResetByExistingPasswordResponseData> =
             safeB2BApiCall {
                 apiService.resetPasswordByExisting(
@@ -565,6 +575,7 @@ internal object StytchB2BApi {
                         existingPassword = existingPassword,
                         newPassword = newPassword,
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
+                        locale = locale,
                     ),
                 )
             }
@@ -662,6 +673,7 @@ internal object StytchB2BApi {
             sessionDurationMinutes: UInt,
             codeVerifier: String,
             intermediateSessionToken: String? = null,
+            locale: Locale? = null,
         ): StytchResult<SSOAuthenticateResponseData> =
             safeB2BApiCall {
                 apiService.ssoAuthenticate(
@@ -670,6 +682,7 @@ internal object StytchB2BApi {
                         sessionDurationMinutes = sessionDurationMinutes.toInt(),
                         codeVerifier = codeVerifier,
                         intermediateSessionToken = intermediateSessionToken,
+                        locale = locale,
                     ),
                 )
             }
@@ -858,7 +871,7 @@ internal object StytchB2BApi {
             organizationId: String,
             memberId: String,
             mfaPhoneNumber: String? = null,
-            locale: String? = null,
+            locale: Locale? = null,
             intermediateSessionToken: String? = null,
             enableAutofill: Boolean = false,
         ): StytchResult<BasicData> =
@@ -973,7 +986,7 @@ internal object StytchB2BApi {
     internal object OAuth {
         suspend fun authenticate(
             oauthToken: String,
-            locale: String? = null,
+            locale: Locale? = null,
             sessionDurationMinutes: Int,
             pkceCodeVerifier: String,
             intermediateSessionToken: String? = null,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.network.models
 import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.network.models.Locale
 
 internal object B2BRequests {
     object MagicLinks {
@@ -24,6 +25,7 @@ internal object B2BRequests {
                 val loginTemplateId: String? = null,
                 @Json(name = "signup_template_id")
                 val signupTemplateId: String? = null,
+                val locale: Locale? = null,
             )
         }
 
@@ -39,6 +41,7 @@ internal object B2BRequests {
                 val codeChallenge: String,
                 @Json(name = "login_template_id")
                 val loginTemplateId: String? = null,
+                val locale: Locale? = null,
             )
 
             @Keep
@@ -64,7 +67,7 @@ internal object B2BRequests {
                 val name: String? = null,
                 @Json(name = "untrusted_metadata")
                 val untrustedMetadata: Map<String, Any?>? = null,
-                val locale: String? = null,
+                val locale: Locale? = null,
                 val roles: List<String>? = null,
             )
         }
@@ -96,6 +99,7 @@ internal object B2BRequests {
             val sessionDurationMinutes: Int,
             @Json(name = "intermediate_session_token")
             val intermediateSessionToken: String? = null,
+            val locale: Locale? = null,
         )
 
         @Keep
@@ -129,6 +133,7 @@ internal object B2BRequests {
             val codeVerifier: String,
             @Json(name = "intermediate_session_token")
             val intermediateSessionToken: String? = null,
+            val locale: Locale? = null,
         )
 
         @Keep
@@ -144,6 +149,7 @@ internal object B2BRequests {
             val newPassword: String,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
+            val locale: Locale? = null,
         )
 
         @Keep
@@ -222,6 +228,7 @@ internal object B2BRequests {
             val codeVerifier: String,
             @Json(name = "intermediate_session_token")
             val intermediateSessionToken: String? = null,
+            val locale: Locale? = null,
         )
 
         @Keep
@@ -306,7 +313,7 @@ internal object B2BRequests {
         data class ExchangeRequest(
             @Json(name = "organization_id")
             val organizationId: String,
-            val locale: String? = null,
+            val locale: Locale? = null,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int? = null,
         )
@@ -445,7 +452,7 @@ internal object B2BRequests {
                 val memberId: String,
                 @Json(name = "mfa_phone_number")
                 val mfaPhoneNumber: String? = null,
-                val locale: String? = null,
+                val locale: Locale? = null,
                 @Json(name = "intermediate_session_token")
                 val intermediateSessionToken: String? = null,
                 @Json(name = "enable_autofill")
@@ -526,7 +533,7 @@ internal object B2BRequests {
         data class AuthenticateRequest(
             @Json(name = "oauth_token")
             val oauthToken: String,
-            val locale: String? = null,
+            val locale: Locale? = null,
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
             @Json(name = "pkce_code_verifier")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.stytch.sdk.b2b.OAuthAuthenticateResponse
 import com.stytch.sdk.b2b.OAuthDiscoveryAuthenticateResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 
 /**
  * The OAuth interface provides methods for authenticating a user, via the supported OAuth providers, provided you have
@@ -144,7 +145,7 @@ public interface OAuth {
      */
     public data class AuthenticateParameters(
         val oauthToken: String,
-        val locale: String? = null,
+        val locale: Locale? = null,
         val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
     )
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.BasicResponse
 import com.stytch.sdk.b2b.SMSAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 
 /**
  * The OTP interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS
@@ -36,7 +37,7 @@ public interface OTP {
             val organizationId: String,
             val memberId: String,
             val mfaPhoneNumber: String? = null,
-            val locale: String? = null,
+            val locale: Locale? = null,
             val enableAutofill: Boolean = false,
             val autofillSessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
         )

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.b2b.PasswordsAuthenticateResponse
 import com.stytch.sdk.b2b.SessionResetResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 
 /**
  * The Passwords interface provides methods for authenticating, creating, resetting, and performing strength checks of
@@ -28,12 +29,16 @@ public interface Passwords {
      * @property emailAddress is the member's email address
      * @property password is the member's password
      * @property sessionDurationMinutes indicates how long the session should last before it expires
+     * @property locale Used to determine which language to use when sending the user this delivery method.
+     * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+     * if no value is provided, the copy defaults to English.
      */
     public data class AuthParameters(
         val organizationId: String,
         val emailAddress: String,
         val password: String,
         val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+        val locale: Locale? = null,
     )
 
     /**
@@ -119,11 +124,15 @@ public interface Passwords {
      * @property token is the unique sequence of characters that should be received after calling the resetByEmailStart
      * @property password is the private sequence of characters you wish to use as a password
      * @property sessionDurationMinutes indicates how long the session should last before it expires
+     * @property locale Used to determine which language to use when sending the user this delivery method.
+     * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+     * if no value is provided, the copy defaults to English.
      */
     public data class ResetByEmailParameters(
         val token: String,
         val password: String,
         val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+        val locale: Locale? = null,
     )
 
     /**
@@ -156,6 +165,9 @@ public interface Passwords {
      * @property existingPassword The member's current password that they supplied.
      * @property newPassword The member's elected new password.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
+     * @property locale Used to determine which language to use when sending the user this delivery method.
+     * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+     * if no value is provided, the copy defaults to English.
      */
     public data class ResetByExistingPasswordParameters(
         val organizationId: String,
@@ -163,6 +175,7 @@ public interface Passwords {
         val existingPassword: String,
         val newPassword: String,
         val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+        val locale: Locale? = null,
     )
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -26,19 +26,20 @@ internal class PasswordsImpl internal constructor(
     private val api: StytchB2BApi.Passwords,
     private val pkcePairManager: PKCEPairManager,
 ) : Passwords {
-    override suspend fun authenticate(parameters: Passwords.AuthParameters): PasswordsAuthenticateResponse {
-        return withContext(dispatchers.io) {
-            api.authenticate(
-                organizationId = parameters.organizationId,
-                emailAddress = parameters.emailAddress,
-                password = parameters.password,
-                sessionDurationMinutes = parameters.sessionDurationMinutes,
-                intermediateSessionToken = sessionStorage.intermediateSessionToken,
-            ).apply {
-                launchSessionUpdater(dispatchers, sessionStorage)
-            }
+    override suspend fun authenticate(parameters: Passwords.AuthParameters): PasswordsAuthenticateResponse =
+        withContext(dispatchers.io) {
+            api
+                .authenticate(
+                    organizationId = parameters.organizationId,
+                    emailAddress = parameters.emailAddress,
+                    password = parameters.password,
+                    sessionDurationMinutes = parameters.sessionDurationMinutes,
+                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
+                    locale = parameters.locale,
+                ).apply {
+                    launchSessionUpdater(dispatchers, sessionStorage)
+                }
         }
-    }
 
     override fun authenticate(
         parameters: Passwords.AuthParameters,
@@ -95,15 +96,17 @@ internal class PasswordsImpl internal constructor(
                 return@withContext
             }
             result =
-                api.resetByEmail(
-                    passwordResetToken = parameters.token,
-                    password = parameters.password,
-                    sessionDurationMinutes = parameters.sessionDurationMinutes,
-                    codeVerifier = codeVerifier,
-                    intermediateSessionToken = sessionStorage.intermediateSessionToken,
-                ).apply {
-                    launchSessionUpdater(dispatchers, sessionStorage)
-                }
+                api
+                    .resetByEmail(
+                        passwordResetToken = parameters.token,
+                        password = parameters.password,
+                        sessionDurationMinutes = parameters.sessionDurationMinutes,
+                        codeVerifier = codeVerifier,
+                        intermediateSessionToken = sessionStorage.intermediateSessionToken,
+                        locale = parameters.locale,
+                    ).apply {
+                        launchSessionUpdater(dispatchers, sessionStorage)
+                    }
             pkcePairManager.clearPKCECodePair()
         }
         return result
@@ -121,19 +124,20 @@ internal class PasswordsImpl internal constructor(
 
     override suspend fun resetByExisting(
         parameters: Passwords.ResetByExistingPasswordParameters,
-    ): PasswordResetByExistingPasswordResponse {
-        return withContext(dispatchers.io) {
-            api.resetByExisting(
-                organizationId = parameters.organizationId,
-                emailAddress = parameters.emailAddress,
-                existingPassword = parameters.existingPassword,
-                newPassword = parameters.newPassword,
-                sessionDurationMinutes = parameters.sessionDurationMinutes,
-            ).apply {
-                launchSessionUpdater(dispatchers, sessionStorage)
-            }
+    ): PasswordResetByExistingPasswordResponse =
+        withContext(dispatchers.io) {
+            api
+                .resetByExisting(
+                    organizationId = parameters.organizationId,
+                    emailAddress = parameters.emailAddress,
+                    existingPassword = parameters.existingPassword,
+                    newPassword = parameters.newPassword,
+                    sessionDurationMinutes = parameters.sessionDurationMinutes,
+                    locale = parameters.locale,
+                ).apply {
+                    launchSessionUpdater(dispatchers, sessionStorage)
+                }
         }
-    }
 
     override fun resetByExisting(
         parameters: Passwords.ResetByExistingPasswordParameters,
@@ -145,14 +149,13 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
-    override suspend fun resetBySession(parameters: Passwords.ResetBySessionParameters): SessionResetResponse {
-        return withContext(dispatchers.io) {
+    override suspend fun resetBySession(parameters: Passwords.ResetBySessionParameters): SessionResetResponse =
+        withContext(dispatchers.io) {
             api.resetBySession(
                 organizationId = parameters.organizationId,
                 password = parameters.password,
             )
         }
-    }
 
     override fun resetBySession(
         parameters: Passwords.ResetBySessionParameters,
@@ -164,14 +167,13 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
-    override suspend fun strengthCheck(parameters: Passwords.StrengthCheckParameters): PasswordStrengthCheckResponse {
-        return withContext(dispatchers.io) {
+    override suspend fun strengthCheck(parameters: Passwords.StrengthCheckParameters): PasswordStrengthCheckResponse =
+        withContext(dispatchers.io) {
             api.strengthCheck(
                 email = parameters.email,
                 password = parameters.password,
             )
         }
-    }
 
     override fun strengthCheck(
         parameters: Passwords.StrengthCheckParameters,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.SessionsAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.B2BSessionData
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
+import com.stytch.sdk.common.network.models.Locale
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -111,7 +112,7 @@ public interface B2BSessions {
     public data class ExchangeParameters(
         val organizationId: String,
         val sessionDurationMinutes: UInt,
-        val locale: String? = null,
+        val locale: Locale? = null,
     )
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -13,6 +13,7 @@ import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 
 /**
  * Single-Sign On (SSO) refers to the ability for a user to use a single identity to authenticate and gain access to
@@ -56,10 +57,14 @@ public interface SSO {
      * Data class used for wrapping parameters used in SSO Authenticate calls
      * @property ssoToken the SSO token to authenticate
      * @property sessionDurationMinutes indicates how long the session should last before it expires
+     * @property locale Used to determine which language to use when sending the user this delivery method.
+     * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+     * if no value is provided, the copy defaults to English.
      */
     public data class AuthenticateParams(
         val ssoToken: String,
         val sessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+        val locale: Locale? = null,
     )
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -83,6 +83,7 @@ internal class SSOImpl(
                         sessionDurationMinutes = params.sessionDurationMinutes,
                         codeVerifier = codeVerifier,
                         intermediateSessionToken = sessionStorage.intermediateSessionToken,
+                        locale = params.locale,
                     ).apply {
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.utils.createEnumJsonAdapter
 import com.stytch.sdk.consumer.network.models.CryptoWalletType
 import okhttp3.Interceptor
@@ -23,7 +24,8 @@ internal interface ApiService {
             revokeSession: () -> Unit,
         ): OkHttpClient {
             val builder =
-                OkHttpClient.Builder()
+                OkHttpClient
+                    .Builder()
                     .readTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
                     .writeTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
                     .connectTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
@@ -39,12 +41,12 @@ internal interface ApiService {
                         }
                         return@Interceptor response
                     },
-                )
-                .addNetworkInterceptor {
+                ).addNetworkInterceptor {
                     // OkHttp is adding a charset to the content-type which is rejected by the API
                     // see: https://github.com/square/okhttp/issues/3081
                     it.proceed(
-                        it.request()
+                        it
+                            .request()
                             .newBuilder()
                             .header("Content-Type", "application/json")
                             .build(),
@@ -61,13 +63,16 @@ internal interface ApiService {
             apiService: Class<T>,
         ): T {
             val moshi =
-                Moshi.Builder()
+                Moshi
+                    .Builder()
                     .add(createEnumJsonAdapter<AllowedAuthMethods>())
                     .add(createEnumJsonAdapter<MfaMethod>())
                     .add(createEnumJsonAdapter<SetMFAEnrollment>())
                     .add(createEnumJsonAdapter<CryptoWalletType>())
+                    .add(createEnumJsonAdapter<Locale>())
                     .build()
-            return Retrofit.Builder()
+            return Retrofit
+                .Builder()
                 .baseUrl(hostUrl)
                 .addConverterFactory(MoshiConverterFactory.create(moshi))
                 .client(clientBuilder(authHeaderInterceptor, dfpInterceptor, revokeSession))

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.common.network.models
 import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.utils.IEnumValue
 
 internal object CommonRequests {
     object Sessions {
@@ -67,4 +68,14 @@ internal object CommonRequests {
             val errorDescription: String? = null,
         )
     }
+}
+
+@Keep
+@JsonClass(generateAdapter = false)
+public enum class Locale(
+    override val jsonName: String,
+) : IEnumValue {
+    EN("en"),
+    ES("es"),
+    PT_BR("pt-br"),
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.magicLinks
 import android.os.Parcelable
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.AuthResponse
 import kotlinx.parcelize.Parcelize
 
@@ -62,6 +63,9 @@ public interface MagicLinks {
          * @property signupTemplateId Use a custom template for sign-up emails. By default, it will use your default
          * email template. The template must be a template using our built-in customizations or a custom HTML email for
          * Magic links - Sign-up.
+         * @property locale Used to determine which language to use when sending the user this delivery method.
+         * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+         * if no value is provided, the copy defaults to English.
          */
         @Parcelize
         public data class Parameters(
@@ -72,6 +76,7 @@ public interface MagicLinks {
             val signupExpirationMinutes: UInt? = null,
             val loginTemplateId: String? = null,
             val signupTemplateId: String? = null,
+            val locale: Locale? = null,
         ) : Parcelable
 
         /**

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
@@ -85,6 +85,7 @@ internal class MagicLinksImpl internal constructor(
                         codeChallenge = challengeCode,
                         loginTemplateId = parameters.loginTemplateId,
                         signupTemplateId = parameters.signupTemplateId,
+                        locale = parameters.locale,
                     )
             }
 
@@ -121,6 +122,7 @@ internal class MagicLinksImpl internal constructor(
                         loginTemplateId = parameters.loginTemplateId,
                         signupTemplateId = parameters.signupTemplateId,
                         codeChallenge = challengeCode,
+                        locale = parameters.locale,
                     )
                 } else {
                     api.sendPrimary(
@@ -132,6 +134,7 @@ internal class MagicLinksImpl internal constructor(
                         loginTemplateId = parameters.loginTemplateId,
                         signupTemplateId = parameters.signupTemplateId,
                         codeChallenge = challengeCode,
+                        locale = parameters.locale,
                     )
                 }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -21,6 +21,7 @@ import com.stytch.sdk.common.network.models.BiometricsStartResponse
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.common.network.models.NameData
 import com.stytch.sdk.common.network.models.NoResponseData
@@ -148,6 +149,7 @@ internal object StytchApi {
                 codeChallenge: String,
                 loginTemplateId: String?,
                 signupTemplateId: String?,
+                locale: Locale? = null,
             ): StytchResult<BasicData> =
                 safeConsumerApiCall {
                     apiService.loginOrCreateUserByEmail(
@@ -157,6 +159,7 @@ internal object StytchApi {
                             codeChallenge = codeChallenge,
                             loginTemplateId = loginTemplateId,
                             signupTemplateId = signupTemplateId,
+                            locale = locale,
                         ),
                     )
                 }
@@ -169,9 +172,9 @@ internal object StytchApi {
                 safeConsumerApiCall {
                     apiService.authenticate(
                         ConsumerRequests.MagicLinks.AuthenticateRequest(
-                            token,
-                            codeVerifier,
-                            sessionDurationMinutes.toInt(),
+                            token = token,
+                            codeVerifier = codeVerifier,
+                            sessionDurationMinutes = sessionDurationMinutes.toInt(),
                         ),
                     )
                 }
@@ -186,6 +189,7 @@ internal object StytchApi {
                 loginTemplateId: String?,
                 signupTemplateId: String?,
                 codeChallenge: String?,
+                locale: Locale? = null,
             ): StytchResult<BasicData> =
                 safeConsumerApiCall {
                     apiService.sendEmailMagicLinkPrimary(
@@ -198,6 +202,7 @@ internal object StytchApi {
                             loginTemplateId = loginTemplateId,
                             signupTemplateId = signupTemplateId,
                             codeChallenge = codeChallenge,
+                            locale = locale,
                         ),
                     )
                 }
@@ -212,6 +217,7 @@ internal object StytchApi {
                 loginTemplateId: String?,
                 signupTemplateId: String?,
                 codeChallenge: String?,
+                locale: Locale? = null,
             ): StytchResult<BasicData> =
                 safeConsumerApiCall {
                     apiService.sendEmailMagicLinkSecondary(
@@ -224,6 +230,7 @@ internal object StytchApi {
                             loginTemplateId = loginTemplateId,
                             signupTemplateId = signupTemplateId,
                             codeChallenge = codeChallenge,
+                            locale = locale,
                         ),
                     )
                 }
@@ -235,6 +242,7 @@ internal object StytchApi {
             phoneNumber: String,
             expirationMinutes: UInt,
             enableAutofill: Boolean = false,
+            locale: Locale? = null,
         ): StytchResult<LoginOrCreateOTPData> =
             safeConsumerApiCall {
                 apiService.loginOrCreateUserByOTPWithSMS(
@@ -242,6 +250,7 @@ internal object StytchApi {
                         phoneNumber = phoneNumber,
                         expirationMinutes = expirationMinutes.toInt(),
                         enableAutofill = enableAutofill,
+                        locale = locale,
                     ),
                 )
             }
@@ -250,12 +259,14 @@ internal object StytchApi {
         suspend fun sendOTPWithSMSPrimary(
             phoneNumber: String,
             expirationMinutes: UInt?,
+            locale: Locale? = null,
         ): StytchResult<OTPSendResponseData> =
             safeConsumerApiCall {
                 apiService.sendOTPWithSMSPrimary(
                     ConsumerRequests.OTP.SMS(
                         phoneNumber = phoneNumber,
                         expirationMinutes = expirationMinutes?.toInt(),
+                        locale = locale,
                     ),
                 )
             }
@@ -264,12 +275,14 @@ internal object StytchApi {
         suspend fun sendOTPWithSMSSecondary(
             phoneNumber: String,
             expirationMinutes: UInt?,
+            locale: Locale? = null,
         ): StytchResult<OTPSendResponseData> =
             safeConsumerApiCall {
                 apiService.sendOTPWithSMSSecondary(
                     ConsumerRequests.OTP.SMS(
                         phoneNumber = phoneNumber,
                         expirationMinutes = expirationMinutes?.toInt(),
+                        locale = locale,
                     ),
                 )
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.network.models
 import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.NameData
 
 internal object ConsumerRequests {
@@ -20,6 +21,7 @@ internal object ConsumerRequests {
                 val loginTemplateId: String? = null,
                 @Json(name = "signup_template_id")
                 val signupTemplateId: String? = null,
+                val locale: Locale? = null,
             )
         }
 
@@ -51,6 +53,7 @@ internal object ConsumerRequests {
             val signupTemplateId: String?,
             @Json(name = "code_challenge")
             val codeChallenge: String?,
+            val locale: Locale? = null,
         )
     }
 
@@ -140,6 +143,7 @@ internal object ConsumerRequests {
             val expirationMinutes: Int?,
             @Json(name = "enable_autofill")
             val enableAutofill: Boolean = false,
+            val locale: Locale? = null,
         )
 
         @Keep
@@ -161,6 +165,7 @@ internal object ConsumerRequests {
             val loginTemplateId: String?,
             @Json(name = "signup_template_id")
             val signupTemplateId: String?,
+            val locale: Locale? = null,
         )
 
         @Keep

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
 import com.stytch.sdk.consumer.OTPSendResponse
@@ -74,6 +75,9 @@ public interface OTP {
          * @property expirationMinutes indicates how long the OTP should last before it expires
          * @property enableAutofill indicates whether the SMS message should include autofill metadata
          * @property autofillSessionDurationMinutes indicates how long an autofilled session should last
+         * @property locale Used to determine which language to use when sending the user this delivery method.
+         * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
+         * if no value is provided, the copy defaults to English.
          */
         @Parcelize
         public data class Parameters(
@@ -81,6 +85,7 @@ public interface OTP {
             val expirationMinutes: UInt = DEFAULT_OTP_EXPIRATION_TIME_MINUTES,
             val enableAutofill: Boolean = false,
             val autofillSessionDurationMinutes: UInt = DEFAULT_SESSION_TIME_MINUTES,
+            val locale: Locale? = null,
         ) : Parcelable
 
         /**

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
@@ -64,6 +64,7 @@ internal class OTPImpl internal constructor(
                             phoneNumber = parameters.phoneNumber,
                             expirationMinutes = parameters.expirationMinutes,
                             enableAutofill = parameters.enableAutofill,
+                            locale = parameters.locale,
                         ).apply {
                             if (this is StytchResult.Success && parameters.enableAutofill) {
                                 sessionStorage.methodId = this.value.methodId
@@ -94,6 +95,7 @@ internal class OTPImpl internal constructor(
                         .sendOTPWithSMSSecondary(
                             phoneNumber = parameters.phoneNumber,
                             expirationMinutes = parameters.expirationMinutes,
+                            locale = parameters.locale,
                         ).apply {
                             if (this is StytchResult.Success && parameters.enableAutofill) {
                                 sessionStorage.methodId = this.value.methodId
@@ -104,6 +106,7 @@ internal class OTPImpl internal constructor(
                         .sendOTPWithSMSPrimary(
                             phoneNumber = parameters.phoneNumber,
                             expirationMinutes = parameters.expirationMinutes,
+                            locale = parameters.locale,
                         ).apply {
                             if (this is StytchResult.Success && parameters.enableAutofill) {
                                 sessionStorage.methodId = this.value.methodId

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -133,10 +133,10 @@ internal class B2BMagicLinksImplTest {
         runTest {
             every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
             coEvery {
-                mockEmailApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any())
+                mockEmailApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any(), any())
             } returns mockBaseResponse
             impl.email.loginOrSignup(emailMagicLinkParameters)
-            coVerify { mockEmailApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any()) }
+            coVerify { mockEmailApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
@@ -178,9 +178,9 @@ internal class B2BMagicLinksImplTest {
     fun `MagicLinksImpl discovery send delegates to api`() =
         runTest {
             every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
-            coEvery { mockDiscoveryApi.send(any(), any(), any(), any()) } returns mockBaseResponse
+            coEvery { mockDiscoveryApi.send(any(), any(), any(), any(), any()) } returns mockBaseResponse
             impl.email.discoverySend(mockk(relaxed = true))
-            coVerify { mockDiscoveryApi.send(any(), any(), any(), any()) }
+            coVerify { mockDiscoveryApi.send(any(), any(), any(), any(), any()) }
         }
 
     @Test

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -15,6 +15,7 @@ import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.network.ApiService
 import com.stytch.sdk.common.network.models.CommonRequests
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.utils.verifyDelete
 import com.stytch.sdk.utils.verifyGet
 import com.stytch.sdk.utils.verifyPost
@@ -24,7 +25,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import okio.EOFException
-import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.x509Certificate
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -100,7 +100,7 @@ internal class StytchB2BApiServiceTest {
                     inviteTemplateId = "invite-template-id",
                     name = "member name",
                     untrustedMetadata = mapOf("someMetadataKey" to "someMetadataValue"),
-                    locale = "en",
+                    locale = Locale.EN,
                     roles = listOf("role1", "role2"),
                 )
             requestIgnoringResponseException {
@@ -114,7 +114,7 @@ internal class StytchB2BApiServiceTest {
                         "invite_template_id" to parameters.inviteTemplateId,
                         "name" to parameters.name,
                         "untrusted_metadata" to parameters.untrustedMetadata,
-                        "locale" to parameters.locale,
+                        "locale" to parameters.locale?.jsonName,
                         "roles" to parameters.roles,
                     ),
             )
@@ -222,7 +222,7 @@ internal class StytchB2BApiServiceTest {
             val parameters =
                 B2BRequests.Session.ExchangeRequest(
                     organizationId = "test-123",
-                    locale = "en",
+                    locale = Locale.EN,
                     sessionDurationMinutes = 30,
                 )
             requestIgnoringResponseException {
@@ -232,7 +232,7 @@ internal class StytchB2BApiServiceTest {
                 expectedBody =
                     mapOf(
                         "organization_id" to parameters.organizationId,
-                        "locale" to parameters.locale,
+                        "locale" to parameters.locale?.jsonName,
                         "session_duration_minutes" to parameters.sessionDurationMinutes,
                     ),
             )
@@ -1093,7 +1093,7 @@ internal class StytchB2BApiServiceTest {
                     organizationId = "my-organization-id",
                     memberId = "my-member-id",
                     mfaPhoneNumber = "+15555550123",
-                    locale = "en",
+                    locale = Locale.EN,
                     enableAutofill = true,
                 )
             requestIgnoringResponseException {
@@ -1105,7 +1105,7 @@ internal class StytchB2BApiServiceTest {
                         "organization_id" to parameters.organizationId,
                         "member_id" to parameters.memberId,
                         "mfa_phone_number" to parameters.mfaPhoneNumber,
-                        "locale" to parameters.locale,
+                        "locale" to parameters.locale?.jsonName,
                         "enable_autofill" to parameters.enableAutofill,
                     ),
             )
@@ -1247,7 +1247,7 @@ internal class StytchB2BApiServiceTest {
             val params =
                 B2BRequests.OAuth.AuthenticateRequest(
                     oauthToken = "my-oauth-token",
-                    locale = "en-us",
+                    locale = Locale.EN,
                     sessionDurationMinutes = 30,
                     pkceCodeVerifier = "pkce-code-verifier",
                     intermediateSessionToken = "intermediate-session-token",
@@ -1259,7 +1259,7 @@ internal class StytchB2BApiServiceTest {
                 expectedBody =
                     mapOf(
                         "oauth_token" to params.oauthToken,
-                        "locale" to params.locale,
+                        "locale" to params.locale?.jsonName,
                         "session_duration_minutes" to params.sessionDurationMinutes,
                         "pkce_code_verifier" to params.pkceCodeVerifier,
                         "intermediate_session_token" to params.intermediateSessionToken,

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -18,6 +18,7 @@ import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchDataResponse
 import com.stytch.sdk.common.network.models.CommonRequests
+import com.stytch.sdk.common.network.models.Locale
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -97,7 +98,7 @@ internal class StytchB2BApiTest {
         runTest {
             every { StytchB2BApi.isInitialized } returns true
             coEvery { StytchB2BApi.apiService.loginOrSignupByEmail(any()) } returns mockk(relaxed = true)
-            StytchB2BApi.MagicLinks.Email.loginOrSignupByEmail("", "", "", "", "", "", "")
+            StytchB2BApi.MagicLinks.Email.loginOrSignupByEmail("", "", "", "", "", "", "", null)
             coVerify { StytchB2BApi.apiService.loginOrSignupByEmail(any()) }
         }
 
@@ -124,7 +125,7 @@ internal class StytchB2BApiTest {
         runTest {
             every { StytchB2BApi.isInitialized } returns true
             coEvery { StytchB2BApi.apiService.sendDiscoveryMagicLink(any()) } returns mockk(relaxed = true)
-            StytchB2BApi.MagicLinks.Discovery.send("", "", "", "")
+            StytchB2BApi.MagicLinks.Discovery.send("", "", "", "", Locale.EN)
             coVerify { StytchB2BApi.apiService.sendDiscoveryMagicLink(any()) }
         }
 
@@ -731,7 +732,7 @@ internal class StytchB2BApiTest {
         runTest {
             every { StytchB2BApi.isInitialized } returns true
             coEvery { StytchB2BApi.apiService.oauthAuthenticate(any()) } returns mockk(relaxed = true)
-            StytchB2BApi.OAuth.authenticate("", "", 30, "", "")
+            StytchB2BApi.OAuth.authenticate("", Locale.EN, 30, "", "")
             coVerify { StytchB2BApi.apiService.oauthAuthenticate(any()) }
         }
 
@@ -775,9 +776,7 @@ internal class StytchB2BApiTest {
         runTest {
             every { StytchB2BApi.isInitialized } returns true
 
-            fun mockApiCall(): StytchDataResponse<Boolean> {
-                return StytchDataResponse(true)
-            }
+            fun mockApiCall(): StytchDataResponse<Boolean> = StytchDataResponse(true)
             val result = StytchB2BApi.safeB2BApiCall { mockApiCall() }
             assert(result is StytchResult.Success)
         }
@@ -787,13 +786,12 @@ internal class StytchB2BApiTest {
         runTest {
             every { StytchB2BApi.isInitialized } returns true
 
-            fun mockApiCall(): StytchDataResponse<Boolean> {
+            fun mockApiCall(): StytchDataResponse<Boolean> =
                 throw HttpException(
                     mockk(relaxed = true) {
                         every { errorBody() } returns null
                     },
                 )
-            }
             val result = StytchB2BApi.safeB2BApiCall { mockApiCall() }
             assert(result is StytchResult.Error)
         }
@@ -803,9 +801,7 @@ internal class StytchB2BApiTest {
         runTest {
             every { StytchB2BApi.isInitialized } returns true
 
-            fun mockApiCall(): StytchDataResponse<Boolean> {
-                throw StytchAPIError(errorType = "", message = "")
-            }
+            fun mockApiCall(): StytchDataResponse<Boolean> = throw StytchAPIError(errorType = "", message = "")
             val result = StytchB2BApi.safeB2BApiCall { mockApiCall() }
             assert(result is StytchResult.Error)
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -88,17 +88,17 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl authenticate delegates to api`() =
         runTest {
             val mockkResponse = StytchResult.Success<PasswordsAuthenticateResponseData>(mockk(relaxed = true))
-            coEvery { mockApi.authenticate(any(), any(), any(), any(), any()) } returns mockkResponse
+            coEvery { mockApi.authenticate(any(), any(), any(), any(), any(), any()) } returns mockkResponse
             val response = impl.authenticate(mockk(relaxed = true))
             assert(response is StytchResult.Success)
-            coVerify { mockApi.authenticate(any(), any(), any(), any(), any()) }
+            coVerify { mockApi.authenticate(any(), any(), any(), any(), any(), any()) }
             verify { mockkResponse.launchSessionUpdater(any(), any()) }
         }
 
     @Test
     fun `PasswordsImpl authenticate with callback calls callback method`() {
         val mockkResponse = StytchResult.Success<PasswordsAuthenticateResponseData>(mockk(relaxed = true))
-        coEvery { mockApi.authenticate(any(), any(), any(), any(), any()) } returns mockkResponse
+        coEvery { mockApi.authenticate(any(), any(), any(), any(), any(), any()) } returns mockkResponse
         val mockCallback = spyk<(PasswordsAuthenticateResponse) -> Unit>()
         impl.authenticate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }
@@ -165,10 +165,10 @@ internal class PasswordsImplTest {
         runTest {
             every { mockPKCEPairManager.getPKCECodePair() } returns PKCECodePair("", "")
             val mockkResponse = StytchResult.Success<EmailResetResponseData>(mockk(relaxed = true))
-            coEvery { mockApi.resetByEmail(any(), any(), any(), any(), any()) } returns mockkResponse
+            coEvery { mockApi.resetByEmail(any(), any(), any(), any(), any(), any()) } returns mockkResponse
             val response = impl.resetByEmail(mockk(relaxed = true))
             assert(response is StytchResult.Success)
-            coVerify { mockApi.resetByEmail(any(), any(), any(), any(), any()) }
+            coVerify { mockApi.resetByEmail(any(), any(), any(), any(), any(), any()) }
             verify { mockkResponse.launchSessionUpdater(any(), any()) }
             verify(exactly = 1) { mockPKCEPairManager.clearPKCECodePair() }
         }
@@ -177,7 +177,7 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl resetByEmail with callback calls callback method`() {
         every { mockPKCEPairManager.getPKCECodePair() } returns PKCECodePair("", "")
         val mockkResponse = StytchResult.Success<EmailResetResponseData>(mockk(relaxed = true))
-        coEvery { mockApi.resetByEmail(any(), any(), any(), any(), any()) } returns mockkResponse
+        coEvery { mockApi.resetByEmail(any(), any(), any(), any(), any(), any()) } returns mockkResponse
         val mockCallback = spyk<(EmailResetResponse) -> Unit>()
         impl.resetByEmail(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }
@@ -189,17 +189,17 @@ internal class PasswordsImplTest {
     fun `PasswordsImpl resetByExisting delegates to api`() =
         runTest {
             val mockkResponse = StytchResult.Success<PasswordResetByExistingPasswordResponseData>(mockk(relaxed = true))
-            coEvery { mockApi.resetByExisting(any(), any(), any(), any(), any()) } returns mockkResponse
+            coEvery { mockApi.resetByExisting(any(), any(), any(), any(), any(), any()) } returns mockkResponse
             val response = impl.resetByExisting(mockk(relaxed = true))
             assert(response is StytchResult.Success)
-            coVerify { mockApi.resetByExisting(any(), any(), any(), any(), any()) }
+            coVerify { mockApi.resetByExisting(any(), any(), any(), any(), any(), any()) }
             verify { mockkResponse.launchSessionUpdater(any(), any()) }
         }
 
     @Test
     fun `PasswordsImpl resetByExisting with callback calls callback method`() {
         val mockkResponse = StytchResult.Success<PasswordResetByExistingPasswordResponseData>(mockk(relaxed = true))
-        coEvery { mockApi.resetByExisting(any(), any(), any(), any(), any()) } returns mockkResponse
+        coEvery { mockApi.resetByExisting(any(), any(), any(), any(), any(), any()) } returns mockkResponse
         val mockCallback = spyk<(PasswordResetByExistingPasswordResponse) -> Unit>()
         impl.resetByExisting(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(mockkResponse) }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
@@ -121,10 +121,10 @@ internal class MagicLinksImplTest {
         runTest {
             every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
             coEvery {
-                mockApi.loginOrCreate(any(), any(), any(), any(), any())
+                mockApi.loginOrCreate(any(), any(), any(), any(), any(), any())
             } returns successfulLoginOrCreateResponse
             impl.email.loginOrCreate(emailMagicLinkParameters)
-            coVerify { mockApi.loginOrCreate(any(), any(), any(), any(), any()) }
+            coVerify { mockApi.loginOrCreate(any(), any(), any(), any(), any(), any()) }
         }
 
     @Test

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer.network
 
 import com.stytch.sdk.common.network.ApiService
 import com.stytch.sdk.common.network.models.CommonRequests
+import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.NameData
 import com.stytch.sdk.consumer.network.models.ConsumerRequests
 import com.stytch.sdk.consumer.network.models.CryptoWalletType
@@ -58,6 +59,7 @@ internal class StytchApiServiceTests {
                     codeChallenge = "123",
                     loginTemplateId = "loginTemplateId",
                     signupTemplateId = "signUpTemplateId",
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByEmail(parameters)
@@ -70,6 +72,7 @@ internal class StytchApiServiceTests {
                         "code_challenge" to parameters.codeChallenge,
                         "login_template_id" to parameters.loginTemplateId,
                         "signup_template_id" to parameters.signupTemplateId,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -88,6 +91,7 @@ internal class StytchApiServiceTests {
                     loginExpirationMinutes = 30,
                     signupExpirationMinutes = 30,
                     signupMagicLinkUrl = SIGNUP_MAGIC_LINK,
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.sendEmailMagicLinkPrimary(parameters)
@@ -103,6 +107,7 @@ internal class StytchApiServiceTests {
                         "login_expiration_minutes" to parameters.loginExpirationMinutes,
                         "signup_expiration_minutes" to parameters.loginExpirationMinutes,
                         "signup_magic_link_url" to parameters.signupMagicLinkUrl,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -121,6 +126,7 @@ internal class StytchApiServiceTests {
                     loginExpirationMinutes = 30,
                     signupExpirationMinutes = 30,
                     signupMagicLinkUrl = SIGNUP_MAGIC_LINK,
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.sendEmailMagicLinkSecondary(parameters)
@@ -136,6 +142,7 @@ internal class StytchApiServiceTests {
                         "login_expiration_minutes" to parameters.loginExpirationMinutes,
                         "signup_expiration_minutes" to parameters.loginExpirationMinutes,
                         "signup_magic_link_url" to parameters.signupMagicLinkUrl,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -176,6 +183,7 @@ internal class StytchApiServiceTests {
                     expirationMinutes = 60,
                     loginTemplateId = "loginTemplateId",
                     signupTemplateId = "signUpTemplateId",
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithEmail(parameters)
@@ -187,6 +195,7 @@ internal class StytchApiServiceTests {
                         "expiration_minutes" to parameters.expirationMinutes,
                         "login_template_id" to parameters.loginTemplateId,
                         "signup_template_id" to parameters.signupTemplateId,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -201,6 +210,7 @@ internal class StytchApiServiceTests {
                     expirationMinutes = 60,
                     loginTemplateId = "loginTemplateId",
                     signupTemplateId = "signUpTemplateId",
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.sendOTPWithEmailPrimary(parameters)
@@ -212,6 +222,7 @@ internal class StytchApiServiceTests {
                         "expiration_minutes" to parameters.expirationMinutes,
                         "login_template_id" to parameters.loginTemplateId,
                         "signup_template_id" to parameters.signupTemplateId,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -226,6 +237,7 @@ internal class StytchApiServiceTests {
                     expirationMinutes = 60,
                     loginTemplateId = "loginTemplateId",
                     signupTemplateId = "signUpTemplateId",
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.sendOTPWithEmailSecondary(parameters)
@@ -237,6 +249,7 @@ internal class StytchApiServiceTests {
                         "expiration_minutes" to parameters.expirationMinutes,
                         "login_template_id" to parameters.loginTemplateId,
                         "signup_template_id" to parameters.signupTemplateId,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -250,6 +263,7 @@ internal class StytchApiServiceTests {
                     phoneNumber = "000",
                     expirationMinutes = 24,
                     enableAutofill = true,
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithSMS(parameters)
@@ -260,6 +274,7 @@ internal class StytchApiServiceTests {
                         "phone_number" to parameters.phoneNumber,
                         "expiration_minutes" to parameters.expirationMinutes,
                         "enable_autofill" to parameters.enableAutofill,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -273,6 +288,7 @@ internal class StytchApiServiceTests {
                     phoneNumber = "000",
                     expirationMinutes = 24,
                     enableAutofill = true,
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.sendOTPWithSMSPrimary(parameters)
@@ -283,6 +299,7 @@ internal class StytchApiServiceTests {
                         "phone_number" to parameters.phoneNumber,
                         "expiration_minutes" to parameters.expirationMinutes,
                         "enable_autofill" to parameters.enableAutofill,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }
@@ -296,6 +313,7 @@ internal class StytchApiServiceTests {
                     phoneNumber = "000",
                     expirationMinutes = 24,
                     enableAutofill = true,
+                    locale = Locale.EN,
                 )
             requestIgnoringResponseException {
                 apiService.sendOTPWithSMSSecondary(parameters)
@@ -306,6 +324,7 @@ internal class StytchApiServiceTests {
                         "phone_number" to parameters.phoneNumber,
                         "expiration_minutes" to parameters.expirationMinutes,
                         "enable_autofill" to parameters.enableAutofill,
+                        "locale" to parameters.locale?.jsonName,
                     ),
             )
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
@@ -93,14 +93,14 @@ internal class OTPImplTest {
     @Test
     fun `OTPImpl sms loginOrCreate delegates to api`() =
         runTest {
-            coEvery { mockApi.loginOrCreateByOTPWithSMS(any(), any()) } returns mockk(relaxed = true)
+            coEvery { mockApi.loginOrCreateByOTPWithSMS(any(), any(), any(), any()) } returns mockk(relaxed = true)
             impl.sms.loginOrCreate(mockk(relaxed = true))
-            coVerify { mockApi.loginOrCreateByOTPWithSMS(any(), any()) }
+            coVerify { mockApi.loginOrCreateByOTPWithSMS(any(), any(), any(), any()) }
         }
 
     @Test
     fun `OTPImpl sms loginOrCreate with callback calls callback method`() {
-        coEvery { mockApi.loginOrCreateByOTPWithSMS(any(), any()) } returns mockk(relaxed = true)
+        coEvery { mockApi.loginOrCreateByOTPWithSMS(any(), any(), any(), any()) } returns mockk(relaxed = true)
         val mockCallback = spyk<(LoginOrCreateOTPResponse) -> Unit>()
         impl.sms.loginOrCreate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }


### PR DESCRIPTION
Linear Ticket: [SDK-1911](https://linear.app/stytch/issue/SDK-1911)

## Changes:

1. Adds a Locale enum and updates the (few) existing usages to use it
2. Adds locale param to all supported endpoints

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A