### PR TITLE
Add CompletableFuture methods to all api methods

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.network.models.EmailInvites
 import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Discovery interface provides methods for discovering a member's available organizations, creating organizations,
@@ -41,6 +42,12 @@ public interface Discovery {
      * @param callback a callback that receives a [DiscoverOrganizationsResponse]
      */
     public fun listOrganizations(callback: (DiscoverOrganizationsResponse) -> Unit)
+
+    /**
+     * Discover a member's available organizations
+     * @return [DiscoverOrganizationsResponse]
+     */
+    public fun listOrganizationsCompletable(): CompletableFuture<DiscoverOrganizationsResponse>
 
     /**
      * Data class used for wrapping parameters used with exchanging sessions between organizations.
@@ -76,6 +83,17 @@ public interface Discovery {
         parameters: SessionExchangeParameters,
         callback: (IntermediateSessionExchangeResponse) -> Unit,
     )
+
+    /**
+     * Exchange an Intermediate Session for a fully realized Member Session in a desired Organization. This operation
+     * consumes the Intermediate Session. This endpoint can be used to accept invites and create new members via domain
+     * matching.
+     * @param parameters required for exchanging a session between organizations
+     * @return [IntermediateSessionExchangeResponse]
+     */
+    public fun exchangeIntermediateSessionCompletable(
+        parameters: SessionExchangeParameters,
+    ): CompletableFuture<IntermediateSessionExchangeResponse>
 
     /**
      * A data class used for wrapping parameters used with creating organizations
@@ -148,4 +166,16 @@ public interface Discovery {
         parameters: CreateOrganizationParameters,
         callback: (OrganizationCreateResponse) -> Unit,
     )
+
+    /**
+     * Create a new organization. If an end user does not want to join any already-existing organization, or has no
+     * possible organizations to join, this endpoint can be used to create a new Organization and Member. This operation
+     * consumes the Intermediate Session. This endpoint can also be used to start an initial session for the newly
+     * created member and organization.
+     * @param parameters required for creating an organization
+     * @return [OrganizationCreateResponse]
+     */
+    public fun createOrganizationCompletable(
+        parameters: CreateOrganizationParameters,
+    ): CompletableFuture<OrganizationCreateResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.network.models.Locale
+import java.util.concurrent.CompletableFuture
 
 /**
  * The B2BMagicLinks interface provides methods for sending and authenticating users with Email Magic Links.
@@ -66,6 +67,15 @@ public interface B2BMagicLinks {
     )
 
     /**
+     * Authenticate a Member with a Magic Link. This endpoint requires a Magic Link token that is not expired or
+     * previously used. Provide a value for session_duration_minutes to receive a Session. If the Member’s status is
+     * pending, they will be updated to active.
+     * @param parameters required to authenticate
+     * @return [EMLAuthenticateResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<EMLAuthenticateResponse>
+
+    /**
      * A data class used for wrapping parameters used for authenticating a discovery magic link
      * @property token the discovery magic links token
      */
@@ -91,6 +101,16 @@ public interface B2BMagicLinks {
         parameters: DiscoveryAuthenticateParameters,
         callback: (DiscoveryEMLAuthResponse) -> Unit,
     )
+
+    /**
+     * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
+     * expired or previously used.
+     * @param parameters required to authenticate
+     * @return [DiscoveryEMLAuthResponse]
+     */
+    public fun discoveryAuthenticateCompletable(
+        parameters: DiscoveryAuthenticateParameters,
+    ): CompletableFuture<DiscoveryEMLAuthResponse>
 
     /**
      * Provides all possible ways to call EmailMagicLinks endpoints
@@ -145,6 +165,14 @@ public interface B2BMagicLinks {
         )
 
         /**
+         * Send either a login or signup magic link to a Member. A new or pending Member will receive a signup
+         * Email Magic Link. An active Member will receive a login Email Magic Link.
+         * @param parameters required to receive magic link
+         * @return [BaseResponse]
+         */
+        public fun loginOrSignupCompletable(parameters: Parameters): CompletableFuture<BaseResponse>
+
+        /**
          * A data class used for wrapping paramaters used for sending a discovery magic link
          * @property emailAddress is the account identifier for the account in the form of an Email address where you
          * wish to receive a magic link to authenticate
@@ -181,6 +209,13 @@ public interface B2BMagicLinks {
             parameters: DiscoverySendParameters,
             callback: (BaseResponse) -> Unit,
         )
+
+        /**
+         * Send a discovery magic link to an email address
+         * @param parameters required to send a discovery magic link
+         * @return [BaseResponse]
+         */
+        public fun discoverySendCompletable(parameters: DiscoverySendParameters): CompletableFuture<BaseResponse>
 
         /**
          * A data class used for wrapping paramaters used for sending an invite magic link
@@ -237,5 +272,14 @@ public interface B2BMagicLinks {
             parameters: InviteParameters,
             callback: (MemberResponse) -> Unit,
         )
+
+        /**
+         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
+         * status until they successfully authenticate. Sending invites to pending Members will update their status to
+         * invited. Sending invites to already active Members will return an error.
+         * @param parameters required to send an invite magic link
+         * @return [MemberResponse]
+         */
+        public fun inviteCompletable(parameters: InviteParameters): CompletableFuture<MemberResponse>
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -13,8 +13,11 @@ import com.stytch.sdk.common.errors.StytchFailedToCreateCodeChallengeError
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class B2BMagicLinksImpl internal constructor(
     private val externalScope: CoroutineScope,
@@ -51,6 +54,14 @@ internal class B2BMagicLinksImpl internal constructor(
         }
     }
 
+    override fun authenticateCompletable(
+        parameters: B2BMagicLinks.AuthParameters,
+    ): CompletableFuture<EMLAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
+
     override suspend fun discoveryAuthenticate(
         parameters: B2BMagicLinks.DiscoveryAuthenticateParameters,
     ): DiscoveryEMLAuthResponse {
@@ -76,6 +87,14 @@ internal class B2BMagicLinksImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun discoveryAuthenticateCompletable(
+        parameters: B2BMagicLinks.DiscoveryAuthenticateParameters,
+    ): CompletableFuture<DiscoveryEMLAuthResponse> =
+        externalScope
+            .async {
+                discoveryAuthenticate(parameters)
+            }.asCompletableFuture()
 
     private inner class EmailMagicLinksImpl : B2BMagicLinks.EmailMagicLinks {
         override suspend fun loginOrSignup(parameters: B2BMagicLinks.EmailMagicLinks.Parameters): BaseResponse {
@@ -117,6 +136,14 @@ internal class B2BMagicLinksImpl internal constructor(
             }
         }
 
+        override fun loginOrSignupCompletable(
+            parameters: B2BMagicLinks.EmailMagicLinks.Parameters,
+        ): CompletableFuture<BaseResponse> =
+            externalScope
+                .async {
+                    loginOrSignup(parameters)
+                }.asCompletableFuture()
+
         override suspend fun discoverySend(
             parameters: B2BMagicLinks.EmailMagicLinks.DiscoverySendParameters,
         ): BaseResponse {
@@ -152,6 +179,14 @@ internal class B2BMagicLinksImpl internal constructor(
             }
         }
 
+        override fun discoverySendCompletable(
+            parameters: B2BMagicLinks.EmailMagicLinks.DiscoverySendParameters,
+        ): CompletableFuture<BaseResponse> =
+            externalScope
+                .async {
+                    discoverySend(parameters)
+                }.asCompletableFuture()
+
         override suspend fun invite(parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters): MemberResponse =
             withContext(dispatchers.io) {
                 emailApi.invite(
@@ -174,5 +209,13 @@ internal class B2BMagicLinksImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun inviteCompletable(
+            parameters: B2BMagicLinks.EmailMagicLinks.InviteParameters,
+        ): CompletableFuture<MemberResponse> =
+            externalScope
+                .async {
+                    invite(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/Member.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/Member.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.UpdateMemberResponse
 import com.stytch.sdk.b2b.network.models.MemberData
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Member interface provides methods for retrieving and updating the current authenticated member.
@@ -33,6 +34,12 @@ public interface Member {
      * @param callback a callback that receives a [MemberResponse]
      */
     public fun get(callback: (MemberResponse) -> Unit)
+
+    /**
+     * Wraps Stytch’s organization/members/me endpoint.
+     * @return [MemberResponse]
+     */
+    public fun getCompletable(): CompletableFuture<MemberResponse>
 
     /**
      * Get member from memory without network call
@@ -81,6 +88,13 @@ public interface Member {
     )
 
     /**
+     * Updates the currently authenticated member
+     * @param params required to update the member
+     * @return [UpdateMemberResponse]
+     */
+    public fun updateCompletable(params: UpdateParams): CompletableFuture<UpdateMemberResponse>
+
+    /**
      * Deletes a [MemberAuthenticationFactor] from the currently authenticated member
      * @return [DeleteMemberAuthenticationFactorResponse]
      */
@@ -94,4 +108,12 @@ public interface Member {
         factor: MemberAuthenticationFactor,
         callback: (DeleteMemberAuthenticationFactorResponse) -> Unit,
     )
+
+    /**
+     * Deletes a [MemberAuthenticationFactor] from the currently authenticated member
+     * @return [DeleteMemberAuthenticationFactorResponse]
+     */
+    public fun deleteFactorCompletable(
+        factor: MemberAuthenticationFactor,
+    ): CompletableFuture<DeleteMemberAuthenticationFactorResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberImpl.kt
@@ -9,9 +9,12 @@ import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class MemberImpl(
     private val externalScope: CoroutineScope,
@@ -53,6 +56,12 @@ internal class MemberImpl(
         }
     }
 
+    override fun getCompletable(): CompletableFuture<MemberResponse> =
+        externalScope
+            .async {
+                get()
+            }.asCompletableFuture()
+
     override fun getSync(): MemberData? = sessionStorage.member
 
     override suspend fun update(params: Member.UpdateParams): UpdateMemberResponse =
@@ -76,6 +85,12 @@ internal class MemberImpl(
         }
     }
 
+    override fun updateCompletable(params: Member.UpdateParams): CompletableFuture<UpdateMemberResponse> =
+        externalScope
+            .async {
+                update(params)
+            }.asCompletableFuture()
+
     override suspend fun deleteFactor(factor: MemberAuthenticationFactor): DeleteMemberAuthenticationFactorResponse =
         withContext(dispatchers.io) {
             when (factor) {
@@ -98,4 +113,12 @@ internal class MemberImpl(
             callback(result)
         }
     }
+
+    override fun deleteFactorCompletable(
+        factor: MemberAuthenticationFactor,
+    ): CompletableFuture<DeleteMemberAuthenticationFactorResponse> =
+        externalScope
+            .async {
+                deleteFactor(factor)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.OAuthAuthenticateResponse
 import com.stytch.sdk.b2b.OAuthDiscoveryAuthenticateResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.network.models.Locale
+import java.util.concurrent.CompletableFuture
 
 /**
  * The OAuth interface provides methods for authenticating a user, via the supported OAuth providers, provided you have
@@ -123,6 +124,15 @@ public interface OAuth {
             parameters: DiscoveryAuthenticateParameters,
             callback: (OAuthDiscoveryAuthenticateResponse) -> Unit,
         )
+
+        /**
+         * Authenticate an OAuth Discovery flow
+         * @param parameters required to authenticate the OAuth Discovery flow
+         * @return [OAuthDiscoveryAuthenticateResponse]
+         */
+        public fun authenticateCompletable(
+            parameters: DiscoveryAuthenticateParameters,
+        ): CompletableFuture<OAuthDiscoveryAuthenticateResponse>
     }
 
     /**
@@ -171,4 +181,13 @@ public interface OAuth {
         parameters: AuthenticateParameters,
         callback: (OAuthAuthenticateResponse) -> Unit,
     )
+
+    /**
+     * Authenticate an OAuth flow
+     * @param parameters required to authenticate the OAuth flow
+     * @return [OAuthAuthenticateResponse]
+     */
+    public fun authenticateCompletable(
+        parameters: AuthenticateParameters,
+    ): CompletableFuture<OAuthAuthenticateResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -15,8 +15,11 @@ import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.utils.buildUri
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class OAuthImpl(
     private val externalScope: CoroutineScope,
@@ -68,6 +71,14 @@ internal class OAuthImpl(
             callback(authenticate(parameters))
         }
     }
+
+    override fun authenticateCompletable(
+        parameters: OAuth.AuthenticateParameters,
+    ): CompletableFuture<OAuthAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
 
     private inner class ProviderImpl(
         private val providerName: String,
@@ -162,5 +173,13 @@ internal class OAuthImpl(
                 callback(authenticate(parameters))
             }
         }
+
+        override fun authenticateCompletable(
+            parameters: OAuth.Discovery.DiscoveryAuthenticateParameters,
+        ): CompletableFuture<OAuthDiscoveryAuthenticateResponse> =
+            externalScope
+                .async {
+                    authenticate(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
@@ -22,6 +22,7 @@ import com.stytch.sdk.b2b.network.models.OrganizationData
 import com.stytch.sdk.b2b.network.models.SearchOperator
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Organization interface provides methods for retrieving, updating, and deleting the current authenticated user's
@@ -44,6 +45,12 @@ public interface Organization {
      * @return [OrganizationResponse]
      */
     public suspend fun get(): OrganizationResponse
+
+    /**
+     * Wraps Stytch’s organization/me endpoint.
+     * @return [OrganizationResponse]
+     */
+    public fun getCompletable(): CompletableFuture<OrganizationResponse>
 
     /**
      * Wraps Stytch’s organization/me endpoint.
@@ -129,6 +136,18 @@ public interface Organization {
     )
 
     /**
+     * Updates the Organization of the logged-in member.
+     * The member must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+     * An Organization must always have at least one auth setting set to either RESTRICTED or ALL_ALLOWED in order to
+     * provision new Members.
+     * @param parameters the parameters required for updating an organization
+     * @return [UpdateOrganizationResponse]
+     */
+    public fun updateCompletable(
+        parameters: UpdateOrganizationParameters,
+    ): CompletableFuture<UpdateOrganizationResponse>
+
+    /**
      * Deletes the Organization of the logged-in member. All Members of the Organization will also be deleted.
      * The member must have permission to call this endpoint via the project's RBAC policy & their role assignments.
      * Note: This endpoint will log out the current member, as they will also be deleted
@@ -143,6 +162,14 @@ public interface Organization {
      * @param callback a callback that receives a [DeleteOrganizationResponse]
      */
     public fun delete(callback: (DeleteOrganizationResponse) -> Unit)
+
+    /**
+     * Deletes the Organization of the logged-in member. All Members of the Organization will also be deleted.
+     * The member must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+     * Note: This endpoint will log out the current member, as they will also be deleted
+     * @return [DeleteOrganizationResponse]
+     */
+    public fun deleteCompletable(): CompletableFuture<DeleteOrganizationResponse>
 
     /**
      * Public variable that exposes an instance of Organization.Members
@@ -174,6 +201,14 @@ public interface Organization {
         )
 
         /**
+         * Deletes a Member.
+         * The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+         * @param memberId The ID of the member to be deleted
+         * @return [DeleteMemberResponse]
+         */
+        public fun deleteCompletable(memberId: String): CompletableFuture<DeleteMemberResponse>
+
+        /**
          * Reactivates a deleted Member's status and its associated email status (if applicable) to active.
          * The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
          * @param memberId The ID of the member to be reactivated
@@ -191,6 +226,14 @@ public interface Organization {
             memberId: String,
             callback: (ReactivateMemberResponse) -> Unit,
         )
+
+        /**
+         * Reactivates a deleted Member's status and its associated email status (if applicable) to active.
+         * The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+         * @param memberId The ID of the member to be reactivated
+         * @return [ReactivateMemberResponse]
+         */
+        public fun reactivateCompletable(memberId: String): CompletableFuture<ReactivateMemberResponse>
 
         /**
          * Deletes a [MemberAuthenticationFactor] from the currently authenticated member
@@ -212,6 +255,16 @@ public interface Organization {
             authenticationFactor: MemberAuthenticationFactor,
             callback: (DeleteOrganizationMemberAuthenticationFactorResponse) -> Unit,
         )
+
+        /**
+         * Deletes a [MemberAuthenticationFactor] from the currently authenticated member
+         * @param authenticationFactor the authentication factor to delete
+         * @return [DeleteOrganizationMemberAuthenticationFactorResponse]
+         */
+        public fun deleteMemberAuthenticationFactorCompletable(
+            memberId: String,
+            authenticationFactor: MemberAuthenticationFactor,
+        ): CompletableFuture<DeleteOrganizationMemberAuthenticationFactorResponse>
 
         /**
          * Data class used for wrapping the parameters necessary for creating a user
@@ -263,6 +316,14 @@ public interface Organization {
             parameters: CreateMemberParameters,
             callback: (CreateMemberResponse) -> Unit,
         )
+
+        /**
+         * Creates a Member.
+         * The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+         * @param parameters the parameters required for creating a user
+         * @return [CreateMemberResponse]
+         */
+        public fun createCompletable(parameters: CreateMemberParameters): CompletableFuture<CreateMemberResponse>
 
         /**
          * Data class used for wrapping the parameters necessary for creating a user
@@ -320,6 +381,16 @@ public interface Organization {
             parameters: UpdateMemberParameters,
             callback: (UpdateOrganizationMemberResponse) -> Unit,
         )
+
+        /**
+         * Updates a Member.
+         * The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+         * @param parameters the parameters required for updating a user
+         * @return [UpdateOrganizationMemberResponse]
+         */
+        public fun updateCompletable(
+            parameters: UpdateMemberParameters,
+        ): CompletableFuture<UpdateOrganizationMemberResponse>
 
         /**
          * Data class used for wrapping the parameters necessary to search members
@@ -493,5 +564,14 @@ public interface Organization {
             parameters: SearchParameters,
             callback: (MemberSearchResponse) -> Unit,
         )
+
+        /**
+         * Search for Members from the caller's organization. Submitting an empty query returns all non-deleted Members.
+         * All fuzzy search filters require a minimum of three characters.
+         * The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+         * @param parameters the parameters for searching
+         * @return [MemberSearchResponse]
+         */
+        public fun searchCompletable(parameters: SearchParameters): CompletableFuture<MemberSearchResponse>
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
@@ -246,9 +246,11 @@ internal class OrganizationImpl(
 
         override fun createCompletable(
             parameters: Organization.OrganizationMembers.CreateMemberParameters,
-        ): CompletableFuture<CreateMemberResponse> {
-            TODO("Not yet implemented")
-        }
+        ): CompletableFuture<CreateMemberResponse> =
+            externalScope
+                .async {
+                    create(parameters)
+                }.asCompletableFuture()
 
         override suspend fun update(
             parameters: Organization.OrganizationMembers.UpdateMemberParameters,
@@ -319,8 +321,10 @@ internal class OrganizationImpl(
 
         override fun searchCompletable(
             parameters: Organization.OrganizationMembers.SearchParameters,
-        ): CompletableFuture<MemberSearchResponse> {
-            TODO("Not yet implemented")
-        }
+        ): CompletableFuture<MemberSearchResponse> =
+            externalScope
+                .async {
+                    search(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
@@ -17,9 +17,12 @@ import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class OrganizationImpl(
     private val externalScope: CoroutineScope,
@@ -61,31 +64,38 @@ internal class OrganizationImpl(
         }
     }
 
+    override fun getCompletable(): CompletableFuture<OrganizationResponse> =
+        externalScope
+            .async {
+                get()
+            }.asCompletableFuture()
+
     override fun getSync(): OrganizationData? = sessionStorage.organization
 
     override suspend fun update(parameters: Organization.UpdateOrganizationParameters): UpdateOrganizationResponse =
         withContext(dispatchers.io) {
-            api.updateOrganization(
-                organizationName = parameters.organizationName,
-                organizationSlug = parameters.organizationSlug,
-                organizationLogoUrl = parameters.organizationLogoUrl,
-                ssoDefaultConnectionId = parameters.ssoDefaultConnectionId,
-                ssoJitProvisioning = parameters.ssoJitProvisioning,
-                ssoJitProvisioningAllowedConnections = parameters.ssoJitProvisioningAllowedConnections,
-                emailAllowedDomains = parameters.emailAllowedDomains,
-                emailJitProvisioning = parameters.emailJitProvisioning,
-                emailInvites = parameters.emailInvites,
-                authMethods = parameters.authMethods,
-                allowedAuthMethods = parameters.allowedAuthMethods,
-                mfaMethods = parameters.mfaMethods,
-                allowedMfaMethods = parameters.allowedMfaMethods,
-                mfaPolicy = parameters.mfaPolicy,
-                rbacEmailImplicitRoleAssignments = parameters.rbacEmailImplicitRoleAssignments,
-            ).apply {
-                if (this is StytchResult.Success) {
-                    sessionStorage.organization = this.value.organization
+            api
+                .updateOrganization(
+                    organizationName = parameters.organizationName,
+                    organizationSlug = parameters.organizationSlug,
+                    organizationLogoUrl = parameters.organizationLogoUrl,
+                    ssoDefaultConnectionId = parameters.ssoDefaultConnectionId,
+                    ssoJitProvisioning = parameters.ssoJitProvisioning,
+                    ssoJitProvisioningAllowedConnections = parameters.ssoJitProvisioningAllowedConnections,
+                    emailAllowedDomains = parameters.emailAllowedDomains,
+                    emailJitProvisioning = parameters.emailJitProvisioning,
+                    emailInvites = parameters.emailInvites,
+                    authMethods = parameters.authMethods,
+                    allowedAuthMethods = parameters.allowedAuthMethods,
+                    mfaMethods = parameters.mfaMethods,
+                    allowedMfaMethods = parameters.allowedMfaMethods,
+                    mfaPolicy = parameters.mfaPolicy,
+                    rbacEmailImplicitRoleAssignments = parameters.rbacEmailImplicitRoleAssignments,
+                ).apply {
+                    if (this is StytchResult.Success) {
+                        sessionStorage.organization = this.value.organization
+                    }
                 }
-            }
         }
 
     override fun update(
@@ -97,6 +107,14 @@ internal class OrganizationImpl(
             callback(result)
         }
     }
+
+    override fun updateCompletable(
+        parameters: Organization.UpdateOrganizationParameters,
+    ): CompletableFuture<UpdateOrganizationResponse> =
+        externalScope
+            .async {
+                update(parameters)
+            }.asCompletableFuture()
 
     override suspend fun delete(): DeleteOrganizationResponse =
         withContext(dispatchers.io) {
@@ -116,6 +134,12 @@ internal class OrganizationImpl(
         }
     }
 
+    override fun deleteCompletable(): CompletableFuture<DeleteOrganizationResponse> =
+        externalScope
+            .async {
+                delete()
+            }.asCompletableFuture()
+
     override val members: Organization.OrganizationMembers = OrganizationMembersImpl()
 
     private inner class OrganizationMembersImpl : Organization.OrganizationMembers {
@@ -134,6 +158,12 @@ internal class OrganizationImpl(
             }
         }
 
+        override fun deleteCompletable(memberId: String): CompletableFuture<DeleteMemberResponse> =
+            externalScope
+                .async {
+                    delete(memberId)
+                }.asCompletableFuture()
+
         override suspend fun reactivate(memberId: String): ReactivateMemberResponse =
             withContext(dispatchers.io) {
                 api.reactivateOrganizationMember(memberId = memberId)
@@ -147,6 +177,12 @@ internal class OrganizationImpl(
                 callback(members.reactivate(memberId))
             }
         }
+
+        override fun reactivateCompletable(memberId: String): CompletableFuture<ReactivateMemberResponse> =
+            externalScope
+                .async {
+                    reactivate(memberId)
+                }.asCompletableFuture()
 
         override suspend fun deleteMemberAuthenticationFactor(
             memberId: String,
@@ -173,6 +209,15 @@ internal class OrganizationImpl(
             }
         }
 
+        override fun deleteMemberAuthenticationFactorCompletable(
+            memberId: String,
+            authenticationFactor: MemberAuthenticationFactor,
+        ): CompletableFuture<DeleteOrganizationMemberAuthenticationFactorResponse> =
+            externalScope
+                .async {
+                    deleteMemberAuthenticationFactor(memberId, authenticationFactor)
+                }.asCompletableFuture()
+
         override suspend fun create(
             parameters: Organization.OrganizationMembers.CreateMemberParameters,
         ): CreateMemberResponse =
@@ -197,6 +242,12 @@ internal class OrganizationImpl(
                 val result = members.create(parameters)
                 callback(result)
             }
+        }
+
+        override fun createCompletable(
+            parameters: Organization.OrganizationMembers.CreateMemberParameters,
+        ): CompletableFuture<CreateMemberResponse> {
+            TODO("Not yet implemented")
         }
 
         override suspend fun update(
@@ -225,6 +276,14 @@ internal class OrganizationImpl(
                 callback(update(parameters))
             }
         }
+
+        override fun updateCompletable(
+            parameters: Organization.OrganizationMembers.UpdateMemberParameters,
+        ): CompletableFuture<UpdateOrganizationMemberResponse> =
+            externalScope
+                .async {
+                    update(parameters)
+                }.asCompletableFuture()
 
         override suspend fun search(
             parameters: Organization.OrganizationMembers.SearchParameters,
@@ -256,6 +315,12 @@ internal class OrganizationImpl(
             externalScope.launch(dispatchers.ui) {
                 callback(members.search(parameters))
             }
+        }
+
+        override fun searchCompletable(
+            parameters: Organization.OrganizationMembers.SearchParameters,
+        ): CompletableFuture<MemberSearchResponse> {
+            TODO("Not yet implemented")
         }
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.SMSAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.network.models.Locale
+import java.util.concurrent.CompletableFuture
 
 /**
  * The OTP interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS
@@ -62,6 +63,13 @@ public interface OTP {
         )
 
         /**
+         * Send a one-time passcode (OTP) to a user using their phone number via SMS.
+         * @param parameters required to receive a SMS OTP
+         * @return [BasicResponse]
+         */
+        public fun sendCompletable(parameters: SendParameters): CompletableFuture<BasicResponse>
+
+        /**
          * A data class wrapping the parameters needed to authenticate an SMS OTP
          * @property organizationId The ID of the organization the member belongs to
          * @property memberId The ID of the member to send the OTP to
@@ -97,5 +105,14 @@ public interface OTP {
             parameters: AuthenticateParameters,
             callback: (SMSAuthenticateResponse) -> Unit,
         )
+
+        /**
+         * Authenticate a one-time passcode (OTP) sent to a user via SMS.
+         * @param parameters required to authenticate an SMS OTP
+         * @return [SMSAuthenticateResponse]
+         */
+        public fun authenticateCompletable(
+            parameters: AuthenticateParameters,
+        ): CompletableFuture<SMSAuthenticateResponse>
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
@@ -8,8 +8,11 @@ import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.StytchDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class OTPImpl(
     private val externalScope: CoroutineScope,
@@ -45,6 +48,12 @@ internal class OTPImpl(
             }
         }
 
+        override fun sendCompletable(parameters: OTP.SMS.SendParameters): CompletableFuture<BasicResponse> =
+            externalScope
+                .async {
+                    send(parameters)
+                }.asCompletableFuture()
+
         override suspend fun authenticate(parameters: OTP.SMS.AuthenticateParameters): SMSAuthenticateResponse =
             withContext(dispatchers.io) {
                 api
@@ -68,5 +77,13 @@ internal class OTPImpl(
                 callback(authenticate(parameters))
             }
         }
+
+        override fun authenticateCompletable(
+            parameters: OTP.SMS.AuthenticateParameters,
+        ): CompletableFuture<SMSAuthenticateResponse> =
+            externalScope
+                .async {
+                    authenticate(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
@@ -8,6 +8,7 @@ import com.stytch.sdk.b2b.SessionResetResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.network.models.Locale
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Passwords interface provides methods for authenticating, creating, resetting, and performing strength checks of
@@ -83,6 +84,24 @@ public interface Passwords {
     )
 
     /**
+     * Authenticate a member with their email address and password. This endpoint verifies that the member has a
+     * password currently set, and that the entered password is correct.
+     *
+     * There are two instances where the endpoint will return a reset_password error even if they enter their previous
+     * password:
+     * 1. The member's credentials appeared in the HaveIBeenPwned dataset. We force a password reset to ensure that the
+     * member is the legitimate owner of the email address, and not a malicious actor abusing the compromised
+     * credentials.
+     * 2. The member used email based authentication (e.g. Magic Links, Google OAuth) for the first time, and had not
+     * previously verified their email address for password based login. We force a password reset in this instance in
+     * order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack
+     * account-takeover attack.
+     * @param parameters required to authenticate
+     * @return [PasswordsAuthenticateResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<PasswordsAuthenticateResponse>
+
+    /**
      * Data class used for wrapping parameters used with Passwords ResetByEmailStart endpoint
      * @property organizationId is the member's organization ID
      * @property emailAddress is the member's email address
@@ -124,6 +143,14 @@ public interface Passwords {
     )
 
     /**
+     * Initiates a password reset for the email address provided. This will trigger an email to be sent to the address,
+     * containing a magic link that will allow them to set a new password and authenticate.
+     * @param parameters required to reset an account password
+     * @return [BaseResponse]
+     */
+    public fun resetByEmailStartCompletable(parameters: ResetByEmailStartParameters): CompletableFuture<BaseResponse>
+
+    /**
      * Data class used for wrapping parameters used with Passwords ResetByEmail endpoint
      * @property token is the unique sequence of characters that should be received after calling the resetByEmailStart
      * @property password is the private sequence of characters you wish to use as a password
@@ -163,6 +190,16 @@ public interface Passwords {
         parameters: ResetByEmailParameters,
         callback: (EmailResetResponse) -> Unit,
     )
+
+    /**
+     * Reset the member’s password and authenticate them. This endpoint checks that the magic link token is valid,
+     * hasn’t expired, or already been used. The provided password needs to meet our password strength requirements,
+     * which can be checked in advance with the [strengthCheck] method. If the token and password are accepted, the
+     * password is securely stored for future authentication and the member is authenticated.
+     * @param parameters required to reset an account password
+     * @return [EmailResetResponse]
+     */
+    public fun resetByEmailCompletable(parameters: ResetByEmailParameters): CompletableFuture<EmailResetResponse>
 
     /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
@@ -212,6 +249,18 @@ public interface Passwords {
     )
 
     /**
+     * Reset the member’s password and authenticate them. This endpoint checks that the existing password matches the
+     * stored value. The provided password needs to meet our password strength requirements, which can be checked in
+     * advance with the password strength endpoint. If the password and accompanying parameters are accepted, the
+     * password is securely stored for future authentication and the member is authenticated.
+     * @param parameters required to reset a member's password
+     * @return [PasswordResetByExistingPasswordResponse]
+     */
+    public fun resetByExistingCompletable(
+        parameters: ResetByExistingPasswordParameters,
+    ): CompletableFuture<PasswordResetByExistingPasswordResponse>
+
+    /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
      * @property organizationId is the member's organization ID
      * @property password is the new password to set
@@ -245,6 +294,16 @@ public interface Passwords {
     )
 
     /**
+     * Reset the member’s password and authenticate them. This endpoint checks that the session is valid and hasn’t
+     * expired or been revoked. The provided password needs to meet our password strength requirements, which can be
+     * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
+     * the password is securely stored for future authentication and the member is authenticated.
+     * @param parameters required to reset a member's password
+     * @return [SessionResetResponse]
+     */
+    public fun resetBySessionCompletable(parameters: ResetBySessionParameters): CompletableFuture<SessionResetResponse>
+
+    /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
      * @property email is the account identifier for the account in the form of an Email address that you wish to use to
      * initiate a password strength check
@@ -275,4 +334,14 @@ public interface Passwords {
         parameters: StrengthCheckParameters,
         callback: (PasswordStrengthCheckResponse) -> Unit,
     )
+
+    /**
+     * This method allows you to check whether or not the member’s provided password is valid, and to provide feedback
+     * to the member on how to increase the strength of their password.
+     * @param parameters required to advise on password strength
+     * @return [PasswordStrengthCheckResponse]
+     */
+    public fun strengthCheckCompletable(
+        parameters: StrengthCheckParameters,
+    ): CompletableFuture<PasswordStrengthCheckResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -15,8 +15,11 @@ import com.stytch.sdk.common.errors.StytchFailedToCreateCodeChallengeError
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 @Suppress("TooManyFunctions")
 internal class PasswordsImpl internal constructor(
@@ -50,6 +53,14 @@ internal class PasswordsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun authenticateCompletable(
+        parameters: Passwords.AuthParameters,
+    ): CompletableFuture<PasswordsAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
 
     override suspend fun resetByEmailStart(parameters: Passwords.ResetByEmailStartParameters): BaseResponse {
         val result: BaseResponse
@@ -85,6 +96,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetByEmailStartCompletable(
+        parameters: Passwords.ResetByEmailStartParameters,
+    ): CompletableFuture<BaseResponse> =
+        externalScope
+            .async {
+                resetByEmailStart(parameters)
+            }.asCompletableFuture()
+
     override suspend fun resetByEmail(parameters: Passwords.ResetByEmailParameters): EmailResetResponse {
         val codeVerifier =
             pkcePairManager.getPKCECodePair()?.codeVerifier ?: return StytchResult.Error(StytchMissingPKCEError(null))
@@ -114,6 +133,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetByEmailCompletable(
+        parameters: Passwords.ResetByEmailParameters,
+    ): CompletableFuture<EmailResetResponse> =
+        externalScope
+            .async {
+                resetByEmail(parameters)
+            }.asCompletableFuture()
+
     override suspend fun resetByExisting(
         parameters: Passwords.ResetByExistingPasswordParameters,
     ): PasswordResetByExistingPasswordResponse =
@@ -141,6 +168,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetByExistingCompletable(
+        parameters: Passwords.ResetByExistingPasswordParameters,
+    ): CompletableFuture<PasswordResetByExistingPasswordResponse> =
+        externalScope
+            .async {
+                resetByExisting(parameters)
+            }.asCompletableFuture()
+
     override suspend fun resetBySession(parameters: Passwords.ResetBySessionParameters): SessionResetResponse =
         withContext(dispatchers.io) {
             api.resetBySession(
@@ -159,6 +194,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetBySessionCompletable(
+        parameters: Passwords.ResetBySessionParameters,
+    ): CompletableFuture<SessionResetResponse> =
+        externalScope
+            .async {
+                resetBySession(parameters)
+            }.asCompletableFuture()
+
     override suspend fun strengthCheck(parameters: Passwords.StrengthCheckParameters): PasswordStrengthCheckResponse =
         withContext(dispatchers.io) {
             api.strengthCheck(
@@ -176,4 +219,12 @@ internal class PasswordsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun strengthCheckCompletable(
+        parameters: Passwords.StrengthCheckParameters,
+    ): CompletableFuture<PasswordStrengthCheckResponse> =
+        externalScope
+            .async {
+                strengthCheck(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/rbac/RBAC.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/rbac/RBAC.kt
@@ -1,5 +1,7 @@
 package com.stytch.sdk.b2b.rbac
 
+import java.util.concurrent.CompletableFuture
+
 /**
  * The RBAC interface provides methods for checking a user's permissions according to the roles defined in the Stytch
  * Dashboard
@@ -53,6 +55,21 @@ public interface RBAC {
     )
 
     /**
+     * Determines whether the logged-in member is allowed to perform the specified action on the specified resource.
+     * Returns `true` if the member can perform the action, `false` otherwise.
+     *
+     * If the member is not logged in, this method will always return false.
+     * If the resource or action provided are not valid for the configured RBAC policy, this method will return false.
+     *
+     * To check authorization using cached data, use {@link isAuthorizedSync}.
+     * Remember - authorization checks for sensitive actions should always occur on the backend as well.
+     */
+    public fun isAuthorizedCompletable(
+        resourceId: String,
+        action: String,
+    ): CompletableFuture<Boolean>
+
+    /**
      * Evaluates all permissions granted to the logged-in member.
      * Returns a Map<RoleId, Map<Action, Boolean>> response indicating the member's permissions.
      * Each boolean will be `true` if the member can perform the action, `false` otherwise.
@@ -73,4 +90,15 @@ public interface RBAC {
      * Remember - authorization checks for sensitive actions should always occur on the backend as well.
      */
     public fun allPermissions(callback: (Map<String, Map<String, Boolean>>) -> Unit)
+
+    /**
+     * Evaluates all permissions granted to the logged-in member.
+     * Returns a Map<RoleId, Map<Action, Boolean>> response indicating the member's permissions.
+     * Each boolean will be `true` if the member can perform the action, `false` otherwise.
+     *
+     * If the member is not logged in, all values will be false.
+     *
+     * Remember - authorization checks for sensitive actions should always occur on the backend as well.
+     */
+    public fun allPermissionsCompletable(): CompletableFuture<Map<String, Map<String, Boolean>>>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodes.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodes.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.recoveryCodes
 import com.stytch.sdk.b2b.RecoveryCodesGetResponse
 import com.stytch.sdk.b2b.RecoveryCodesRecoverResponse
 import com.stytch.sdk.b2b.RecoveryCodesRotateResponse
+import java.util.concurrent.CompletableFuture
 
 /**
  * The RecoveryCodes interface provides methods for getting, rotating, and using recovery codes for a member
@@ -21,6 +22,12 @@ public interface RecoveryCodes {
     public fun get(callback: (RecoveryCodesGetResponse) -> Unit)
 
     /**
+     * Get the recovery codes for an authenticated member
+     * @return [RecoveryCodesGetResponse]
+     */
+    public fun getCompletable(): CompletableFuture<RecoveryCodesGetResponse>
+
+    /**
      * Rotate the recovery codes for an authenticated member
      * @return [RecoveryCodesRotateResponse]
      */
@@ -31,6 +38,12 @@ public interface RecoveryCodes {
      * @param callback a callback that receives a [RecoveryCodesRotateResponse]
      */
     public fun rotate(callback: (RecoveryCodesRotateResponse) -> Unit)
+
+    /**
+     * Rotate the recovery codes for an authenticated member
+     * @return [RecoveryCodesRotateResponse]
+     */
+    public fun rotateCompletable(): CompletableFuture<RecoveryCodesRotateResponse>
 
     /**
      * A data class wrapping the parameters needed to consume a recovery code
@@ -62,4 +75,11 @@ public interface RecoveryCodes {
         parameters: RecoverParameters,
         callback: (RecoveryCodesRecoverResponse) -> Unit,
     )
+
+    /**
+     * Consume a recovery code for a member
+     * @param parameters the parameters needed to consume a recovery code
+     * @return [RecoveryCodesRecoverResponse]
+     */
+    public fun recoverCompletable(parameters: RecoverParameters): CompletableFuture<RecoveryCodesRecoverResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.SCIMRotateCompleteResponse
 import com.stytch.sdk.b2b.SCIMRotateStartResponse
 import com.stytch.sdk.b2b.SCIMUpdateConnectionResponse
 import com.stytch.sdk.b2b.network.models.SCIMGroupImplicitRoleAssignment
+import java.util.concurrent.CompletableFuture
 
 /**
  * The SCIM interface provides methods for creating, getting, updating, deleting, and rotating SCIM connections
@@ -72,6 +73,17 @@ public interface SCIM {
     )
 
     /**
+     * Creates a new SCIM connection.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/create-scim-connection create-connection} endpoint.
+     * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
+     * @param parameters the parameters necessary to create a SCIM connection
+     * @return [SCIMCreateConnectionResponse]
+     */
+    public fun createConnectionCompletable(
+        parameters: CreateConnectionParameters,
+    ): CompletableFuture<SCIMCreateConnectionResponse>
+
+    /**
      *  Updates an existing SCIM connection.
      *  This method wraps the {@link https://stytch.com/docs/b2b/api/update-scim-connection update-connection} endpoint.
      *  If attempting to modify the `scim_group_implicit_role_assignments` the caller must have the
@@ -99,6 +111,20 @@ public interface SCIM {
     )
 
     /**
+     *  Updates an existing SCIM connection.
+     *  This method wraps the {@link https://stytch.com/docs/b2b/api/update-scim-connection update-connection} endpoint.
+     *  If attempting to modify the `scim_group_implicit_role_assignments` the caller must have the
+     *  `update.settings.implicit-roles` permission on the `stytch.organization` resource. For all other fields, the
+     *  caller must have the `update` permission on the `stytch.scim` resource. SCIM via the project's RBAC policy &
+     *  their role assignments.
+     *  @param parameters the parameters necessary to update a SCIM connection
+     *  @return [SCIMUpdateConnectionResponse]
+     */
+    public fun updateConnectionCompletable(
+        parameters: UpdateConnectionParameters,
+    ): CompletableFuture<SCIMUpdateConnectionResponse>
+
+    /**
      * Deletes an existing SCIM connection.
      * This method wraps the {@link https://stytch.com/docs/b2b/api/delete-scim-connection delete-connection} endpoint.
      * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
@@ -120,6 +146,15 @@ public interface SCIM {
     )
 
     /**
+     * Deletes an existing SCIM connection.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/delete-scim-connection delete-connection} endpoint.
+     * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
+     * @param connectionId the ID of the connection to be deleted
+     * @return [SCIMDeleteConnectionResponse]
+     */
+    public fun deleteConnectionCompletable(connectionId: String): CompletableFuture<SCIMDeleteConnectionResponse>
+
+    /**
      * Gets the SCIM connection for an organization.
      * This method wraps the {@link https://stytch.com/docs/b2b/api/get-scim-connection get-connection} endpoint. The
      * caller must have permission to view SCIM via the project's RBAC policy & their role assignments.
@@ -134,6 +169,14 @@ public interface SCIM {
      * @param callback a callback that receives a [SCIMGetConnectionResponse]
      */
     public fun getConnection(callback: (SCIMGetConnectionResponse) -> Unit)
+
+    /**
+     * Gets the SCIM connection for an organization.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/get-scim-connection get-connection} endpoint. The
+     * caller must have permission to view SCIM via the project's RBAC policy & their role assignments.
+     * @return [SCIMGetConnectionResponse]
+     */
+    public fun getConnectionCompletable(): CompletableFuture<SCIMGetConnectionResponse>
 
     /**
      * Gets all groups associated with an organization's SCIM connection.
@@ -157,6 +200,17 @@ public interface SCIM {
     )
 
     /**
+     * Gets all groups associated with an organization's SCIM connection.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/get-scim-connection-groups get-connection-groups}
+     * endpoint. The caller must have permission to view SCIM via the project's RBAC policy & their role assignments.
+     * @param parameters the parameters necessary to get connection groups
+     * @return [SCIMGetConnectionGroupsResponse]
+     */
+    public fun getConnectionGroupsCompletable(
+        parameters: GetConnectionGroupsParameters,
+    ): CompletableFuture<SCIMGetConnectionGroupsResponse>
+
+    /**
      * Starts the SCIM bearer token rotation process.
      * This method wraps the {@link https://stytch.com/docs/b2b/api/scim-rotate-token-start start-rotation} endpoint.
      * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
@@ -176,6 +230,15 @@ public interface SCIM {
         connectionId: String,
         callback: (SCIMRotateStartResponse) -> Unit,
     )
+
+    /**
+     * Starts the SCIM bearer token rotation process.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/scim-rotate-token-start start-rotation} endpoint.
+     * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
+     * @param connectionId the ID of the connection to start the bearer token rotation process
+     * @return [SCIMRotateStartResponse]
+     */
+    public fun rotateStartCompletable(connectionId: String): CompletableFuture<SCIMRotateStartResponse>
 
     /**
      * Completes the SCIM bearer token rotate, removing the old bearer token from operation.
@@ -199,6 +262,15 @@ public interface SCIM {
     )
 
     /**
+     * Completes the SCIM bearer token rotate, removing the old bearer token from operation.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/scim-rotate-token-complete complete-rotation}
+     * endpoint. The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
+     * @param connectionId the ID of the connection to complete the bearer token rotation process
+     * @return [SCIMRotateCompleteResponse]
+     */
+    public fun rotateCompleteCompletable(connectionId: String): CompletableFuture<SCIMRotateCompleteResponse>
+
+    /**
      * Cancels the SCIM bearer token rotate, removing the new bearer token issued.
      * This method wraps the {@link https://stytch.com/docs/b2b/api/scim-rotate-token-cancel cancel-rotation} endpoint.
      * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
@@ -218,4 +290,13 @@ public interface SCIM {
         connectionId: String,
         callback: (SCIMRotateCancelResponse) -> Unit,
     )
+
+    /**
+     * Cancels the SCIM bearer token rotate, removing the new bearer token issued.
+     * This method wraps the {@link https://stytch.com/docs/b2b/api/scim-rotate-token-cancel cancel-rotation} endpoint.
+     * The caller must have permission to modify SCIM via the project's RBAC policy & their role assignments.
+     * @param connectionId the ID of the connection to cancel a bearer token rotation process
+     * @return [SCIMRotateCancelResponse]
+     */
+    public fun rotateCancelCompletable(connectionId: String): CompletableFuture<SCIMRotateCancelResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIMImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIMImpl.kt
@@ -11,8 +11,11 @@ import com.stytch.sdk.b2b.SCIMUpdateConnectionResponse
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.common.StytchDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class SCIMImpl(
     private val externalScope: CoroutineScope,
@@ -36,6 +39,14 @@ internal class SCIMImpl(
         }
     }
 
+    override fun createConnectionCompletable(
+        parameters: SCIM.CreateConnectionParameters,
+    ): CompletableFuture<SCIMCreateConnectionResponse> =
+        externalScope
+            .async {
+                createConnection(parameters)
+            }.asCompletableFuture()
+
     override suspend fun updateConnection(parameters: SCIM.UpdateConnectionParameters): SCIMUpdateConnectionResponse =
         withContext(dispatchers.io) {
             api.updateConnection(
@@ -55,6 +66,14 @@ internal class SCIMImpl(
         }
     }
 
+    override fun updateConnectionCompletable(
+        parameters: SCIM.UpdateConnectionParameters,
+    ): CompletableFuture<SCIMUpdateConnectionResponse> =
+        externalScope
+            .async {
+                updateConnection(parameters)
+            }.asCompletableFuture()
+
     override suspend fun deleteConnection(connectionId: String): SCIMDeleteConnectionResponse =
         withContext(dispatchers.io) {
             api.deleteConection(connectionId = connectionId)
@@ -69,6 +88,12 @@ internal class SCIMImpl(
         }
     }
 
+    override fun deleteConnectionCompletable(connectionId: String): CompletableFuture<SCIMDeleteConnectionResponse> =
+        externalScope
+            .async {
+                deleteConnection(connectionId)
+            }.asCompletableFuture()
+
     override suspend fun getConnection(): SCIMGetConnectionResponse =
         withContext(dispatchers.io) {
             api.getConnection()
@@ -79,6 +104,12 @@ internal class SCIMImpl(
             callback(getConnection())
         }
     }
+
+    override fun getConnectionCompletable(): CompletableFuture<SCIMGetConnectionResponse> =
+        externalScope
+            .async {
+                getConnection()
+            }.asCompletableFuture()
 
     override suspend fun getConnectionGroups(
         parameters: SCIM.GetConnectionGroupsParameters,
@@ -99,6 +130,14 @@ internal class SCIMImpl(
         }
     }
 
+    override fun getConnectionGroupsCompletable(
+        parameters: SCIM.GetConnectionGroupsParameters,
+    ): CompletableFuture<SCIMGetConnectionGroupsResponse> =
+        externalScope
+            .async {
+                getConnectionGroups(parameters)
+            }.asCompletableFuture()
+
     override suspend fun rotateStart(connectionId: String): SCIMRotateStartResponse =
         withContext(dispatchers.io) {
             api.rotateStart(connectionId = connectionId)
@@ -112,6 +151,12 @@ internal class SCIMImpl(
             callback(rotateStart(connectionId))
         }
     }
+
+    override fun rotateStartCompletable(connectionId: String): CompletableFuture<SCIMRotateStartResponse> =
+        externalScope
+            .async {
+                rotateStart(connectionId)
+            }.asCompletableFuture()
 
     override suspend fun rotateComplete(connectionId: String): SCIMRotateCompleteResponse =
         withContext(dispatchers.io) {
@@ -127,6 +172,12 @@ internal class SCIMImpl(
         }
     }
 
+    override fun rotateCompleteCompletable(connectionId: String): CompletableFuture<SCIMRotateCompleteResponse> =
+        externalScope
+            .async {
+                rotateComplete(connectionId)
+            }.asCompletableFuture()
+
     override suspend fun rotateCancel(connectionId: String): SCIMRotateCancelResponse =
         withContext(dispatchers.io) {
             api.rotateCancel(connectionId = connectionId)
@@ -140,4 +191,10 @@ internal class SCIMImpl(
             callback(rotateCancel(connectionId))
         }
     }
+
+    override fun rotateCancelCompletable(connectionId: String): CompletableFuture<SCIMRotateCancelResponse> =
+        externalScope
+            .async {
+                rotateCancel(connectionId)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.searchManager
 
 import com.stytch.sdk.b2b.B2BSearchMemberResponse
 import com.stytch.sdk.b2b.B2BSearchOrganizationResponse
+import java.util.concurrent.CompletableFuture
 
 /**
  * The SearchManager interface provides methods for searching for organizations and members
@@ -33,6 +34,15 @@ public interface SearchManager {
     )
 
     /**
+     * Search for an organization
+     * @param parameters the parameters needed to make the search request
+     * @return [B2BSearchOrganizationResponse]
+     */
+    public fun searchOrganizationCompletable(
+        parameters: SearchOrganizationParameters,
+    ): CompletableFuture<B2BSearchOrganizationResponse>
+
+    /**
      * A data class wrapping the parameters used for a Search Members call
      * @property emailAddress the email address of the member to search for
      * @property organizationId the id of the organization the member belongs to
@@ -58,4 +68,11 @@ public interface SearchManager {
         parameters: SearchMemberParameters,
         callback: (B2BSearchMemberResponse) -> Unit,
     )
+
+    /**
+     * Search for an organization member
+     * @param parameters the parameters needed to make the search request
+     * @return [B2BSearchMemberResponse]
+     */
+    public fun searchMemberCompletable(parameters: SearchMemberParameters): CompletableFuture<B2BSearchMemberResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManagerImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManagerImpl.kt
@@ -5,8 +5,11 @@ import com.stytch.sdk.b2b.B2BSearchOrganizationResponse
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.common.StytchDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class SearchManagerImpl(
     private val externalScope: CoroutineScope,
@@ -31,6 +34,14 @@ internal class SearchManagerImpl(
         }
     }
 
+    override fun searchOrganizationCompletable(
+        parameters: SearchManager.SearchOrganizationParameters,
+    ): CompletableFuture<B2BSearchOrganizationResponse> =
+        externalScope
+            .async {
+                searchOrganization(parameters)
+            }.asCompletableFuture()
+
     override suspend fun searchMember(parameters: SearchManager.SearchMemberParameters): B2BSearchMemberResponse =
         withContext(dispatchers.io) {
             api.searchMembers(
@@ -47,4 +58,12 @@ internal class SearchManagerImpl(
             callback(searchMember(parameters))
         }
     }
+
+    override fun searchMemberCompletable(
+        parameters: SearchManager.SearchMemberParameters,
+    ): CompletableFuture<B2BSearchMemberResponse> =
+        externalScope
+            .async {
+                searchMember(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.common.network.models.Locale
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.CompletableFuture
 
 /**
  * The B2BSessions interface provides methods for authenticating, updating, or revoking sessions, and properties to
@@ -74,6 +75,14 @@ public interface B2BSessions {
     )
 
     /**
+     * Authenticates a Session and updates its lifetime by the specified session_duration_minutes.
+     * If the session_duration_minutes is not specified, a Session will not be extended
+     * @param authParams required to authenticate
+     * @return [SessionsAuthenticateResponse]
+     */
+    public fun authenticateCompletable(authParams: AuthParams): CompletableFuture<SessionsAuthenticateResponse>
+
+    /**
      * Revoke a Session and immediately invalidate all its tokens.
      * @param params required for revoking a session
      * @return [BaseResponse]
@@ -89,6 +98,13 @@ public interface B2BSessions {
         params: RevokeParams = RevokeParams(),
         callback: (BaseResponse) -> Unit,
     )
+
+    /**
+     * Revoke a Session and immediately invalidate all its tokens.
+     * @param params required for revoking a session
+     * @return [BaseResponse]
+     */
+    public fun revokeCompletable(params: RevokeParams = RevokeParams()): CompletableFuture<BaseResponse>
 
     /**
      * Updates the current session with a sessionToken and sessionJwt
@@ -138,4 +154,11 @@ public interface B2BSessions {
         parameters: ExchangeParameters,
         callback: (SessionExchangeResponse) -> Unit,
     )
+
+    /**
+     * Exchanges an existing session for one in a different organization
+     * @param parameters required for exchanging a session between organizations
+     * @return [SessionExchangeResponse]
+     */
+    public fun exchangeCompletable(parameters: ExchangeParameters): CompletableFuture<SessionExchangeResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
@@ -11,9 +11,12 @@ import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.common.errors.StytchInternalError
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class B2BSessionsImpl internal constructor(
     private val externalScope: CoroutineScope,
@@ -63,11 +66,12 @@ internal class B2BSessionsImpl internal constructor(
             // do not revoke session here since we using stored data to authenticate
             // call backend endpoint
             result =
-                api.authenticate(
-                    authParams.sessionDurationMinutes,
-                ).apply {
-                    launchSessionUpdater(dispatchers, sessionStorage)
-                }
+                api
+                    .authenticate(
+                        authParams.sessionDurationMinutes,
+                    ).apply {
+                        launchSessionUpdater(dispatchers, sessionStorage)
+                    }
         }
         return result
     }
@@ -83,6 +87,14 @@ internal class B2BSessionsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun authenticateCompletable(
+        authParams: B2BSessions.AuthParams,
+    ): CompletableFuture<SessionsAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(authParams)
+            }.asCompletableFuture()
 
     override suspend fun revoke(params: B2BSessions.RevokeParams): BaseResponse {
         var result: BaseResponse
@@ -112,6 +124,12 @@ internal class B2BSessionsImpl internal constructor(
         }
     }
 
+    override fun revokeCompletable(params: B2BSessions.RevokeParams): CompletableFuture<BaseResponse> =
+        externalScope
+            .async {
+                revoke(params)
+            }.asCompletableFuture()
+
     /**
      * @throws StytchInternalError if failed to save data
      */
@@ -128,17 +146,17 @@ internal class B2BSessionsImpl internal constructor(
 
     override fun getSync(): B2BSessionData? = sessionStorage.memberSession
 
-    override suspend fun exchange(parameters: B2BSessions.ExchangeParameters): SessionExchangeResponse {
-        return withContext(dispatchers.io) {
-            api.exchange(
-                organizationId = parameters.organizationId,
-                locale = parameters.locale,
-                sessionDurationMinutes = parameters.sessionDurationMinutes,
-            ).apply {
-                launchSessionUpdater(dispatchers, sessionStorage)
-            }
+    override suspend fun exchange(parameters: B2BSessions.ExchangeParameters): SessionExchangeResponse =
+        withContext(dispatchers.io) {
+            api
+                .exchange(
+                    organizationId = parameters.organizationId,
+                    locale = parameters.locale,
+                    sessionDurationMinutes = parameters.sessionDurationMinutes,
+                ).apply {
+                    launchSessionUpdater(dispatchers, sessionStorage)
+                }
         }
-    }
 
     override fun exchange(
         parameters: B2BSessions.ExchangeParameters,
@@ -150,4 +168,12 @@ internal class B2BSessionsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun exchangeCompletable(
+        parameters: B2BSessions.ExchangeParameters,
+    ): CompletableFuture<SessionExchangeResponse> =
+        externalScope
+            .async {
+                exchange(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -14,6 +14,7 @@ import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.network.models.Locale
+import java.util.concurrent.CompletableFuture
 
 /**
  * Single-Sign On (SSO) refers to the ability for a user to use a single identity to authenticate and gain access to
@@ -91,6 +92,14 @@ public interface SSO {
     )
 
     /**
+     * Authenticate a user given a token. This endpoint verifies that the user completed the SSO Authentication flow by
+     * verifying that the token is valid and hasn't expired.
+     * @param params required for making an authenticate call
+     * @return [SSOAuthenticateResponse]
+     */
+    public fun authenticateCompletable(params: AuthenticateParams): CompletableFuture<SSOAuthenticateResponse>
+
+    /**
      *  Get all SSO Connections owned by the organization.
      *  This method wraps the {@link https://stytch.com/docs/b2b/api/get-sso-connections Get SSO Connections} API
      *  endpoint.
@@ -109,6 +118,15 @@ public interface SSO {
     public fun getConnections(callback: (B2BSSOGetConnectionsResponse) -> Unit)
 
     /**
+     *  Get all SSO Connections owned by the organization.
+     *  This method wraps the {@link https://stytch.com/docs/b2b/api/get-sso-connections Get SSO Connections} API
+     *  endpoint.
+     *  The caller must have permission to call this endpoint via the project's RBAC policy & their role assignments.
+     *  @return [B2BSSOGetConnectionsResponse]
+     */
+    public fun getConnectionsCompletable(): CompletableFuture<B2BSSOGetConnectionsResponse>
+
+    /**
      * Delete an existing SSO connection.
      * @param connectionId The ID of the connection to delete
      * @return [B2BSSODeleteConnectionResponse]
@@ -124,6 +142,13 @@ public interface SSO {
         connectionId: String,
         callback: (B2BSSODeleteConnectionResponse) -> Unit,
     )
+
+    /**
+     * Delete an existing SSO connection.
+     * @param connectionId The ID of the connection to delete
+     * @return [B2BSSODeleteConnectionResponse]
+     */
+    public fun deleteConnectionCompletable(connectionId: String): CompletableFuture<B2BSSODeleteConnectionResponse>
 
     /**
      * Exposes an instance of the [SAML] interface
@@ -165,6 +190,15 @@ public interface SSO {
             parameters: CreateParameters,
             callback: (B2BSSOSAMLCreateConnectionResponse) -> Unit,
         )
+
+        /**
+         * Create a new SAML Connection.
+         * @param parameters The parameters required to create a new SAML connection
+         * @return [B2BSSOSAMLCreateConnectionResponse]
+         */
+        public fun createConnectionCompletable(
+            parameters: CreateParameters,
+        ): CompletableFuture<B2BSSOSAMLCreateConnectionResponse>
 
         /**
          * Data class used for wrapping the parameters for a SAML update request
@@ -216,6 +250,15 @@ public interface SSO {
         )
 
         /**
+         * Update a SAML Connection.
+         * @param parameters The parameters required to update SAML connection
+         * @return [B2BSSOSAMLUpdateConnectionResponse]
+         */
+        public fun updateConnectionCompletable(
+            parameters: UpdateParameters,
+        ): CompletableFuture<B2BSSOSAMLUpdateConnectionResponse>
+
+        /**
          * Data class used for wrapping the parameters for a SAML update by URL request
          * @property connectionId Globally unique UUID that identifies a specific SAML Connection.
          * @property metadataUrl A URL that points to the IdP metadata. This will be provided by the IdP.
@@ -243,6 +286,15 @@ public interface SSO {
             parameters: UpdateByURLParameters,
             callback: (B2BSSOSAMLUpdateConnectionByURLResponse) -> Unit,
         )
+
+        /**
+         * Update a SAML Connection by URL.
+         * @param parameters The parameters required to update a SAML connection by URL
+         * @return [B2BSSOSAMLUpdateConnectionByURLResponse]
+         */
+        public fun updateConnectionByUrlCompletable(
+            parameters: UpdateByURLParameters,
+        ): CompletableFuture<B2BSSOSAMLUpdateConnectionByURLResponse>
 
         /**
          * Data class used for wrapping the parameters to delete a SAML verification certificate
@@ -276,6 +328,17 @@ public interface SSO {
             parameters: DeleteVerificationCertificateParameters,
             callback: (B2BSSOSAMLDeleteVerificationCertificateResponse) -> Unit,
         )
+
+        /**
+         * Delete a SAML verification certificate.
+         * You may need to do this when rotating certificates from your IdP, since Stytch allows a maximum of 5
+         * certificates per connection. There must always be at least one certificate per active connection.
+         * @param parameters The parameters required to delete a SAML verification certificate.
+         * @return [B2BSSOSAMLDeleteVerificationCertificateResponse]
+         */
+        public fun deleteVerificationCertificateCompletable(
+            parameters: DeleteVerificationCertificateParameters,
+        ): CompletableFuture<B2BSSOSAMLDeleteVerificationCertificateResponse>
     }
 
     /**
@@ -308,6 +371,15 @@ public interface SSO {
             parameters: CreateParameters,
             callback: (B2BSSOOIDCCreateConnectionResponse) -> Unit,
         )
+
+        /**
+         * Create a new OIDC Connection.
+         * @param parameters The parameters required to create a new OIDC connection
+         * @return [B2BSSOOIDCCreateConnectionResponse]
+         */
+        public fun createConnectionCompletable(
+            parameters: CreateParameters,
+        ): CompletableFuture<B2BSSOOIDCCreateConnectionResponse>
 
         /**
          * Data class used for wrapping the parameters for an OIDC update request
@@ -357,5 +429,14 @@ public interface SSO {
             parameters: UpdateParameters,
             callback: (B2BSSOOIDCUpdateConnectionResponse) -> Unit,
         )
+
+        /**
+         * Update an OIDC Connection.
+         * @param parameters The parameters required to update an OIDC connection
+         * @return [B2BSSOOIDCUpdateConnectionResponse]
+         */
+        public fun updateConnectionCompletable(
+            parameters: UpdateParameters,
+        ): CompletableFuture<B2BSSOOIDCUpdateConnectionResponse>
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -22,8 +22,11 @@ import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.utils.buildUri
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class SSOImpl(
     private val externalScope: CoroutineScope,
@@ -79,6 +82,12 @@ internal class SSOImpl(
         }
     }
 
+    override fun authenticateCompletable(params: SSO.AuthenticateParams): CompletableFuture<SSOAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(params)
+            }.asCompletableFuture()
+
     override suspend fun getConnections(): B2BSSOGetConnectionsResponse =
         withContext(dispatchers.io) {
             api.getConnections()
@@ -89,6 +98,12 @@ internal class SSOImpl(
             callback(getConnections())
         }
     }
+
+    override fun getConnectionsCompletable(): CompletableFuture<B2BSSOGetConnectionsResponse> =
+        externalScope
+            .async {
+                getConnections()
+            }.asCompletableFuture()
 
     override suspend fun deleteConnection(connectionId: String): B2BSSODeleteConnectionResponse =
         withContext(dispatchers.io) {
@@ -103,6 +118,12 @@ internal class SSOImpl(
             callback(deleteConnection(connectionId))
         }
     }
+
+    override fun deleteConnectionCompletable(connectionId: String): CompletableFuture<B2BSSODeleteConnectionResponse> =
+        externalScope
+            .async {
+                deleteConnection(connectionId)
+            }.asCompletableFuture()
 
     override val saml: SSO.SAML = SAMLImpl()
 
@@ -122,6 +143,14 @@ internal class SSOImpl(
                 callback(createConnection(parameters))
             }
         }
+
+        override fun createConnectionCompletable(
+            parameters: SSO.SAML.CreateParameters,
+        ): CompletableFuture<B2BSSOSAMLCreateConnectionResponse> =
+            externalScope
+                .async {
+                    createConnection(parameters)
+                }.asCompletableFuture()
 
         override suspend fun updateConnection(
             parameters: SSO.SAML.UpdateParameters,
@@ -148,6 +177,14 @@ internal class SSOImpl(
             }
         }
 
+        override fun updateConnectionCompletable(
+            parameters: SSO.SAML.UpdateParameters,
+        ): CompletableFuture<B2BSSOSAMLUpdateConnectionResponse> =
+            externalScope
+                .async {
+                    updateConnection(parameters)
+                }.asCompletableFuture()
+
         override suspend fun updateConnectionByUrl(
             parameters: SSO.SAML.UpdateByURLParameters,
         ): B2BSSOSAMLUpdateConnectionByURLResponse =
@@ -167,6 +204,14 @@ internal class SSOImpl(
             }
         }
 
+        override fun updateConnectionByUrlCompletable(
+            parameters: SSO.SAML.UpdateByURLParameters,
+        ): CompletableFuture<B2BSSOSAMLUpdateConnectionByURLResponse> =
+            externalScope
+                .async {
+                    updateConnectionByUrl(parameters)
+                }.asCompletableFuture()
+
         override suspend fun deleteVerificationCertificate(
             parameters: SSO.SAML.DeleteVerificationCertificateParameters,
         ): B2BSSOSAMLDeleteVerificationCertificateResponse =
@@ -185,6 +230,14 @@ internal class SSOImpl(
                 callback(deleteVerificationCertificate(parameters))
             }
         }
+
+        override fun deleteVerificationCertificateCompletable(
+            parameters: SSO.SAML.DeleteVerificationCertificateParameters,
+        ): CompletableFuture<B2BSSOSAMLDeleteVerificationCertificateResponse> =
+            externalScope
+                .async {
+                    deleteVerificationCertificate(parameters)
+                }.asCompletableFuture()
     }
 
     override val oidc: SSO.OIDC = OIDCImpl()
@@ -205,6 +258,14 @@ internal class SSOImpl(
                 callback(createConnection(parameters))
             }
         }
+
+        override fun createConnectionCompletable(
+            parameters: SSO.OIDC.CreateParameters,
+        ): CompletableFuture<B2BSSOOIDCCreateConnectionResponse> =
+            externalScope
+                .async {
+                    createConnection(parameters)
+                }.asCompletableFuture()
 
         override suspend fun updateConnection(
             parameters: SSO.OIDC.UpdateParameters,
@@ -231,5 +292,13 @@ internal class SSOImpl(
                 callback(updateConnection(parameters))
             }
         }
+
+        override fun updateConnectionCompletable(
+            parameters: SSO.OIDC.UpdateParameters,
+        ): CompletableFuture<B2BSSOOIDCUpdateConnectionResponse> =
+            externalScope
+                .async {
+                    updateConnection(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTP.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.TOTPAuthenticateResponse
 import com.stytch.sdk.b2b.TOTPCreateResponse
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import java.util.concurrent.CompletableFuture
 
 /**
  * The TOTP interface provides methods for creating and authenticating TOTPs for a member
@@ -43,6 +44,13 @@ public interface TOTP {
     )
 
     /**
+     * Create a TOTP for a member
+     * @param parameters required to create a TOTP
+     * @return [TOTPCreateResponse]
+     */
+    public fun createCompletable(parameters: CreateParameters): CompletableFuture<TOTPCreateResponse>
+
+    /**
      * A data class wrapping the parameters needed to authenticate a TOTP
      * @property organizationId The ID of the organization the member belongs to
      * @property memberId The ID of the member to create the TOTP for
@@ -80,4 +88,11 @@ public interface TOTP {
         parameters: AuthenticateParameters,
         callback: (TOTPAuthenticateResponse) -> Unit,
     )
+
+    /**
+     * Authenticate a TOTP for a member
+     * @param parameters required to authenticate a TOTP
+     * @return [TOTPAuthenticateResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<TOTPAuthenticateResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTPImpl.kt
@@ -7,8 +7,11 @@ import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.StytchDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class TOTPImpl(
     private val externalScope: CoroutineScope,
@@ -35,6 +38,12 @@ internal class TOTPImpl(
         }
     }
 
+    override fun createCompletable(parameters: TOTP.CreateParameters): CompletableFuture<TOTPCreateResponse> =
+        externalScope
+            .async {
+                create(parameters)
+            }.asCompletableFuture()
+
     override suspend fun authenticate(parameters: TOTP.AuthenticateParameters): TOTPAuthenticateResponse =
         withContext(dispatchers.io) {
             api
@@ -59,4 +68,12 @@ internal class TOTPImpl(
             callback(authenticate(parameters))
         }
     }
+
+    override fun authenticateCompletable(
+        parameters: TOTP.AuthenticateParameters,
+    ): CompletableFuture<TOTPAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/Biometrics.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/Biometrics.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.biometrics
 import androidx.fragment.app.FragmentActivity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.consumer.BiometricsAuthResponse
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Biometrics interface provides methods for detecting biometric availability, registering, authenticating, and
@@ -91,6 +92,13 @@ public interface Biometrics {
     public fun removeRegistration(callback: (Boolean) -> Unit)
 
     /**
+     * Clears existing biometric registrations stored on device. Useful when removing a user from a given device.
+     * Returns true if the registration was successfully removed from device.
+     * @return Boolean
+     */
+    public fun removeRegistrationCompletable(): CompletableFuture<Boolean>
+
+    /**
      * Indicates if the device is device has a reliable version of the Android KeyStore. If it does not, there may be
      * issues creating encryption keys, as well as implications on where these keys are stored. The safest approach is
      * to not offer biometrics if this returns `false`, but it is possible to force a registration with an unreliable
@@ -121,6 +129,15 @@ public interface Biometrics {
     )
 
     /**
+     * When a valid/active session exists, this method will add a biometric registration for the current user.
+     * The user will later be able to start a new session with biometrics or use biometrics as an additional
+     * authentication factor.
+     * @param parameters required to register a biometrics key
+     * @return [BiometricsAuthResponse]
+     */
+    public fun registerCompletable(parameters: RegisterParameters): CompletableFuture<BiometricsAuthResponse>
+
+    /**
      * If a valid biometric registration exists, this method confirms the current device owner via the device's built-in
      * biometric reader and returns an updated session object by either starting a new session or adding the biometric
      * factor to an existing session.
@@ -140,4 +157,13 @@ public interface Biometrics {
         parameters: AuthenticateParameters,
         callback: (response: BiometricsAuthResponse) -> Unit,
     )
+
+    /**
+     * If a valid biometric registration exists, this method confirms the current device owner via the device's built-in
+     * biometric reader and returns an updated session object by either starting a new session or adding the biometric
+     * factor to an existing session.
+     * @param parameters required to authenticate a biometrics key
+     * @return [BiometricsAuthResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<BiometricsAuthResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
@@ -23,8 +23,11 @@ import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal const val LAST_USED_BIOMETRIC_REGISTRATION_ID = "last_used_biometric_registration_id"
 internal const val PRIVATE_KEY_KEY = "biometrics_private_key"
@@ -115,6 +118,12 @@ internal class BiometricsImpl internal constructor(
         }
     }
 
+    override fun removeRegistrationCompletable(): CompletableFuture<Boolean> =
+        externalScope
+            .async {
+                removeRegistration()
+            }.asCompletableFuture()
+
     override fun isUsingKeystore(): Boolean = storageHelper.checkIfKeysetIsUsingKeystore()
 
     override suspend fun register(parameters: Biometrics.RegisterParameters): BiometricsAuthResponse =
@@ -180,6 +189,14 @@ internal class BiometricsImpl internal constructor(
         }
     }
 
+    override fun registerCompletable(
+        parameters: Biometrics.RegisterParameters,
+    ): CompletableFuture<BiometricsAuthResponse> =
+        externalScope
+            .async {
+                register(parameters)
+            }.asCompletableFuture()
+
     override suspend fun authenticate(parameters: Biometrics.AuthenticateParameters): BiometricsAuthResponse =
         withContext(dispatchers.io) {
             try {
@@ -235,4 +252,12 @@ internal class BiometricsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun authenticateCompletable(
+        parameters: Biometrics.AuthenticateParameters,
+    ): CompletableFuture<BiometricsAuthResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
 import com.stytch.sdk.consumer.network.models.CryptoWalletType
+import java.util.concurrent.CompletableFuture
 
 /**
  * The CryptoWallet interface provides methods for authenticating a user using one of the supported Crypto Wallets
@@ -54,6 +55,15 @@ public interface CryptoWallet {
     )
 
     /**
+     * Begin a crypto wallet authentication flow
+     * @param parameters the parameters required to begin a crypto wallet authentication flow
+     * @return [CryptoWalletAuthenticateStartResponse]
+     */
+    public fun authenticateStartCompletable(
+        parameters: AuthenticateStartParameters,
+    ): CompletableFuture<CryptoWalletAuthenticateStartResponse>
+
+    /**
      * Complete a crypto wallet authentication flow
      * @param parameters the parameters required to complete a crypto wallet authentication flow
      * @return [AuthResponse]
@@ -69,4 +79,11 @@ public interface CryptoWallet {
         parameters: AuthenticateParameters,
         callback: (AuthResponse) -> Unit,
     )
+
+    /**
+     * Complete a crypto wallet authentication flow
+     * @param parameters the parameters required to complete a crypto wallet authentication flow
+     * @return [AuthResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<AuthResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.AuthResponse
 import kotlinx.parcelize.Parcelize
+import java.util.concurrent.CompletableFuture
 
 /**
  * MagicLinks interface that encompasses authentication functions as well as other related functionality
@@ -46,6 +47,14 @@ public interface MagicLinks {
         parameters: AuthParameters,
         callback: (response: AuthResponse) -> Unit,
     )
+
+    /**
+     * Authenticate a user given a magic link. This endpoint verifies that the magic link token is valid, hasn't expired
+     * or been previously used.
+     * @param parameters required to authenticate
+     * @return [AuthResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<AuthResponse>
 
     /**
      * Provides all possible ways to call EmailMagicLinks endpoints
@@ -103,6 +112,14 @@ public interface MagicLinks {
         )
 
         /**
+         * Send either a login or signup magic link to the user based on if the email is associated with a user already.
+         * A new or pending user will receive a signup magic link. An active user will receive a login magic link.
+         * @param parameters required to receive magic link
+         * @return [BaseResponse]
+         */
+        public fun loginOrCreateCompletable(parameters: Parameters): CompletableFuture<BaseResponse>
+
+        /**
          * Send a magic link to an existing Stytch user using their email address. If you'd like to create a user and
          * send them a magic link by email with one request, use [loginOrCreate]
          * @param parameters required to receive magic link
@@ -120,5 +137,13 @@ public interface MagicLinks {
             parameters: Parameters,
             callback: (response: BaseResponse) -> Unit,
         )
+
+        /**
+         * Send a magic link to an existing Stytch user using their email address. If you'd like to create a user and
+         * send them a magic link by email with one request, use [loginOrCreate]
+         * @param parameters required to receive magic link
+         * @return [BaseResponse]
+         */
+        public fun sendCompletable(parameters: Parameters): CompletableFuture<BaseResponse>
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
@@ -11,8 +11,11 @@ import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class MagicLinksImpl internal constructor(
     private val externalScope: CoroutineScope,
@@ -49,6 +52,12 @@ internal class MagicLinksImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun authenticateCompletable(parameters: MagicLinks.AuthParameters): CompletableFuture<AuthResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
 
     private inner class EmailMagicLinksImpl : MagicLinks.EmailMagicLinks {
         override suspend fun loginOrCreate(parameters: MagicLinks.EmailMagicLinks.Parameters): BaseResponse {
@@ -89,6 +98,14 @@ internal class MagicLinksImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun loginOrCreateCompletable(
+            parameters: MagicLinks.EmailMagicLinks.Parameters,
+        ): CompletableFuture<BaseResponse> =
+            externalScope
+                .async {
+                    loginOrCreate(parameters)
+                }.asCompletableFuture()
 
         override suspend fun send(parameters: MagicLinks.EmailMagicLinks.Parameters): BaseResponse =
             withContext(dispatchers.io) {
@@ -134,5 +151,13 @@ internal class MagicLinksImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun sendCompletable(
+            parameters: MagicLinks.EmailMagicLinks.Parameters,
+        ): CompletableFuture<BaseResponse> =
+            externalScope
+                .async {
+                    send(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.consumer.NativeOAuthResponse
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
+import java.util.concurrent.CompletableFuture
 
 /**
  * The OAuth interface provides methods for authenticating a user via a native Google OneTap prompt or any of the
@@ -152,6 +153,15 @@ public interface OAuth {
         )
 
         /**
+         * Begin a Google OneTap login flow. Returns an authenticated session if the flow was successfully initiated.
+         * If this returns an error, it means the Google OneTap flow is not available (no play services on device
+         * or user signed out), and you can fallback to the ThirdParty/Legacy Google OAuth flow
+         * @param parameters required to begin the OneTap flow
+         * @return NativeOAuthResponse
+         */
+        public fun startCompletable(parameters: StartParameters): CompletableFuture<NativeOAuthResponse>
+
+        /**
          * Sign a user out of Google Play Services
          */
         public fun signOut(activity: Activity)
@@ -228,4 +238,13 @@ public interface OAuth {
         parameters: ThirdParty.AuthenticateParameters,
         callback: (OAuthAuthenticatedResponse) -> Unit,
     )
+
+    /**
+     * Authenticate a ThirdParty OAuth flow
+     * @param parameters required to authenticate the OAuth flow
+     * @return [OAuthAuthenticatedResponse]
+     */
+    public fun authenticateCompletable(
+        parameters: ThirdParty.AuthenticateParameters,
+    ): CompletableFuture<OAuthAuthenticatedResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
@@ -10,8 +10,11 @@ import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class OAuthImpl(
     private val externalScope: CoroutineScope,
@@ -82,4 +85,12 @@ internal class OAuthImpl(
             callback(result)
         }
     }
+
+    override fun authenticateCompletable(
+        parameters: OAuth.ThirdParty.AuthenticateParameters,
+    ): CompletableFuture<OAuthAuthenticatedResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
 import com.stytch.sdk.consumer.OTPSendResponse
 import kotlinx.parcelize.Parcelize
+import java.util.concurrent.CompletableFuture
 
 /**
  * The OTP interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS, WhatsApp, and
@@ -68,6 +69,16 @@ public interface OTP {
     )
 
     /**
+     * Authenticate a user given a method_id (the associated email_id or phone_id) and a code. This endpoint verifies
+     * that the code is valid, hasn't expired or been previously used. A given method_id may only have a single active
+     * OTP code at any given time, if a user requests another OTP code before the first one has expired, the first one
+     * will be invalidated.
+     * @param parameters required to authenticate
+     * @return [AuthResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<AuthResponse>
+
+    /**
      * Provides all possible ways to call SMS OTP endpoints
      */
     public interface SmsOTP {
@@ -112,6 +123,14 @@ public interface OTP {
         )
 
         /**
+         * Send a one-time passcode (OTP) to a user using their phone number via SMS. If the phone number is not
+         * associated with a user already, a user will be created.
+         * @param parameters required to receive a SMS OTP
+         * @return [LoginOrCreateOTPResponse]
+         */
+        public fun loginOrCreateCompletable(parameters: Parameters): CompletableFuture<LoginOrCreateOTPResponse>
+
+        /**
          * Send a one-time passcode (OTP) to a user's phone number via SMS. If you'd like to create a user and send them
          * a passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
@@ -129,6 +148,14 @@ public interface OTP {
             parameters: Parameters,
             callback: (response: OTPSendResponse) -> Unit,
         )
+
+        /**
+         * Send a one-time passcode (OTP) to a user's phone number via SMS. If you'd like to create a user and send them
+         * a passcode with one request, use our [loginOrCreate] method.
+         * @param parameters required to send OTP
+         * @return [OTPSendResponse]
+         */
+        public fun sendCompletable(parameters: Parameters): CompletableFuture<OTPSendResponse>
     }
 
     /**
@@ -169,6 +196,14 @@ public interface OTP {
         )
 
         /**
+         * Send a one-time passcode (OTP) to a user using their phone number via WhatsApp. If the phone number is not
+         * associated with a user already, a user will be created.
+         * @param parameters required to receive a WhatsApp OTP
+         * @return [BaseResponse]
+         */
+        public fun loginOrCreateCompletable(parameters: Parameters): CompletableFuture<LoginOrCreateOTPResponse>
+
+        /**
          * Send a one-time passcode (OTP) to a user's phone number via WhatsApp. If you'd like to create a user and send
          * them a passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
@@ -186,6 +221,14 @@ public interface OTP {
             parameters: Parameters,
             callback: (response: OTPSendResponse) -> Unit,
         )
+
+        /**
+         * Send a one-time passcode (OTP) to a user's phone number via WhatsApp. If you'd like to create a user and send
+         * them a passcode with one request, use our [loginOrCreate] method.
+         * @param parameters required to send OTP
+         * @return [OTPSendResponse]
+         */
+        public fun sendCompletable(parameters: Parameters): CompletableFuture<OTPSendResponse>
     }
 
     /**
@@ -233,6 +276,14 @@ public interface OTP {
         )
 
         /**
+         * Send a one-time passcode (OTP) to a user using their email address. If the email address is not associated
+         * with a user already, a user will be created.
+         * @param parameters required to receive an Email OTP
+         * @return [LoginOrCreateOTPResponse]
+         */
+        public fun loginOrCreateCompletable(parameters: Parameters): CompletableFuture<LoginOrCreateOTPResponse>
+
+        /**
          * Send a one-time passcode (OTP) to a user's email address. If you'd like to create a user and send them a
          * passcode with one request, use our [loginOrCreate] method.
          * @param parameters required to send OTP
@@ -250,5 +301,13 @@ public interface OTP {
             parameters: Parameters,
             callback: (response: OTPSendResponse) -> Unit,
         )
+
+        /**
+         * Send a one-time passcode (OTP) to a user's email address. If you'd like to create a user and send them a
+         * passcode with one request, use our [loginOrCreate] method.
+         * @param parameters required to send OTP
+         * @return [OTPSendResponse] response from backend
+         */
+        public fun sendCompletable(parameters: Parameters): CompletableFuture<OTPSendResponse>
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
@@ -10,8 +10,11 @@ import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class OTPImpl internal constructor(
     private val externalScope: CoroutineScope,
@@ -51,6 +54,12 @@ internal class OTPImpl internal constructor(
         }
     }
 
+    override fun authenticateCompletable(parameters: OTP.AuthParameters): CompletableFuture<AuthResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
+
     private inner class SmsOTPImpl : OTP.SmsOTP {
         override suspend fun loginOrCreate(parameters: OTP.SmsOTP.Parameters): LoginOrCreateOTPResponse {
             val result: LoginOrCreateOTPResponse
@@ -84,6 +93,14 @@ internal class OTPImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun loginOrCreateCompletable(
+            parameters: OTP.SmsOTP.Parameters,
+        ): CompletableFuture<LoginOrCreateOTPResponse> =
+            externalScope
+                .async {
+                    loginOrCreate(parameters)
+                }.asCompletableFuture()
 
         override suspend fun send(parameters: OTP.SmsOTP.Parameters): OTPSendResponse =
             withContext(dispatchers.io) {
@@ -124,6 +141,12 @@ internal class OTPImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun sendCompletable(parameters: OTP.SmsOTP.Parameters): CompletableFuture<OTPSendResponse> =
+            externalScope
+                .async {
+                    send(parameters)
+                }.asCompletableFuture()
     }
 
     private inner class WhatsAppOTPImpl : OTP.WhatsAppOTP {
@@ -150,6 +173,14 @@ internal class OTPImpl internal constructor(
             }
         }
 
+        override fun loginOrCreateCompletable(
+            parameters: OTP.WhatsAppOTP.Parameters,
+        ): CompletableFuture<LoginOrCreateOTPResponse> =
+            externalScope
+                .async {
+                    loginOrCreate(parameters)
+                }.asCompletableFuture()
+
         override suspend fun send(parameters: OTP.WhatsAppOTP.Parameters): OTPSendResponse =
             withContext(dispatchers.io) {
                 if (sessionStorage.persistedSessionIdentifiersExist) {
@@ -174,6 +205,12 @@ internal class OTPImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun sendCompletable(parameters: OTP.WhatsAppOTP.Parameters): CompletableFuture<OTPSendResponse> =
+            externalScope
+                .async {
+                    send(parameters)
+                }.asCompletableFuture()
     }
 
     private inner class EmailOTPImpl : OTP.EmailOTP {
@@ -201,6 +238,14 @@ internal class OTPImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun loginOrCreateCompletable(
+            parameters: OTP.EmailOTP.Parameters,
+        ): CompletableFuture<LoginOrCreateOTPResponse> =
+            externalScope
+                .async {
+                    loginOrCreate(parameters)
+                }.asCompletableFuture()
 
         override suspend fun send(parameters: OTP.EmailOTP.Parameters): OTPSendResponse =
             withContext(dispatchers.io) {
@@ -230,5 +275,11 @@ internal class OTPImpl internal constructor(
                 callback(result)
             }
         }
+
+        override fun sendCompletable(parameters: OTP.EmailOTP.Parameters): CompletableFuture<OTPSendResponse> =
+            externalScope
+                .async {
+                    send(parameters)
+                }.asCompletableFuture()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Passkeys interface provides methods for detecting Passkeys support, registering, and authenticating with
@@ -68,6 +69,13 @@ public interface Passkeys {
     )
 
     /**
+     * Creates a new Passkey registration.
+     * @param parameters required to register a Passkey
+     * @return [WebAuthnRegisterResponse]
+     */
+    public fun registerCompletable(parameters: RegisterParameters): CompletableFuture<WebAuthnRegisterResponse>
+
+    /**
      * Authenticates a Passkey registration.
      * @param parameters required to authenticate a Passkey registration
      * @return [AuthResponse]
@@ -85,6 +93,13 @@ public interface Passkeys {
     )
 
     /**
+     * Authenticates a Passkey registration.
+     * @param parameters required to authenticate a Passkey registration
+     * @return [AuthResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<AuthResponse>
+
+    /**
      * Updates a Passkey registration.
      * @param parameters required to update a Passkey registration
      * @return [WebAuthnUpdateResponse]
@@ -100,4 +115,11 @@ public interface Passkeys {
         parameters: UpdateParameters,
         callback: (response: WebAuthnUpdateResponse) -> Unit,
     )
+
+    /**
+     * Updates a Passkey registration.
+     * @param parameters required to update a Passkey registration
+     * @return [WebAuthnUpdateResponse]
+     */
+    public fun updateCompletable(parameters: UpdateParameters): CompletableFuture<WebAuthnUpdateResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.PasswordsCreateResponse
 import com.stytch.sdk.consumer.PasswordsStrengthCheckResponse
 import kotlinx.parcelize.Parcelize
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Passwords interface provides methods for authenticating, creating, resetting, and performing strength checks of
@@ -142,6 +143,16 @@ public interface Passwords {
     )
 
     /**
+     * Reset the user’s password and authenticate them. This endpoint checks that the session is valid and hasn’t
+     * expired or been revoked. The provided password needs to meet our password strength requirements, which can be
+     * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
+     * the password is securely stored for future authentication and the user is authenticated.
+     * @param parameters required to reset a user's password
+     * @return [AuthResponse]
+     */
+    public fun resetBySessionCompletable(parameters: ResetBySessionParameters): CompletableFuture<AuthResponse>
+
+    /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
      * @property email is the account identifier for the account in the form of an Email address that you wish to use to
      * initiate a password strength check
@@ -184,6 +195,24 @@ public interface Passwords {
     )
 
     /**
+     * Authenticate a user with their email address and password. This endpoint verifies that the user has a password
+     * currently set, and that the entered password is correct.
+     *
+     * There are two instances where the endpoint will return a reset_password error even if they enter their previous
+     * password:
+     * 1. The member's credentials appeared in the HaveIBeenPwned dataset. We force a password reset to ensure that the
+     * member is the legitimate owner of the email address, and not a malicious actor abusing the compromised
+     * credentials.
+     * 2. The member used email based authentication (e.g. Magic Links, Google OAuth) for the first time, and had not
+     * previously verified their email address for password based login. We force a password reset in this instance in
+     * order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack
+     * account-takeover attack.
+     * @param parameters required to authenticate
+     * @return [AuthResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<AuthResponse>
+
+    /**
      * Create a new user with a password and an authenticated session for the user if requested. If a user with this
      * email already exists in the project, this method will return an error.
      * @param parameters required to create an account
@@ -203,6 +232,14 @@ public interface Passwords {
     )
 
     /**
+     * Create a new user with a password and an authenticated session for the user if requested. If a user with this
+     * email already exists in the project, this method will return an error.
+     * @param parameters required to create an account
+     * @return [PasswordsCreateResponse]
+     */
+    public fun createCompletable(parameters: CreateParameters): CompletableFuture<PasswordsCreateResponse>
+
+    /**
      * Initiates a password reset for the email address provided. This will trigger an email to be sent to the address,
      * containing a magic link that will allow them to set a new password and authenticate.
      * @param parameters required to reset an account password
@@ -220,6 +257,14 @@ public interface Passwords {
         parameters: ResetByEmailStartParameters,
         callback: (response: BaseResponse) -> Unit,
     )
+
+    /**
+     * Initiates a password reset for the email address provided. This will trigger an email to be sent to the address,
+     * containing a magic link that will allow them to set a new password and authenticate.
+     * @param parameters required to reset an account password
+     * @return [BaseResponse]
+     */
+    public fun resetByEmailStartCompletable(parameters: ResetByEmailStartParameters): CompletableFuture<BaseResponse>
 
     /**
      * Reset the user’s password and authenticate them. This endpoint checks that the magic link token is valid, hasn’t
@@ -245,6 +290,16 @@ public interface Passwords {
     )
 
     /**
+     * Reset the user’s password and authenticate them. This endpoint checks that the magic link token is valid, hasn’t
+     * expired, or already been used. The provided password needs to meet our password strength requirements, which can
+     * be checked in advance with the [strengthCheck] method. If the token and password are accepted, the password is
+     * securely stored for future authentication and the user is authenticated.
+     * @param parameters required to reset an account password
+     * @return [AuthResponse]
+     */
+    public fun resetByEmailCompletable(parameters: ResetByEmailParameters): CompletableFuture<AuthResponse>
+
+    /**
      * Reset a user's password and authenticate them
      * @param parameters required to reset a user's password
      * @returns [AuthResponse]
@@ -260,6 +315,15 @@ public interface Passwords {
         parameters: ResetByExistingPasswordParameters,
         callback: (AuthResponse) -> Unit,
     )
+
+    /**
+     * Reset a user's password and authenticate them
+     * @param parameters required to reset a user's password
+     * @returns [AuthResponse]
+     */
+    public fun resetByExistingPasswordCompletable(
+        parameters: ResetByExistingPasswordParameters,
+    ): CompletableFuture<AuthResponse>
 
     /**
      * This method allows you to check whether or not the user’s provided password is valid, and to provide feedback to
@@ -279,4 +343,14 @@ public interface Passwords {
         parameters: StrengthCheckParameters,
         callback: (response: PasswordsStrengthCheckResponse) -> Unit,
     )
+
+    /**
+     * This method allows you to check whether or not the user’s provided password is valid, and to provide feedback to
+     * the user on how to increase the strength of their password.
+     * @param parameters required to advise on password strength
+     * @return [PasswordsStrengthCheckResponse]
+     */
+    public fun strengthCheckCompletable(
+        parameters: StrengthCheckParameters,
+    ): CompletableFuture<PasswordsStrengthCheckResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -13,8 +13,11 @@ import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class PasswordsImpl internal constructor(
     private val externalScope: CoroutineScope,
@@ -49,6 +52,12 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun authenticateCompletable(parameters: Passwords.AuthParameters): CompletableFuture<AuthResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
+
     override suspend fun create(parameters: Passwords.CreateParameters): PasswordsCreateResponse {
         val result: PasswordsCreateResponse
 
@@ -76,6 +85,12 @@ internal class PasswordsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun createCompletable(parameters: Passwords.CreateParameters): CompletableFuture<PasswordsCreateResponse> =
+        externalScope
+            .async {
+                create(parameters)
+            }.asCompletableFuture()
 
     override suspend fun resetByEmailStart(parameters: Passwords.ResetByEmailStartParameters): BaseResponse {
         val result: BaseResponse
@@ -115,6 +130,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetByEmailStartCompletable(
+        parameters: Passwords.ResetByEmailStartParameters,
+    ): CompletableFuture<BaseResponse> =
+        externalScope
+            .async {
+                resetByEmailStart(parameters)
+            }.asCompletableFuture()
+
     override suspend fun resetByEmail(parameters: Passwords.ResetByEmailParameters): AuthResponse {
         val codeVerifier =
             pkcePairManager.getPKCECodePair()?.codeVerifier ?: return StytchResult.Error(StytchMissingPKCEError(null))
@@ -142,6 +165,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetByEmailCompletable(
+        parameters: Passwords.ResetByEmailParameters,
+    ): CompletableFuture<AuthResponse> =
+        externalScope
+            .async {
+                resetByEmail(parameters)
+            }.asCompletableFuture()
+
     override suspend fun resetByExistingPassword(
         parameters: Passwords.ResetByExistingPasswordParameters,
     ): AuthResponse =
@@ -166,6 +197,14 @@ internal class PasswordsImpl internal constructor(
         }
     }
 
+    override fun resetByExistingPasswordCompletable(
+        parameters: Passwords.ResetByExistingPasswordParameters,
+    ): CompletableFuture<AuthResponse> =
+        externalScope
+            .async {
+                resetByExistingPassword(parameters)
+            }.asCompletableFuture()
+
     override suspend fun resetBySession(parameters: Passwords.ResetBySessionParameters): AuthResponse =
         withContext(dispatchers.io) {
             api
@@ -186,6 +225,14 @@ internal class PasswordsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun resetBySessionCompletable(
+        parameters: Passwords.ResetBySessionParameters,
+    ): CompletableFuture<AuthResponse> =
+        externalScope
+            .async {
+                resetBySession(parameters)
+            }.asCompletableFuture()
 
     override suspend fun strengthCheck(parameters: Passwords.StrengthCheckParameters): PasswordsStrengthCheckResponse {
         val result: PasswordsStrengthCheckResponse
@@ -208,4 +255,12 @@ internal class PasswordsImpl internal constructor(
             callback(result)
         }
     }
+
+    override fun strengthCheckCompletable(
+        parameters: Passwords.StrengthCheckParameters,
+    ): CompletableFuture<PasswordsStrengthCheckResponse> =
+        externalScope
+            .async {
+                strengthCheck(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.network.models.SessionData
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.CompletableFuture
 
 /**
  * The Sessions interface provides methods for authenticating, updating, or revoking sessions, and properties to
@@ -77,6 +78,14 @@ public interface Sessions {
     )
 
     /**
+     * Authenticates a Session and updates its lifetime by the specified session_duration_minutes.
+     * If the session_duration_minutes is not specified, a Session will not be extended
+     * @param authParams required to authenticate
+     * @return [AuthResponse]
+     */
+    public fun authenticateCompletable(authParams: AuthParams): CompletableFuture<AuthResponse>
+
+    /**
      * Revoke a Session and immediately invalidate all its tokens.
      * @param params required for revoking a session
      * @return [BaseResponse]
@@ -92,6 +101,13 @@ public interface Sessions {
         params: RevokeParams = RevokeParams(),
         callback: (BaseResponse) -> Unit,
     )
+
+    /**
+     * Revoke a Session and immediately invalidate all its tokens.
+     * @param params required for revoking a session
+     * @return [BaseResponse]
+     */
+    public fun revokeCompletable(params: RevokeParams = RevokeParams()): CompletableFuture<BaseResponse>
 
     /**
      * Updates the current session with a sessionToken and sessionJwt

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTP.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.consumer.TOTPAuthenticateResponse
 import com.stytch.sdk.consumer.TOTPCreateResponse
 import com.stytch.sdk.consumer.TOTPRecoverResponse
 import com.stytch.sdk.consumer.TOTPRecoveryCodesResponse
+import java.util.concurrent.CompletableFuture
 
 /**
  * The TOTP interface provides methods for creating and authenticating TOTP codes; retrieving recovery codes; and
@@ -65,6 +66,14 @@ public interface TOTP {
     )
 
     /**
+     *  Call this method to create a new TOTP instance for a user. The user can use the authenticator application of
+     *  their choice to scan the QR code or enter the secret.
+     *  @param parameters the parameters required to create a TOTP
+     *  @return [TOTPCreateResponse]
+     */
+    public fun createCompletable(parameters: CreateParameters): CompletableFuture<TOTPCreateResponse>
+
+    /**
      * Call this method to authenticate a TOTP code entered by a user. If this method succeeds, the user will be logged
      * in and granted an active session
      * @param parameters the parameters required to authenticate a TOTP
@@ -84,6 +93,14 @@ public interface TOTP {
     )
 
     /**
+     * Call this method to authenticate a TOTP code entered by a user. If this method succeeds, the user will be logged
+     * in and granted an active session
+     * @param parameters the parameters required to authenticate a TOTP
+     * @return [TOTPAuthenticateResponse]
+     */
+    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<TOTPAuthenticateResponse>
+
+    /**
      * Call this method to retrieve the recovery codes for a TOTP instance tied to a user.
      * @return [TOTPRecoveryCodesResponse]
      */
@@ -94,6 +111,12 @@ public interface TOTP {
      * @param callback a callback that receives a [TOTPRecoveryCodesResponse]
      */
     public fun recoveryCodes(callback: (TOTPRecoveryCodesResponse) -> Unit)
+
+    /**
+     * Call this method to retrieve the recovery codes for a TOTP instance tied to a user.
+     * @return [TOTPRecoveryCodesResponse]
+     */
+    public fun recoveryCodesCompletable(): CompletableFuture<TOTPRecoveryCodesResponse>
 
     /**
      * Call this method to authenticate a recovery code for a TOTP instance. If this method succeeds, the user will be
@@ -113,4 +136,12 @@ public interface TOTP {
         parameters: RecoverParameters,
         callback: (TOTPRecoverResponse) -> Unit,
     )
+
+    /**
+     * Call this method to authenticate a recovery code for a TOTP instance. If this method succeeds, the user will be
+     * logged in and granted an active session
+     * @param parameters the parameters required to authenticate a recovery code for a TOTP instance
+     * @return [TOTPRecoverResponse]
+     */
+    public fun recoverCompletable(parameters: RecoverParameters): CompletableFuture<TOTPRecoverResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTPImpl.kt
@@ -9,8 +9,11 @@ import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class TOTPImpl(
     private val externalScope: CoroutineScope,
@@ -34,6 +37,12 @@ internal class TOTPImpl(
         }
     }
 
+    override fun createCompletable(parameters: TOTP.CreateParameters): CompletableFuture<TOTPCreateResponse> =
+        externalScope
+            .async {
+                create(parameters)
+            }.asCompletableFuture()
+
     override suspend fun authenticate(parameters: TOTP.AuthenticateParameters): TOTPAuthenticateResponse =
         withContext(dispatchers.io) {
             api
@@ -54,6 +63,14 @@ internal class TOTPImpl(
         }
     }
 
+    override fun authenticateCompletable(
+        parameters: TOTP.AuthenticateParameters,
+    ): CompletableFuture<TOTPAuthenticateResponse> =
+        externalScope
+            .async {
+                authenticate(parameters)
+            }.asCompletableFuture()
+
     override suspend fun recoveryCodes(): TOTPRecoveryCodesResponse =
         withContext(dispatchers.io) {
             api.recoveryCodes()
@@ -64,6 +81,12 @@ internal class TOTPImpl(
             callback(recoveryCodes())
         }
     }
+
+    override fun recoveryCodesCompletable(): CompletableFuture<TOTPRecoveryCodesResponse> =
+        externalScope
+            .async {
+                recoveryCodes()
+            }.asCompletableFuture()
 
     override suspend fun recover(parameters: TOTP.RecoverParameters): TOTPRecoverResponse =
         withContext(dispatchers.io) {
@@ -84,4 +107,10 @@ internal class TOTPImpl(
             callback(recover(parameters))
         }
     }
+
+    override fun recoverCompletable(parameters: TOTP.RecoverParameters): CompletableFuture<TOTPRecoverResponse> =
+        externalScope
+            .async {
+                recover(parameters)
+            }.asCompletableFuture()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagement.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagement.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.consumer.UpdateUserResponse
 import com.stytch.sdk.consumer.UserResponse
 import com.stytch.sdk.consumer.network.models.UserData
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.CompletableFuture
 
 /**
  * The UserManagement interface provides methods for retrieving an authenticated user and deleting authentication
@@ -37,6 +38,12 @@ public interface UserManagement {
     public fun getUser(callback: (UserResponse) -> Unit)
 
     /**
+     * Fetches a user from the current session
+     * @return [UserResponse]
+     */
+    public fun getUserCompletable(): CompletableFuture<UserResponse>
+
+    /**
      * Get user from memory without making a network call
      * @return [UserData]
      */
@@ -56,6 +63,12 @@ public interface UserManagement {
         factor: UserAuthenticationFactor,
         callback: (DeleteFactorResponse) -> Unit,
     )
+
+    /**
+     * Deletes a [UserAuthenticationFactor] from the currently authenticated user
+     * @return [DeleteFactorResponse]
+     */
+    public fun deleteFactorCompletable(factor: UserAuthenticationFactor): CompletableFuture<DeleteFactorResponse>
 
     /**
      * Data class used for wrapping parameters used with User updates
@@ -87,6 +100,13 @@ public interface UserManagement {
     )
 
     /**
+     * Updates the currently authenticated user
+     * @param params required to udpate the user
+     * @return [UpdateUserResponse]
+     */
+    public fun updateCompletable(params: UpdateParams): CompletableFuture<UpdateUserResponse>
+
+    /**
      * Data class used for wrapping parameters used for searching Users
      * @property email the email address to search for
      */
@@ -110,4 +130,11 @@ public interface UserManagement {
         params: SearchParams,
         callback: (SearchUserResponse) -> Unit,
     )
+
+    /**
+     * Searches for the specified user
+     * @param params required for searching users
+     * @return [SearchUserResponse]
+     */
+    public fun searchCompletable(params: SearchParams): CompletableFuture<SearchUserResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
@@ -10,9 +10,12 @@ import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.network.models.UserData
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
 
 internal class UserManagementImpl(
     private val externalScope: CoroutineScope,
@@ -50,6 +53,12 @@ internal class UserManagementImpl(
         }
     }
 
+    override fun getUserCompletable(): CompletableFuture<UserResponse> =
+        externalScope
+            .async {
+                getUser()
+            }.asCompletableFuture()
+
     override fun getSyncUser(): UserData? = sessionStorage.user
 
     override suspend fun deleteFactor(factor: UserAuthenticationFactor): DeleteFactorResponse =
@@ -79,6 +88,12 @@ internal class UserManagementImpl(
         }
     }
 
+    override fun deleteFactorCompletable(factor: UserAuthenticationFactor): CompletableFuture<DeleteFactorResponse> =
+        externalScope
+            .async {
+                deleteFactor(factor)
+            }.asCompletableFuture()
+
     override suspend fun update(params: UserManagement.UpdateParams): UpdateUserResponse =
         withContext(dispatchers.io) {
             api.updateUser(
@@ -97,6 +112,12 @@ internal class UserManagementImpl(
         }
     }
 
+    override fun updateCompletable(params: UserManagement.UpdateParams): CompletableFuture<UpdateUserResponse> =
+        externalScope
+            .async {
+                update(params)
+            }.asCompletableFuture()
+
     override suspend fun search(params: UserManagement.SearchParams): SearchUserResponse =
         withContext(dispatchers.io) {
             api.searchUsers(email = params.email)
@@ -110,4 +131,10 @@ internal class UserManagementImpl(
             callback(search(params))
         }
     }
+
+    override fun searchCompletable(params: UserManagement.SearchParams): CompletableFuture<SearchUserResponse> =
+        externalScope
+            .async {
+                search(params)
+            }.asCompletableFuture()
 }


### PR DESCRIPTION
Linear Ticket: [SDK-2003](https://linear.app/stytch/issue/SDK-2003)

## Changes:

1. Adds a `xCompletable` method returning a `CompletableFuture<T>` to all API methods, to match what we do in the Java SDK

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A