### PR TITLE
Update B2B Workbench app to support both headless and B2B UI testing

### DIFF
--- a/source/sdk/src/main/AndroidManifest.xml
+++ b/source/sdk/src/main/AndroidManifest.xml
@@ -40,6 +40,23 @@
                     android:host="deeplink" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.b2b.B2BAuthenticationActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <!-- These manifestPlaceholders in are defined in the application build.gradle -->
+                <data
+                    android:scheme="stytchui-${STYTCH_B2B_PUBLIC_TOKEN}"
+                    android:host="deeplink" />
+            </intent-filter>
+        </activity>
     </application>
     <queries>
         <intent>

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -17,8 +17,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.androidx.AndroidScreen
-import cafe.adriel.voyager.navigator.CurrentScreen
-import cafe.adriel.voyager.navigator.Navigator
 import com.stytch.sdk.R
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
@@ -42,12 +40,14 @@ internal fun StytchB2BAuthenticationApp(
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState()),
         ) {
+            /*
             Navigator(listOfNotNull(screen)) { navigator ->
                 screen?.let {
                     navigator.push(it)
                 }
                 CurrentScreen()
             }
+             */
             if (!bootstrapData.disableSDKWatermark) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/workbench-apps/b2b-workbench/build.gradle
+++ b/workbench-apps/b2b-workbench/build.gradle
@@ -18,7 +18,8 @@ android {
         manifestPlaceholders = [
             'stytchOAuthRedirectScheme': 'app',
             'stytchOAuthRedirectHost': 'b2bOAuth',
-            'STYTCH_PUBLIC_TOKEN': rootProject.ext["STYTCH_PUBLIC_TOKEN"]
+            'STYTCH_PUBLIC_TOKEN': rootProject.ext["STYTCH_PUBLIC_TOKEN"],
+            'STYTCH_B2B_PUBLIC_TOKEN': rootProject.ext["STYTCH_B2B_PUBLIC_TOKEN"],
         ]
     }
 

--- a/workbench-apps/b2b-workbench/src/main/AndroidManifest.xml
+++ b/workbench-apps/b2b-workbench/src/main/AndroidManifest.xml
@@ -30,6 +30,8 @@
                     android:host="@string/host" />
             </intent-filter>
         </activity>
+        <activity android:name="com.stytch.exampleapp.b2b.HeadlessWorkbenchActivity"  android:exported="false" />
+        <activity android:name="com.stytch.exampleapp.b2b.UIWorkbenchActivity"  android:exported="false" />
     </application>
 
 </manifest>

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/HeadlessWorkbenchActivity.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/HeadlessWorkbenchActivity.kt
@@ -1,0 +1,71 @@
+package com.stytch.exampleapp.b2b
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.fragment.app.FragmentActivity
+import com.stytch.exampleapp.b2b.theme.AppTheme
+import com.stytch.exampleapp.b2b.ui.AppScreen
+
+internal const val SSO_REQUEST_ID = 2
+internal const val B2B_OAUTH_REQUEST = 3
+
+class HeadlessWorkbenchActivity : FragmentActivity() {
+    private val homeViewModel: HomeViewModel by viewModels()
+    private val passwordsViewModel: PasswordsViewModel by viewModels()
+    private val discoveryViewModel: DiscoveryViewModel by viewModels()
+    private val ssoViewModel: SSOViewModel by viewModels()
+    private val memberViewModel: MemberViewModel by viewModels()
+    private val organizationViewModel: OrganizationViewModel by viewModels()
+    private val otpViewModel: OTPViewModel by viewModels()
+    private val totpViewModel: TOTPViewModel by viewModels()
+    private val recoveryCodesViewModel: RecoveryCodesViewModel by viewModels()
+    private val oAuthViewModel: OAuthViewModel by viewModels()
+    private val scimViewModel: SCIMViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                AppScreen(
+                    homeViewModel,
+                    passwordsViewModel,
+                    discoveryViewModel,
+                    ssoViewModel,
+                    memberViewModel,
+                    organizationViewModel,
+                    otpViewModel,
+                    totpViewModel,
+                    recoveryCodesViewModel,
+                    oAuthViewModel,
+                    scimViewModel,
+                )
+            }
+        }
+        if (intent.action == Intent.ACTION_VIEW) {
+            handleIntent(intent)
+        }
+    }
+
+    private fun handleIntent(intent: Intent) {
+        intent.data?.let { appLinkData ->
+            Toast.makeText(this, getString(R.string.deeplink_received_toast), Toast.LENGTH_LONG).show()
+            homeViewModel.handleUri(appLinkData)
+        }
+    }
+
+    public override fun onActivityResult(
+        requestCode: Int,
+        resultCode: Int,
+        data: Intent?,
+    ) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            SSO_REQUEST_ID -> {
+                ssoViewModel.authenticateSSO(resultCode = resultCode, intent = data)
+            }
+        }
+    }
+}

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/MainActivity.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/MainActivity.kt
@@ -2,70 +2,46 @@ package com.stytch.exampleapp.b2b
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import com.stytch.exampleapp.b2b.theme.AppTheme
-import com.stytch.exampleapp.b2b.ui.AppScreen
-
-internal const val SSO_REQUEST_ID = 2
-internal const val B2B_OAUTH_REQUEST = 3
 
 class MainActivity : FragmentActivity() {
-    private val homeViewModel: HomeViewModel by viewModels()
-    private val passwordsViewModel: PasswordsViewModel by viewModels()
-    private val discoveryViewModel: DiscoveryViewModel by viewModels()
-    private val ssoViewModel: SSOViewModel by viewModels()
-    private val memberViewModel: MemberViewModel by viewModels()
-    private val organizationViewModel: OrganizationViewModel by viewModels()
-    private val otpViewModel: OTPViewModel by viewModels()
-    private val totpViewModel: TOTPViewModel by viewModels()
-    private val recoveryCodesViewModel: RecoveryCodesViewModel by viewModels()
-    private val oAuthViewModel: OAuthViewModel by viewModels()
-    private val scimViewModel: SCIMViewModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-                AppScreen(
-                    homeViewModel,
-                    passwordsViewModel,
-                    discoveryViewModel,
-                    ssoViewModel,
-                    memberViewModel,
-                    organizationViewModel,
-                    otpViewModel,
-                    totpViewModel,
-                    recoveryCodesViewModel,
-                    oAuthViewModel,
-                    scimViewModel,
-                )
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState()),
+                ) {
+                    Button(onClick = ::launchHeadlessWorkbench) {
+                        Text(text = "Launch Headless Workbench")
+                    }
+                    Button(onClick = ::launchUIWorkbench) {
+                        Text(text = "Launch UI Workbench")
+                    }
+                }
             }
