### PR TITLE
Move to lazy delegates with custom getter to avoid race conditions with SharedPreferences

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.29.0'
+  PUBLISH_VERSION = '0.29.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchLazyDelegate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchLazyDelegate.kt
@@ -1,0 +1,22 @@
+package com.stytch.sdk.common
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+internal class StytchLazyDelegate<T>(
+    private val assertInitialized: () -> Unit,
+    private val initializer: () -> T,
+) : ReadOnlyProperty<Any?, T> {
+    private var value: T? = null
+
+    override fun getValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+    ): T {
+        assertInitialized()
+        if (value == null) {
+            value = initializer()
+        }
+        return value!!
+    }
+}

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -101,6 +101,7 @@ internal class StytchB2BClientTest {
         StytchB2BClient.dispatchers = StytchDispatchers(dispatcher, dispatcher)
         StytchB2BClient.dfpProvider = mockk()
         StytchB2BClient.pkcePairManager = mockPKCEPairManager
+        StytchB2BClient.sessionStorage = mockk(relaxed = true, relaxUnitFun = true)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -100,6 +100,7 @@ internal class StytchClientTest {
         StytchClient.dispatchers = StytchDispatchers(dispatcher, dispatcher)
         StytchClient.dfpProvider = mockk()
         StytchClient.pkcePairManager = mockPKCEPairManager
+        StytchClient.sessionStorage = mockk(relaxed = true, relaxUnitFun = true)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Linear Ticket: [SDK-2111](https://linear.app/stytch/issue/SDK-2111)

## Changes:

1. By exposing flows that read the values from shared preferences, we exposed a (harmless, but frustrating when offline) race condition for reporting authentication state. This change maintains our initialization assertion while ensuring that no shared preferences access attempts are made before full initialization

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A