### PR TITLE
Fix GH workflows

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -62,6 +62,8 @@ jobs:
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
+                git config --local user.name "CI"
+                git config --local user.email "ci@stytch.com"
                 git tag -a "${{needs.check.outputs.this_version}}" -m "${{needs.check.outputs.this_version}}"
                 git push --follow-tags
             - name: Create Release

--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -41,7 +41,7 @@ jobs:
         cd main/docs
         zip -r ../../Docs.zip .
         cd -
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: "main"
         path: Docs.zip


### PR DESCRIPTION
Linear Ticket: [SDK-2103](https://linear.app/stytch/issue/SDK-2103)

## Changes:

1. Docs workflow was using mismatched versions of the artifact upload and download steps, causing it to fail
2. Local git wasn't configured with a name/email, so tag creation failed
3. I _think_ the release publish was actually just a flake from the Maven server, as a subsequent publish succeeded manually

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A