### PR TITLE
Attempt to address reported NPE on startup

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.30.0'
+  PUBLISH_VERSION = '0.30.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -127,7 +127,7 @@ public object StytchB2BClient {
             deviceInfo = context.getDeviceInfo()
             appSessionId = "app-session-id-${UUID.randomUUID()}"
             StorageHelper.initialize(context)
-            sessionStorage = B2BSessionStorage(StorageHelper, externalScope)
+            sessionStorage = B2BSessionStorage(StorageHelper)
             StytchB2BApi.configure(publicToken, deviceInfo)
             val activityProvider = ActivityProvider(context.applicationContext as Application)
             dfpProvider =

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -123,7 +123,7 @@ public object StytchClient {
             deviceInfo = context.getDeviceInfo()
             appSessionId = "app-session-id-${UUID.randomUUID()}"
             StorageHelper.initialize(context)
-            sessionStorage = ConsumerSessionStorage(StorageHelper, externalScope)
+            sessionStorage = ConsumerSessionStorage(StorageHelper)
             StytchApi.configure(publicToken, deviceInfo)
             val activityProvider = ActivityProvider(context.applicationContext as Application)
             dfpProvider =

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/member/MemberImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/member/MemberImplTest.kt
@@ -67,7 +67,7 @@ internal class MemberImplTest {
         every { mockSharedPreferencesEditor.apply() } just runs
         every { mockSharedPreferences.getLong(any(), any()) } returns 0
         StorageHelper.sharedPreferences = mockSharedPreferences
-        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper, TestScope()), recordPrivateCalls = true)
+        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper), recordPrivateCalls = true)
         impl =
             MemberImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/organization/OrganizationImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/organization/OrganizationImplTest.kt
@@ -79,7 +79,7 @@ internal class OrganizationImplTest {
         every { mockSharedPreferences.getLong(any(), any()) } returns 0
         every { mockSharedPreferencesEditor.apply() } just runs
         StorageHelper.sharedPreferences = mockSharedPreferences
-        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper, TestScope()), recordPrivateCalls = true)
+        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper), recordPrivateCalls = true)
         impl =
             OrganizationImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/otp/OTPImplTest.kt
@@ -92,7 +92,7 @@ internal class OTPImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
-        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper, TestScope()), recordPrivateCalls = true)
+        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper), recordPrivateCalls = true)
         impl =
             OTPImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodesImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodesImplTest.kt
@@ -71,7 +71,7 @@ internal class RecoveryCodesImplTest {
         every { mockSharedPreferences.getLong(any(), any()) } returns 0L
         every { mockSharedPreferencesEditor.apply() } just runs
         StorageHelper.sharedPreferences = mockSharedPreferences
-        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper, TestScope()), recordPrivateCalls = true)
+        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper), recordPrivateCalls = true)
         impl =
             RecoveryCodesImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionStorageTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionStorageTest.kt
@@ -16,7 +16,6 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -37,7 +36,7 @@ internal class B2BSessionStorageTest {
         every { mockStorageHelper.saveValue(any(), any()) } just runs
         every { mockStorageHelper.saveLong(any(), any()) } just runs
         every { mockStorageHelper.getLong(any()) } returns 0
-        storage = B2BSessionStorage(mockStorageHelper, TestScope())
+        storage = B2BSessionStorage(mockStorageHelper)
     }
 
     @After

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/totp/TOTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/totp/TOTPImplTest.kt
@@ -68,7 +68,7 @@ internal class TOTPImplTest {
         every { mockSharedPreferences.getLong(any(), any()) } returns 0L
         every { mockSharedPreferencesEditor.apply() } just runs
         StorageHelper.sharedPreferences = mockSharedPreferences
-        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper, TestScope()), recordPrivateCalls = true)
+        spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper), recordPrivateCalls = true)
         impl =
             TOTPImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorageTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorageTest.kt
@@ -18,7 +18,6 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Test
 import java.security.KeyStore
@@ -47,7 +46,7 @@ internal class ConsumerSessionStorageTest {
         StorageHelper.sharedPreferences = mockSharedPreferences
         every { StorageHelper.loadValue(any()) } returns null
         every { StorageHelper.saveValue(any(), any()) } just runs
-        impl = ConsumerSessionStorage(StorageHelper, TestScope())
+        impl = ConsumerSessionStorage(StorageHelper)
     }
 
     @Test(expected = StytchNoCurrentSessionError::class)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/SessionStorageTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/SessionStorageTest.kt
@@ -16,7 +16,6 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -37,7 +36,7 @@ internal class SessionStorageTest {
         every { mockStorageHelper.saveValue(any(), any()) } just runs
         every { mockStorageHelper.saveLong(any(), any()) } just runs
         every { mockStorageHelper.getLong(any()) } returns 0
-        storage = ConsumerSessionStorage(mockStorageHelper, TestScope())
+        storage = ConsumerSessionStorage(mockStorageHelper)
     }
 
     @After


### PR DESCRIPTION
Linear Ticket: [SDK-2311](https://linear.app/stytch/issue/SDK-2311)

## Changes:

1. Moves the declaration of the flows to the top of the file, on the off-chance that _somehow_ a value is being set (and trying to emit) before the flow has been created? Since [Kotlin classes are created top-to-bottom](https://discuss.kotlinlang.org/t/property-declaration-order-in-file-shouldnt-matter/3872), the "source" properties _were_ being created before the flows. I'm unsure how the source property _setters_ would be called before the flows were created, though.
2. Initializes the flows with a `null` value and then emits the desired value in the new-at-the-bottom `init` method? This goes along with the above. If I move the property initializers above the "source" properties, I don't want the source property initialization to happen before the flows are created.
3. Replace the `emit` calls with `tryEmit`, which removes the need for launching in a coroutine. Both methods are thread-safe, but maybe that gets out-of-whack when the emissions were launched in the application-level scope (ie: trying to call a method from Thread 2 on a property created on Thread 1)? We don't need the suspending fallback of `emit` because we're the only ones observing these flows AND we're guaranteed to not be listening to them until AFTER the session storages have been initialized due to the lazy delegation in the clients.

## Notes:

- I have been unable to reproduce the reported crash, so this is kind of a blind guess as to what could be going on
- Consider this a WIP for now. I'm waiting to hear back from the customer on if there are reliable repro steps, and will do some more thinking on these changes, but wanted to get something up in the interim.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A