-        }
-        if (intent.action == Intent.ACTION_VIEW) {
-            handleIntent(intent)
         }
     }
 
-    private fun handleIntent(intent: Intent) {
-        intent.data?.let { appLinkData ->
-            Toast.makeText(this, getString(R.string.deeplink_received_toast), Toast.LENGTH_LONG).show()
-            homeViewModel.handleUri(appLinkData)
-        }
+    private fun launchHeadlessWorkbench() {
+        val intent = Intent(this, HeadlessWorkbenchActivity::class.java)
+        startActivity(intent)
     }
 
-    public override fun onActivityResult(
-        requestCode: Int,
-        resultCode: Int,
-        data: Intent?,
-    ) {
-        super.onActivityResult(requestCode, resultCode, data)
-        when (requestCode) {
-            SSO_REQUEST_ID -> {
-                ssoViewModel.authenticateSSO(resultCode = resultCode, intent = data)
-            }
-        }
+    private fun launchUIWorkbench() {
+        val intent = Intent(this, UIWorkbenchActivity::class.java)
+        startActivity(intent)
     }
 }

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/UIWorkbenchActivity.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/UIWorkbenchActivity.kt
@@ -1,0 +1,50 @@
+package com.stytch.exampleapp.b2b
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.ui.b2b.StytchB2BUI
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
+
+class UIWorkbenchActivity : ComponentActivity() {
+    private val stytchUi =
+        StytchB2BUI
+            .Builder()
+            .apply {
+                activity(this@UIWorkbenchActivity)
+                productConfig(
+                    StytchB2BProductConfig(),
+                )
+                onAuthenticated {
+                    when (it) {
+                        is StytchResult.Success -> {
+                            Toast
+                                .makeText(
+                                    this@UIWorkbenchActivity,
+                                    "Authentication Succeeded",
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                        }
+                        is StytchResult.Error -> {
+                            Toast.makeText(this@UIWorkbenchActivity, it.exception.message, Toast.LENGTH_LONG).show()
+                        }
+                    }
+                }
+            }.build()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            Column {
+                Button(onClick = stytchUi::authenticate) {
+                    Text("Launch Authentication")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-2256](https://linear.app/stytch/issue/SDK-2256)

## Changes:

1. Add B2B activity to SDK manifest (so it can actually launch!)
2. Change B2B Workbench start activity to one that allows you to switch between headless and UI testing
3. Create a blank UI testing activity to validate that it launches correctly

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A