### PR TITLE
Setup autopublish workflow

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -48,12 +48,9 @@ jobs:
                 echo "tag_exists=$TAG_EXISTS" >> $GITHUB_OUTPUT
     publish:
         name: Release build and publish
-        runs-on: ubuntu-latest
         needs: check
         if: needs.check.outputs.tag_exists == 'false'
-        steps:
-            - uses: actions/checkout@v3
-            - uses: stytchauth/stytch-android/.github/workflows/publish.yml@main
+        uses: stytchauth/stytch-android/.github/workflows/publish.yml@main
     tag-and-release:
         name: Create tag and release
         runs-on: ubuntu-latest

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -1,0 +1,74 @@
+name: Publish stytch-android
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+    check:
+        name: Check versions and tags
+        runs-on: ubuntu-latest
+        outputs:
+            tag_exists: ${{ steps.tags.outputs.tag_exists }}
+            this_version: ${{ steps.version.outputs.this_version }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-java@v3
+              with:
+                distribution: zulu
+                java-version: 17
+                cache: 'gradle'
+            - name: Get current version
+              id: version
+              env:
+                STYTCH_PUBLIC_TOKEN: 'abc123'
+                GOOGLE_OAUTH_CLIENT_ID: 'abc123'
+                STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
+                STYTCH_B2B_ORG_ID: 'abc123'
+                PASSKEYS_DOMAIN: 'abc123'
+                UI_GOOGLE_CLIENT_ID: 'abc123'
+              run: |
+                VERSION=$(./gradlew -q printVersion)
+                echo "Found version $VERSION"
+                echo "this_version=$VERSION" >> $GITHUB_OUTPUT
+            - name: Check if tag exists
+              id: tags
+              run: |
+                git fetch --tags
+                echo "Checking for tags matching ${{ steps.version.outputs.this_version }}"
+                TAG_EXISTS=false
+                if [ $(git tag -l "${{ steps.version.outputs.this_version }}") ]; then
+                    TAG_EXISTS=true
+                fi
+                echo "Tag exists = $TAG_EXISTS"
+                echo "tag_exists=$TAG_EXISTS" >> $GITHUB_OUTPUT
+    publish:
+        name: Release build and publish
+        runs-on: ubuntu-latest
+        needs: check
+        if: needs.check.outputs.tag_exists == 'false'
+        steps:
+            - uses: actions/checkout@v3
+            - uses: stytchauth/stytch-android/.github/workflows/publishHeadless.yml@main
+    tag-and-release:
+        name: Create tag and release
+        runs-on: ubuntu-latest
+        needs: check
+        if: needs.check.outputs.tag_exists == 'false'
+        steps:
+            - uses: actions/checkout@v3
+            - name: Create Tag
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                git tag -a "${{needs.check.outputs.this_version}}" -m "${{needs.check.outputs.this_version}}"
+                git push --follow-tags
+            - name: Create Release
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh release create "${{needs.check.outputs.this_version}}" --generate-notes
+        

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -53,7 +53,7 @@ jobs:
         if: needs.check.outputs.tag_exists == 'false'
         steps:
             - uses: actions/checkout@v3
-            - uses: stytchauth/stytch-android/.github/workflows/publishHeadless.yml@main
+            - uses: stytchauth/stytch-android/.github/workflows/publish.yml@main
     tag-and-release:
         name: Create tag and release
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Headless SDK
+name: Publish SDK
 
 on:
   workflow_dispatch:

--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -202,3 +202,11 @@ tasks.withType(Test).configureEach {
         showStackTraces = true
     }
 }
+
+tasks.register('printVersion') {
+    group = "Documentation"
+    description = "Prints the version of the SDK. Used for autoreleasing the SDK from GitHub"
+    doLast {
+        println(PUBLISH_VERSION)
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-2057](https://linear.app/stytch/issue/SDK-2057)

## Changes:

1. Creates an autopublish workflow to avoid instances where we forget to publish a release 😬 

## Notes:

- The checking of existing tags and conditional kick off of jobs definitely works, but the two pieces that are _untested_ are the actual publishing workflow (it reuses the existing one, so it _should_ be fine, but VSCode is complaining it can't find the action? It should work though, based on the ones we have in our other repos...) and the tag/release creation (those are both fairly straightforward, but I didn't want to pollute the repo with testing tags/versions)

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A