### PR TITLE
Remove unnecessary parameter from SCIM.getConnection methods

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
@@ -123,22 +123,17 @@ public interface SCIM {
      * Gets the SCIM connection for an organization.
      * This method wraps the {@link https://stytch.com/docs/b2b/api/get-scim-connection get-connection} endpoint. The
      * caller must have permission to view SCIM via the project's RBAC policy & their role assignments.
-     * @param connectionId the ID of the connection to get
      * @return [SCIMGetConnectionResponse]
      */
-    public suspend fun getConnection(connectionId: String): SCIMGetConnectionResponse
+    public suspend fun getConnection(): SCIMGetConnectionResponse
 
     /**
      * Gets the SCIM connection for an organization.
      * This method wraps the {@link https://stytch.com/docs/b2b/api/get-scim-connection get-connection} endpoint. The
      * caller must have permission to view SCIM via the project's RBAC policy & their role assignments.
-     * @param connectionId the ID of the connection to get
      * @param callback a callback that receives a [SCIMGetConnectionResponse]
      */
-    public fun getConnection(
-        connectionId: String,
-        callback: (SCIMGetConnectionResponse) -> Unit,
-    )
+    public fun getConnection(callback: (SCIMGetConnectionResponse) -> Unit)
 
     /**
      * Gets all groups associated with an organization's SCIM connection.

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIMImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIMImpl.kt
@@ -69,17 +69,14 @@ internal class SCIMImpl(
         }
     }
 
-    override suspend fun getConnection(connectionId: String): SCIMGetConnectionResponse =
+    override suspend fun getConnection(): SCIMGetConnectionResponse =
         withContext(dispatchers.io) {
             api.getConnection()
         }
 
-    override fun getConnection(
-        connectionId: String,
-        callback: (SCIMGetConnectionResponse) -> Unit,
-    ) {
+    override fun getConnection(callback: (SCIMGetConnectionResponse) -> Unit) {
         externalScope.launch(dispatchers.ui) {
-            callback(getConnection(connectionId))
+            callback(getConnection())
         }
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/scim/SCIMImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/scim/SCIMImplTest.kt
@@ -132,7 +132,7 @@ internal class SCIMImplTest {
     @Test
     fun `SCIMImpl getConnection delegates to api`() =
         runTest {
-            val response = impl.getConnection("connection-id")
+            val response = impl.getConnection()
             assert(response is StytchResult.Success)
             coVerify { mockApi.getConnection() }
         }
@@ -140,7 +140,7 @@ internal class SCIMImplTest {
     @Test
     fun `SCIMImpl getConnection with callback calls callback method`() {
         val mockCallback = spyk<(SCIMGetConnectionResponse) -> Unit>()
-        impl.getConnection("connection-id", mockCallback)
+        impl.getConnection(mockCallback)
         verify { mockCallback.invoke(mockGetResponse) }
     }
 

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/SCIMViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/SCIMViewModel.kt
@@ -66,11 +66,7 @@ class SCIMViewModel : ViewModel() {
 
     fun getConnection() {
         viewModelScope.launchAndToggleLoadingState {
-            _currentResponse.value =
-                StytchB2BClient.scim
-                    .getConnection(
-                        connectionId = connectionIdState.text,
-                    ).toFriendlyDisplay()
+            _currentResponse.value = StytchB2BClient.scim.getConnection().toFriendlyDisplay()
         }
     }
 


### PR DESCRIPTION
No ticket.

## Changes:

1. Removes unnecessary `connectionId` parameter from `SCIM.getConnection` methods

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A