### PR TITLE
Add missing B2B OAuth Providers

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.27.1'
+  PUBLISH_VERSION = '0.28.0'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.stytch.sdk.common.network.models.AuthenticationFactor
 import com.stytch.sdk.common.network.models.CommonAuthenticationData
 import com.stytch.sdk.common.network.models.IBasicData
 import kotlinx.parcelize.Parcelize
@@ -134,7 +133,7 @@ public data class B2BSessionData(
     @Json(name = "expires_at")
     val expiresAt: String,
     @Json(name = "authentication_factors")
-    val authenticationFactors: List<AuthenticationFactor>,
+    val authenticationFactors: List<B2BAuthenticationFactor>,
     @Json(name = "custom_claims")
     val customClaims: @RawValue Map<String, Any?>?,
     val roles: List<String>,
@@ -1206,3 +1205,61 @@ public data class B2BSCIMRotateCancelResponseData(
     val connection: SCIMConnection,
 ) : IBasicData,
     Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2BAuthenticationFactor(
+    @Json(name = "delivery_method")
+    val deliveryMethod: String,
+    val type: String,
+    @Json(name = "last_authenticated_at")
+    val lastAuthenticatedAt: String,
+    @Json(name = "email_factor")
+    val emailFactor: EmailFactor?,
+    @Json(name = "phone_number_factor")
+    val phoneFactor: PhoneFactor?,
+    @Json(name = "google_oauth_factor")
+    val googleOAuthFactor: OAuthFactor?,
+    @Json(name = "microsoft_oauth_factor")
+    val microsoftOAuthFactor: OAuthFactor?,
+    @Json(name = "github_oauth_factor")
+    val githubOAuthFactor: OAuthFactor?,
+    @Json(name = "hubspot_oauth_factor")
+    val hubspotOAuthFactor: OAuthFactor?,
+    @Json(name = "slack_oauth_factor")
+    val slackOAuthFactor: OAuthFactor?,
+) : Parcelable {
+    @Keep
+    @JsonClass(generateAdapter = true)
+    @Parcelize
+    public data class EmailFactor(
+        @Json(name = "email_id")
+        val emailId: String,
+        @Json(name = "email_address")
+        val emailAddress: String,
+    ) : Parcelable
+
+    @Keep
+    @JsonClass(generateAdapter = true)
+    @Parcelize
+    public data class PhoneFactor(
+        @Json(name = "phone_id")
+        val phoneId: String,
+        @Json(name = "phone_number")
+        val phoneNumber: String,
+    ) : Parcelable
+
+    @Keep
+    @JsonClass(generateAdapter = true)
+    @Parcelize
+    public data class OAuthFactor(
+        val id: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
+        @Json(name = "provider_subject")
+        val providerSubject: String,
+        @Json(name = "provider_tenant_id")
+        val providerTenantId: String? = null,
+    ) : Parcelable
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/Enums.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/Enums.kt
@@ -42,16 +42,23 @@ public enum class MfaPolicy {
 }
 
 @JsonClass(generateAdapter = false)
-public enum class AllowedAuthMethods(override val jsonName: String) : IEnumValue {
+public enum class AllowedAuthMethods(
+    override val jsonName: String,
+) : IEnumValue {
     SSO("sso"),
     MAGIC_LINK("magic_link"),
     PASSWORD("password"),
     GOOGLE_OAUTH("google_oauth"),
     MICROSOFT_OAUTH("microsoft_oauth"),
+    HUBSPOT_OAUTH("hubspot_oauth"),
+    GITHUB_OAUTH("github_oauth"),
+    SLACK_OAUTH("slack_oauth"),
 }
 
 @JsonClass(generateAdapter = false)
-public enum class MfaMethod(override val jsonName: String) : IEnumValue {
+public enum class MfaMethod(
+    override val jsonName: String,
+) : IEnumValue {
     SMS("sms_otp"),
     TOTP("totp"),
 }
@@ -63,7 +70,9 @@ public enum class SearchOperator {
 }
 
 @JsonClass(generateAdapter = false)
-public enum class SetMFAEnrollment(override val jsonName: String) : IEnumValue {
+public enum class SetMFAEnrollment(
+    override val jsonName: String,
+) : IEnumValue {
     ENROLL("enroll"),
     UNENROLL("unenroll"),
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
@@ -146,6 +146,21 @@ public interface OAuth {
     public val microsoft: Provider
 
     /**
+     * Exposes an instance of the HubSpot OAuth implementation
+     */
+    public val hubspot: Provider
+
+    /**
+     * Exposes an instance of the Slack OAuth implementation
+     */
+    public val slack: Provider
+
+    /**
+     * Exposes an instance of the GitHub OAuth implementation
+     */
+    public val github: Provider
+
+    /**
      * Exposes an instance of the Discovery OAuth implementation
      */
     public val discovery: Discovery

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -30,6 +30,9 @@ internal class OAuthImpl(
 ) : OAuth {
     override val google: OAuth.Provider = ProviderImpl("google")
     override val microsoft: OAuth.Provider = ProviderImpl("microsoft")
+    override val hubspot: OAuth.Provider = ProviderImpl("hubspot")
+    override val slack: OAuth.Provider = ProviderImpl("slack")
+    override val github: OAuth.Provider = ProviderImpl("github")
     override val discovery: OAuth.Discovery = DiscoveryImpl()
 
     override suspend fun authenticate(parameters: OAuth.AuthenticateParameters): OAuthAuthenticateResponse {


### PR DESCRIPTION
Linear Ticket:
[SDK-2038](https://linear.app/stytch/issue/SDK-2038)
[SDK-2041](https://linear.app/stytch/issue/SDK-2041)
[SDK-2042](https://linear.app/stytch/issue/SDK-2042)

## Changes:

1. Adds Github, Hubspot, and Slack as supported B2B OAuth providers
2. Adds new B2BAuthenticationFactors instead of reusing the consumer ones, which aren't all relevant
3. Bumps version

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A