### PR TITLE
Add final MFA screens

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -40,6 +40,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordAuthenticateScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordForgotScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordResetScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreen
+import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreen
 import com.stytch.sdk.ui.b2b.screens.SuccessScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreen
@@ -159,7 +160,7 @@ internal fun StytchB2BAuthenticationApp(
                     PageTitle(text = "RecoveryCodeEntry")
                 }
                 composable<Routes.RecoveryCodeSave> {
-                    PageTitle(text = "RecoveryCodeSave")
+                    RecoveryCodesSaveScreen(state = state, createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.SMSOTPEnrollment> {
                     PageTitle(text = "SMSOTPEnrollment")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -40,6 +40,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordAuthenticateScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordForgotScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordResetScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreen
+import com.stytch.sdk.ui.b2b.screens.RecoveryCodesEntryScreen
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreen
 import com.stytch.sdk.ui.b2b.screens.SuccessScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreen
@@ -157,7 +158,7 @@ internal fun StytchB2BAuthenticationApp(
                     )
                 }
                 composable<Routes.RecoveryCodeEntry> {
-                    PageTitle(text = "RecoveryCodeEntry")
+                    RecoveryCodesEntryScreen(createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.RecoveryCodeSave> {
                     RecoveryCodesSaveScreen(state = state, createViewModel = ::createViewModelHelper)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -43,11 +43,11 @@ import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreen
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesEntryScreen
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreen
 import com.stytch.sdk.ui.b2b.screens.SMSOTPEnrollmentScreen
+import com.stytch.sdk.ui.b2b.screens.SMSOTPEntryScreen
 import com.stytch.sdk.ui.b2b.screens.SuccessScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreen
 import com.stytch.sdk.ui.shared.components.LoadingDialog
-import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.theme.LocalStytchBootstrapData
 import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
 
@@ -168,7 +168,7 @@ internal fun StytchB2BAuthenticationApp(
                     SMSOTPEnrollmentScreen(state = state, createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.SMSOTPEntry> {
-                    PageTitle(text = "SMSOTPEntry")
+                    SMSOTPEntryScreen(state = state, createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.Success> {
                     SuccessScreen()

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -42,6 +42,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordResetScreen
 import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreen
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesEntryScreen
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreen
+import com.stytch.sdk.ui.b2b.screens.SMSOTPEnrollmentScreen
 import com.stytch.sdk.ui.b2b.screens.SuccessScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreen
@@ -164,7 +165,7 @@ internal fun StytchB2BAuthenticationApp(
                     RecoveryCodesSaveScreen(state = state, createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.SMSOTPEnrollment> {
-                    PageTitle(text = "SMSOTPEnrollment")
+                    SMSOTPEnrollmentScreen(state = state, createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.SMSOTPEntry> {
                     PageTitle(text = "SMSOTPEntry")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import coil3.compose.AsyncImage
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
@@ -112,8 +112,8 @@ internal fun DiscoveryScreen(
     val theme = LocalStytchTheme.current
     val shouldDirectLoginConfigEnabled = config.directLoginForSingleMembership?.status == true
     val createOrganzationsEnabled = LocalStytchBootstrapData.current.createOrganizationEnabled
-    val isCreatingState = viewModel.isCreatingStateFlow.collectAsState()
-    val isExchangingState = viewModel.isExchangingStateFlow.collectAsState()
+    val isCreatingState = viewModel.isCreatingStateFlow.collectAsStateWithLifecycle()
+    val isExchangingState = viewModel.isExchangingStateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current as Activity
 
     fun handleDiscoveryOrganizationStart(discoveredOrganization: DiscoveredOrganization) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MFAEnrollmentSelection.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MFAEnrollmentSelection.kt
@@ -12,12 +12,12 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
@@ -92,7 +92,7 @@ internal fun MFAEnrollmentSelectionScreen(
     viewModel: MFAEnrollmentSelectionScreenViewModel =
         createViewModel(MFAEnrollmentSelectionScreenViewModel::class.java),
 ) {
-    val sortedOptions = viewModel.sortedMfaMethods.collectAsState()
+    val sortedOptions = viewModel.sortedMfaMethods.collectAsStateWithLifecycle()
     val theme = LocalStytchTheme.current
     Column {
         PageTitle(text = "Set up Multi-Factor Authentication")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
@@ -18,7 +18,6 @@ import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.EmailInput
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.StytchButton
-import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -61,7 +60,6 @@ internal fun PasswordForgotScreen(
     createViewModel: CreateViewModel<PasswordForgotScreenViewModel>,
     viewModel: PasswordForgotScreenViewModel = createViewModel(PasswordForgotScreenViewModel::class.java),
 ) {
-    val theme = LocalStytchTheme.current
     Column {
         PageTitle(text = "Check your email for help signing in!")
         BodyText(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
@@ -1,8 +1,13 @@
 package com.stytch.sdk.ui.b2b.screens
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
@@ -68,9 +73,11 @@ internal fun PasswordForgotScreen(
                     "if you have one.",
         )
         EmailInput(
+            modifier = Modifier.fillMaxWidth(),
             emailState = state.value.emailState,
             onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
         )
+        Spacer(modifier = Modifier.height(16.dp))
         StytchButton(
             enabled = state.value.emailState.validEmail == true,
             text = "Continue",

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesEntryScreen.kt
@@ -1,0 +1,51 @@
+package com.stytch.sdk.ui.b2b.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewModelScope
+import com.stytch.sdk.ui.b2b.BaseViewModel
+import com.stytch.sdk.ui.b2b.CreateViewModel
+import com.stytch.sdk.ui.b2b.data.B2BUIAction
+import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
+import com.stytch.sdk.ui.b2b.usecases.UseRecoveryCodesRecover
+import com.stytch.sdk.ui.shared.components.BodyText
+import com.stytch.sdk.ui.shared.components.PageTitle
+import com.stytch.sdk.ui.shared.components.StytchButton
+import com.stytch.sdk.ui.shared.components.StytchInput
+import kotlinx.coroutines.flow.StateFlow
+
+internal class RecoveryCodesEntryScreenViewModel(
+    internal val state: StateFlow<B2BUIState>,
+    dispatchAction: suspend (B2BUIAction) -> Unit,
+    productConfig: StytchB2BProductConfig,
+) : BaseViewModel(state, dispatchAction) {
+    val useRecoveryCodesRecover = UseRecoveryCodesRecover(viewModelScope, state, productConfig, ::request)
+}
+
+@Composable
+internal fun RecoveryCodesEntryScreen(
+    createViewModel: CreateViewModel<RecoveryCodesEntryScreenViewModel>,
+    viewModel: RecoveryCodesEntryScreenViewModel = createViewModel(RecoveryCodesEntryScreenViewModel::class.java),
+) {
+    var recoveryCode by remember { mutableStateOf("") }
+    Column {
+        PageTitle(text = "Enter backup code")
+        BodyText(text = "Enter one of the backup codes you saved when setting up your authenticator app.")
+        StytchInput(modifier = Modifier.fillMaxWidth(), value = recoveryCode, onValueChange = { recoveryCode = it })
+        Spacer(modifier = Modifier.height(16.dp))
+        StytchButton(
+            text = "Done",
+            enabled = recoveryCode.isNotEmpty(),
+        ) { viewModel.useRecoveryCodesRecover(recoveryCode) }
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesSaveScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesSaveScreen.kt
@@ -1,0 +1,128 @@
+package com.stytch.sdk.ui.b2b.screens
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.stytch.sdk.R
+import com.stytch.sdk.ui.b2b.BaseViewModel
+import com.stytch.sdk.ui.b2b.CreateViewModel
+import com.stytch.sdk.ui.b2b.data.B2BUIAction
+import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.shared.components.BodyText
+import com.stytch.sdk.ui.shared.components.PageTitle
+import com.stytch.sdk.ui.shared.components.StytchButton
+import com.stytch.sdk.ui.shared.components.StytchTextButton
+import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
+import kotlinx.coroutines.flow.StateFlow
+
+internal class RecoveryCodesSaveScreenViewModel(
+    internal val state: StateFlow<B2BUIState>,
+    dispatchAction: suspend (B2BUIAction) -> Unit,
+) : BaseViewModel(state, dispatchAction) {
+    fun acknowledgeSave() {
+        dispatch(SetNextRoute(state.value.postAuthScreen))
+    }
+}
+
+@Composable
+internal fun RecoveryCodesSaveScreen(
+    state: State<B2BUIState>,
+    createViewModel: CreateViewModel<RecoveryCodesSaveScreenViewModel>,
+    viewModel: RecoveryCodesSaveScreenViewModel = createViewModel(RecoveryCodesSaveScreenViewModel::class.java),
+) {
+    val theme = LocalStytchTheme.current
+    val clipboardManager = LocalClipboardManager.current
+    val backupCodes =
+        state.value.mfaTOTPState
+            ?.enrollmentState
+            ?.recoveryCodes ?: emptyList()
+    val allCodesJoined = backupCodes.joinToString("\n")
+    val sendIntent: Intent =
+        Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, allCodesJoined)
+            type = "text/plain"
+        }
+    val shareIntent = Intent.createChooser(sendIntent, null)
+    val context = LocalContext.current
+    Column {
+        PageTitle(text = "Save your backup codes!")
+        BodyText(text = "This is the only time you will be able to access and save your backup codes.")
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color(theme.disabledButtonBackgroundColor))
+                    .border(
+                        1.dp,
+                        Color(theme.disabledButtonBackgroundColor),
+                        RoundedCornerShape(theme.buttonBorderRadius),
+                    ),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                backupCodes.forEach { code ->
+                    Text(
+                        modifier = Modifier.fillMaxWidth(0.8f).padding(bottom = 8.dp),
+                        text = code,
+                        style =
+                            TextStyle(
+                                fontFamily = FontFamily(Font(R.font.ibm_plex_mono_regular)),
+                                fontWeight = FontWeight.W400,
+                                fontSize = 16.sp,
+                                lineHeight = 20.sp,
+                                textAlign = TextAlign.Center,
+                                color = Color(theme.primaryTextColor),
+                            ),
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            StytchTextButton(modifier = Modifier.weight(1f), text = "Download codes") {
+                context.startActivity(shareIntent)
+            }
+            StytchTextButton(modifier = Modifier.weight(1f), text = "Copy all") {
+                clipboardManager.setText(AnnotatedString(allCodesJoined))
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        StytchButton(text = "Done", enabled = true, onClick = viewModel::acknowledgeSave)
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesSaveScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesSaveScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,6 +39,7 @@ import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.StytchButton
@@ -49,7 +52,7 @@ internal class RecoveryCodesSaveScreenViewModel(
     dispatchAction: suspend (B2BUIAction) -> Unit,
 ) : BaseViewModel(state, dispatchAction) {
     fun acknowledgeSave() {
-        dispatch(SetNextRoute(state.value.postAuthScreen))
+        dispatch(SetNextRoute(Routes.Success))
     }
 }
 
@@ -74,6 +77,7 @@ internal fun RecoveryCodesSaveScreen(
         }
     val shareIntent = Intent.createChooser(sendIntent, null)
     val context = LocalContext.current
+    var didSaveCodesSomehow by remember { mutableStateOf(false) }
     Column {
         PageTitle(text = "Save your backup codes!")
         BodyText(text = "This is the only time you will be able to access and save your backup codes.")
@@ -94,7 +98,7 @@ internal fun RecoveryCodesSaveScreen(
             ) {
                 backupCodes.forEach { code ->
                     Text(
-                        modifier = Modifier.fillMaxWidth(0.8f).padding(bottom = 8.dp),
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
                         text = code,
                         style =
                             TextStyle(
@@ -117,12 +121,14 @@ internal fun RecoveryCodesSaveScreen(
         ) {
             StytchTextButton(modifier = Modifier.weight(1f), text = "Download codes") {
                 context.startActivity(shareIntent)
+                didSaveCodesSomehow = true
             }
             StytchTextButton(modifier = Modifier.weight(1f), text = "Copy all") {
                 clipboardManager.setText(AnnotatedString(allCodesJoined))
+                didSaveCodesSomehow = true
             }
         }
         Spacer(modifier = Modifier.height(16.dp))
-        StytchButton(text = "Done", enabled = true, onClick = viewModel::acknowledgeSave)
+        StytchButton(text = "Done", enabled = didSaveCodesSomehow, onClick = viewModel::acknowledgeSave)
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
@@ -1,0 +1,47 @@
+package com.stytch.sdk.ui.b2b.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.lifecycle.viewModelScope
+import com.stytch.sdk.ui.b2b.BaseViewModel
+import com.stytch.sdk.ui.b2b.CreateViewModel
+import com.stytch.sdk.ui.b2b.data.B2BUIAction
+import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSSend
+import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberPhoneNumber
+import com.stytch.sdk.ui.shared.components.BodyText
+import com.stytch.sdk.ui.shared.components.PageTitle
+import com.stytch.sdk.ui.shared.components.PhoneEntry
+import kotlinx.coroutines.flow.StateFlow
+
+internal class SMSOTPEnrollmentScreenViewModel(
+    internal val state: StateFlow<B2BUIState>,
+    dispatchAction: suspend (B2BUIAction) -> Unit,
+) : BaseViewModel(state, dispatchAction) {
+    val useSmsOtpSend = UseOTPSMSSend(viewModelScope, state, ::dispatch, ::request)
+    val useUpdateMemberPhoneNumber = UseUpdateMemberPhoneNumber(state, ::dispatch)
+}
+
+@Composable
+internal fun SMSOTPEnrollmentScreen(
+    state: State<B2BUIState>,
+    createViewModel: CreateViewModel<SMSOTPEnrollmentScreenViewModel>,
+    viewModel: SMSOTPEnrollmentScreenViewModel = createViewModel(SMSOTPEnrollmentScreenViewModel::class.java),
+) {
+    val phoneNumberState = state.value.phoneNumberState
+    Column {
+        PageTitle(text = "Enter your phone number to set up Multi-Factor Authentication")
+        BodyText(
+            text = "Your organization requires an additional form of verification to make your account more secure.",
+        )
+        PhoneEntry(
+            countryCode = phoneNumberState.countryCode,
+            onCountryCodeChanged = { viewModel.useUpdateMemberPhoneNumber(it, null) },
+            phoneNumber = phoneNumberState.phoneNumber,
+            onPhoneNumberChanged = { viewModel.useUpdateMemberPhoneNumber(null, it) },
+            onPhoneNumberSubmit = { viewModel.useSmsOtpSend() },
+            statusText = state.value.stytchError?.message,
+        )
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
@@ -1,0 +1,124 @@
+package com.stytch.sdk.ui.b2b.screens
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewModelScope
+import com.stytch.sdk.R
+import com.stytch.sdk.ui.b2b.BaseViewModel
+import com.stytch.sdk.ui.b2b.CreateViewModel
+import com.stytch.sdk.ui.b2b.data.B2BUIAction
+import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSAuthenticate
+import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSSend
+import com.stytch.sdk.ui.shared.components.BodyText
+import com.stytch.sdk.ui.shared.components.OTPEntry
+import com.stytch.sdk.ui.shared.components.PageTitle
+import com.stytch.sdk.ui.shared.components.StytchAlertDialog
+import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
+import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+private const val OTP_EXPIRATION_SECONDS = (2 * 60).toLong()
+private const val ONE_SECOND = 1000L
+
+internal class SMSOTPEntryScreenViewModel(
+    internal val state: StateFlow<B2BUIState>,
+    dispatchAction: suspend (B2BUIAction) -> Unit,
+) : BaseViewModel(state, dispatchAction) {
+    val useOTPSMSSend = UseOTPSMSSend(viewModelScope, state, ::dispatch, ::request)
+    val useOTPSMSAuthenticate = UseOTPSMSAuthenticate(viewModelScope, state, ::request)
+}
+
+@Composable
+internal fun SMSOTPEntryScreen(
+    state: State<B2BUIState>,
+    createViewModel: CreateViewModel<SMSOTPEntryScreenViewModel>,
+    viewModel: SMSOTPEntryScreenViewModel = createViewModel(SMSOTPEntryScreenViewModel::class.java),
+) {
+    val type = LocalStytchTypography.current
+    val theme = LocalStytchTheme.current
+    val recipientFormatted =
+        AnnotatedString(
+            text = " ${state.value.phoneNumberState.formatted()}",
+            spanStyle = SpanStyle(fontWeight = FontWeight.W700),
+        )
+    var showResendDialog by remember { mutableStateOf(false) }
+    var countdownSeconds by remember { mutableLongStateOf(OTP_EXPIRATION_SECONDS) }
+    var expirationTimeFormatted by remember { mutableStateOf("2:00") }
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(Unit) {
+        coroutineScope.launch {
+            while (countdownSeconds > 0) {
+                delay(ONE_SECOND)
+                countdownSeconds -= 1
+                expirationTimeFormatted = DateUtils.formatElapsedTime(countdownSeconds)
+            }
+        }
+    }
+
+    Column(modifier = Modifier.padding(bottom = 32.dp)) {
+        PageTitle(text = "Enter passcode")
+        BodyText(
+            text =
+                buildAnnotatedString {
+                    append("A 6-digit passcode was sent to you at ")
+                    append(recipientFormatted)
+                },
+        )
+        OTPEntry(
+            errorMessage = state.value.stytchError?.message,
+            onCodeComplete = { viewModel.useOTPSMSAuthenticate(it) },
+        )
+        Text(
+            text = stringResource(id = R.string.code_expires_in, expirationTimeFormatted),
+            textAlign = TextAlign.Start,
+            style =
+                type.caption.copy(
+                    color = Color(theme.secondaryTextColor),
+                ),
+            modifier = Modifier.clickable { showResendDialog = true },
+        )
+    }
+    if (showResendDialog) {
+        StytchAlertDialog(
+            onDismissRequest = { showResendDialog = false },
+            title = stringResource(id = R.string.resend_code),
+            body =
+                buildAnnotatedString {
+                    append(stringResource(id = R.string.new_code_will_be_sent_to))
+                    append(recipientFormatted)
+                },
+            cancelText = stringResource(id = R.string.cancel),
+            onCancelClick = { showResendDialog = false },
+            acceptText = stringResource(id = R.string.send_code),
+            onAcceptClick = {
+                viewModel.useOTPSMSSend()
+                countdownSeconds = OTP_EXPIRATION_SECONDS
+                showResendDialog = false
+            },
+        )
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.R
 import com.stytch.sdk.ui.b2b.BaseViewModel
@@ -77,7 +77,7 @@ internal fun TOTPEnrollmentScreen(
     createViewModel: CreateViewModel<TOTPEnrollmentScreenViewModel>,
     viewModel: TOTPEnrollmentScreenViewModel = createViewModel(TOTPEnrollmentScreenViewModel::class.java),
 ) {
-    val totpState = viewModel.totpState.collectAsState().value
+    val totpState = viewModel.totpState.collectAsStateWithLifecycle().value
     val theme = LocalStytchTheme.current
     val clipboardManager = LocalClipboardManager.current
     if (totpState == null || totpState.isCreating) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEntryScreen.kt
@@ -3,13 +3,13 @@ package com.stytch.sdk.ui.b2b.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.ui.b2b.BaseViewModel
@@ -87,7 +87,7 @@ internal fun TOTPEntryScreen(
     createViewModel: CreateViewModel<TOTPEntryScreenViewModel>,
     viewModel: TOTPEntryScreenViewModel = createViewModel(TOTPEntryScreenViewModel::class.java),
 ) {
-    val totpEntryState = viewModel.totpEntryState.collectAsState().value
+    val totpEntryState = viewModel.totpEntryState.collectAsStateWithLifecycle().value
     val theme = LocalStytchTheme.current
     Column {
         PageTitle(text = "Enter verification code")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
@@ -17,6 +17,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesEntryScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.SMSOTPEnrollmentScreenViewModel
+import com.stytch.sdk.ui.b2b.screens.SMSOTPEntryScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreenViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -81,6 +82,8 @@ internal class B2BUIViewModelFactory(
                 RecoveryCodesEntryScreenViewModel(state, dispatchAction, productConfig) as T
             SMSOTPEnrollmentScreenViewModel::class.java ->
                 SMSOTPEnrollmentScreenViewModel(state, dispatchAction) as T
+            SMSOTPEntryScreenViewModel::class.java ->
+                SMSOTPEntryScreenViewModel(state, dispatchAction) as T
             else -> super.create(modelClass)
         }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
@@ -14,6 +14,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordAuthenticateScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordForgotScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordResetScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreenViewModel
+import com.stytch.sdk.ui.b2b.screens.RecoveryCodesEntryScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreenViewModel
@@ -75,6 +76,8 @@ internal class B2BUIViewModelFactory(
                 TOTPEntryScreenViewModel(state, dispatchAction, productConfig) as T
             RecoveryCodesSaveScreenViewModel::class.java ->
                 RecoveryCodesSaveScreenViewModel(state, dispatchAction) as T
+            RecoveryCodesEntryScreenViewModel::class.java ->
+                RecoveryCodesEntryScreenViewModel(state, dispatchAction, productConfig) as T
             else -> super.create(modelClass)
         }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
@@ -14,6 +14,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordAuthenticateScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordForgotScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordResetScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreenViewModel
+import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreenViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -72,6 +73,8 @@ internal class B2BUIViewModelFactory(
                 TOTPEnrollmentScreenViewModel(state, dispatchAction) as T
             TOTPEntryScreenViewModel::class.java ->
                 TOTPEntryScreenViewModel(state, dispatchAction, productConfig) as T
+            RecoveryCodesSaveScreenViewModel::class.java ->
+                RecoveryCodesSaveScreenViewModel(state, dispatchAction) as T
             else -> super.create(modelClass)
         }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
@@ -16,6 +16,7 @@ import com.stytch.sdk.ui.b2b.screens.PasswordResetScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordSetNewScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesEntryScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.RecoveryCodesSaveScreenViewModel
+import com.stytch.sdk.ui.b2b.screens.SMSOTPEnrollmentScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreenViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -78,6 +79,8 @@ internal class B2BUIViewModelFactory(
                 RecoveryCodesSaveScreenViewModel(state, dispatchAction) as T
             RecoveryCodesEntryScreenViewModel::class.java ->
                 RecoveryCodesEntryScreenViewModel(state, dispatchAction, productConfig) as T
+            SMSOTPEnrollmentScreenViewModel::class.java ->
+                SMSOTPEnrollmentScreenViewModel(state, dispatchAction) as T
             else -> super.create(modelClass)
         }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchButton.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchButton.kt
@@ -15,8 +15,8 @@ import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
 internal fun StytchButton(
     modifier: Modifier = Modifier,
     text: String = "",
-    onClick: () -> Unit = { },
     enabled: Boolean,
+    onClick: () -> Unit = { },
 ) {
     val theme = LocalStytchTheme.current
     val type = LocalStytchTypography.current
@@ -31,7 +31,7 @@ internal fun StytchButton(
                 contentColor = Color(theme.buttonTextColor),
                 disabledContentColor = Color(theme.disabledButtonTextColor),
             ),
-        shape = RoundedCornerShape(theme.buttonBorderRadius)
+        shape = RoundedCornerShape(theme.buttonBorderRadius),
     ) {
         Text(
             text = text,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchTextButton.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchTextButton.kt
@@ -13,15 +13,17 @@ import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
 
 @Composable
 internal fun StytchTextButton(
+    modifier: Modifier? = Modifier,
     text: String,
     color: Int? = null,
     onClick: () -> Unit,
 ) {
-    StytchTextButton(text = AnnotatedString(text), color = color, onClick = onClick)
+    StytchTextButton(modifier = modifier, text = AnnotatedString(text), color = color, onClick = onClick)
 }
 
 @Composable
 internal fun StytchTextButton(
+    modifier: Modifier? = Modifier,
     text: AnnotatedString,
     color: Int? = null,
     onClick: () -> Unit,
@@ -29,7 +31,7 @@ internal fun StytchTextButton(
     val type = LocalStytchTypography.current
     val theme = LocalStytchTheme.current
     TextButton(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier ?: Modifier.fillMaxWidth(),
         onClick = onClick,
     ) {
         Text(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchTextButton.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchTextButton.kt
@@ -13,7 +13,7 @@ import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
 
 @Composable
 internal fun StytchTextButton(
-    modifier: Modifier? = Modifier,
+    modifier: Modifier = Modifier.fillMaxWidth(),
     text: String,
     color: Int? = null,
     onClick: () -> Unit,
@@ -23,7 +23,7 @@ internal fun StytchTextButton(
 
 @Composable
 internal fun StytchTextButton(
-    modifier: Modifier? = Modifier,
+    modifier: Modifier = Modifier.fillMaxWidth(),
     text: AnnotatedString,
     color: Int? = null,
     onClick: () -> Unit,
@@ -31,7 +31,7 @@ internal fun StytchTextButton(
     val type = LocalStytchTypography.current
     val theme = LocalStytchTheme.current
     TextButton(
-        modifier = modifier ?: Modifier.fillMaxWidth(),
+        modifier = modifier,
         onClick = onClick,
     ) {
         Text(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/PhoneNumberState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/PhoneNumberState.kt
@@ -19,4 +19,13 @@ internal data class PhoneNumberState(
             }
         return PhoneNumberUtil.getInstance().format(phone, PhoneNumberUtil.PhoneNumberFormat.E164)
     }
+
+    fun formatted(): String {
+        val phone =
+            Phonenumber.PhoneNumber().apply {
+                countryCode = this@PhoneNumberState.countryCode.toInt()
+                nationalNumber = (this@PhoneNumberState.phoneNumber).toLong()
+            }
+        return PhoneNumberUtil.getInstance().format(phone, PhoneNumberUtil.PhoneNumberFormat.NATIONAL)
+    }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/utils/PhoneNumberVisualTransformation.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/utils/PhoneNumberVisualTransformation.kt
@@ -7,8 +7,11 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import com.google.i18n.phonenumbers.PhoneNumberUtil
+import kotlin.math.max
 
-internal class PhoneNumberVisualTransformation(countryCode: String) : VisualTransformation {
+internal class PhoneNumberVisualTransformation(
+    countryCode: String,
+) : VisualTransformation {
     private val phoneNumberFormatter = PhoneNumberUtil.getInstance().getAsYouTypeFormatter(countryCode)
 
     override fun filter(text: AnnotatedString): TransformedText {
@@ -17,13 +20,11 @@ internal class PhoneNumberVisualTransformation(countryCode: String) : VisualTran
         return TransformedText(
             AnnotatedString(transformation.formatted ?: ""),
             object : OffsetMapping {
-                override fun originalToTransformed(offset: Int): Int {
-                    return transformation.originalToTransformed[offset]
-                }
+                override fun originalToTransformed(offset: Int): Int =
+                    max(transformation.originalToTransformed[offset], 0)
 
-                override fun transformedToOriginal(offset: Int): Int {
-                    return transformation.transformedToOriginal[offset]
-                }
+                override fun transformedToOriginal(offset: Int): Int =
+                    max(transformation.transformedToOriginal[offset], 0)
             },
         )
     }
@@ -75,13 +76,12 @@ internal class PhoneNumberVisualTransformation(countryCode: String) : VisualTran
     private fun getFormattedNumber(
         lastNonSeparator: Char,
         hasCursor: Boolean,
-    ): String? {
-        return if (hasCursor) {
+    ): String? =
+        if (hasCursor) {
             phoneNumberFormatter.inputDigitAndRememberPosition(lastNonSeparator)
         } else {
             phoneNumberFormatter.inputDigit(lastNonSeparator)
         }
-    }
 
     private data class Transformation(
         val formatted: String?,


### PR DESCRIPTION
Linear Ticket: 
[SDK-2248](https://linear.app/stytch/issue/SDK-2248)
[SDK-2249](https://linear.app/stytch/issue/SDK-2249)
[SDK-2250](https://linear.app/stytch/issue/SDK-2250)
[SDK-2251](https://linear.app/stytch/issue/SDK-2251)

## Changes:

1. Adds RecoveryCodesSaveScreen, RecoveryCodesEntryScreen, SMSOTPEnrollmentScreen, SMSOTPEntryScreen
2. Parses the phone number from the API into our PhoneNumberState format when encountering an already enrolled MFA flow
3. Adds some helpers for extracting/formatting phone numbers

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A