### PR TITLE
Add missing signup magic link url to consumer EML loginOrCreate

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.27.0'
+  PUBLISH_VERSION = '0.27.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
@@ -77,6 +77,7 @@ internal class MagicLinksImpl internal constructor(
                     api.loginOrCreate(
                         email = parameters.email,
                         loginMagicLinkUrl = parameters.loginMagicLinkUrl,
+                        signupMagicLinkUrl = parameters.signupMagicLinkUrl,
                         codeChallenge = challengeCode,
                         loginTemplateId = parameters.loginTemplateId,
                         signupTemplateId = parameters.signupTemplateId,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -146,6 +146,7 @@ internal object StytchApi {
             suspend fun loginOrCreate(
                 email: String,
                 loginMagicLinkUrl: String?,
+                signupMagicLinkUrl: String?,
                 codeChallenge: String,
                 loginTemplateId: String?,
                 signupTemplateId: String?,
@@ -156,6 +157,7 @@ internal object StytchApi {
                         ConsumerRequests.MagicLinks.Email.LoginOrCreateUserRequest(
                             email = email,
                             loginMagicLinkUrl = loginMagicLinkUrl,
+                            signupMagicLinkUrl = signupMagicLinkUrl,
                             codeChallenge = codeChallenge,
                             loginTemplateId = loginTemplateId,
                             signupTemplateId = signupTemplateId,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -15,6 +15,8 @@ internal object ConsumerRequests {
                 val email: String,
                 @Json(name = "login_magic_link_url")
                 val loginMagicLinkUrl: String?,
+                @Json(name = "signup_magic_link_url")
+                val signupMagicLinkUrl: String?,
                 @Json(name = "code_challenge")
                 val codeChallenge: String,
                 @Json(name = "login_template_id")

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
@@ -123,10 +123,10 @@ internal class MagicLinksImplTest {
         runTest {
             every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
             coEvery {
-                mockApi.loginOrCreate(any(), any(), any(), any(), any(), any())
+                mockApi.loginOrCreate(any(), any(), any(), any(), any(), any(), any())
             } returns successfulLoginOrCreateResponse
             impl.email.loginOrCreate(emailMagicLinkParameters)
-            coVerify { mockApi.loginOrCreate(any(), any(), any(), any(), any(), any()) }
+            coVerify { mockApi.loginOrCreate(any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -56,6 +56,7 @@ internal class StytchApiServiceTests {
                 ConsumerRequests.MagicLinks.Email.LoginOrCreateUserRequest(
                     email = EMAIL,
                     loginMagicLinkUrl = LOGIN_MAGIC_LINK,
+                    signupMagicLinkUrl = SIGNUP_MAGIC_LINK,
                     codeChallenge = "123",
                     loginTemplateId = "loginTemplateId",
                     signupTemplateId = "signUpTemplateId",
@@ -69,6 +70,7 @@ internal class StytchApiServiceTests {
                     mapOf(
                         "email" to parameters.email,
                         "login_magic_link_url" to parameters.loginMagicLinkUrl,
+                        "signup_magic_link_url" to parameters.signupMagicLinkUrl,
                         "code_challenge" to parameters.codeChallenge,
                         "login_template_id" to parameters.loginTemplateId,
                         "signup_template_id" to parameters.signupTemplateId,

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -94,7 +94,7 @@ internal class StytchApiTest {
         runTest {
             every { StytchApi.isInitialized } returns true
             coEvery { StytchApi.apiService.loginOrCreateUserByEmail(any()) } returns mockk(relaxed = true)
-            StytchApi.MagicLinks.Email.loginOrCreate("", "", "", "", "")
+            StytchApi.MagicLinks.Email.loginOrCreate("", null, null, "", null, null)
             coVerify { StytchApi.apiService.loginOrCreateUserByEmail(any()) }
         }
 


### PR DESCRIPTION
Linear Ticket: No Ticket

## Changes:

1. Looks like we've never been passing the signup magic link URL for consumer EML loginOrCreate 😬 

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A