### PR TITLE
B2B UI Polish and Smoketesting

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -536,13 +536,11 @@ public data class DiscoveryAuthenticateResponseData(
 public data class SSOAuthenticateResponseData(
     @Json(name = "organization_id")
     val organizationId: String,
-    @Json(name = "method_id")
-    val methodId: String,
     @Json(name = "session_jwt")
     override val sessionJwt: String,
     @Json(name = "session_token")
     override val sessionToken: String,
-    @Json(name = "session")
+    @Json(name = "member_session")
     override val memberSession: B2BSessionData?,
     @Json(name = "reset_session")
     val resetSession: Boolean,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -824,7 +824,7 @@ public data class OAuthProviderValues(
     @Json(name = "access_token")
     val accessToken: String,
     @Json(name = "id_token")
-    val idToken: String,
+    val idToken: String? = null,
     @Json(name = "refresh_token")
     val refreshToken: String? = null,
     val scopes: List<String> = emptyList(),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationViewModel.kt
@@ -10,10 +10,12 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.searchManager.SearchManager
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.ui.b2b.data.AuthFlowType
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetActiveOrganization
+import com.stytch.sdk.ui.b2b.data.SetAuthFlowType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetIsSearchingForOrganizationBySlug
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
@@ -45,6 +47,10 @@ internal class B2BAuthenticationViewModel(
                 savedStateHandle[B2BUIState.SAVED_STATE_KEY] = newState
             }
         }
+        dispatch(SetAuthFlowType(productConfig.authFlowType))
+        if (productConfig.authFlowType == AuthFlowType.DISCOVERY && stateFlow.value.currentRoute == null) {
+            dispatch(SetNextRoute(Routes.Main))
+        }
     }
 
     internal fun performInitialOrgBySlugSearch(slug: String) {
@@ -64,7 +70,10 @@ internal class B2BAuthenticationViewModel(
                     dispatch(SetIsSearchingForOrganizationBySlug(false))
                     dispatch(SetNextRoute(Routes.Main))
                 }
-                is StytchResult.Error -> dispatch(SetStytchError(response.exception))
+                is StytchResult.Error -> {
+                    dispatch(SetIsSearchingForOrganizationBySlug(false))
+                    dispatch(SetStytchError(response.exception))
+                }
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -29,6 +29,7 @@ import com.stytch.sdk.ui.b2b.data.AuthFlowType
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetStytchError
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.screens.DeepLinkParserScreen
 import com.stytch.sdk.ui.b2b.screens.DiscoveryScreen
@@ -198,7 +199,9 @@ internal fun StytchB2BAuthenticationApp(
                 }
             }
             state.value.stytchError?.let {
-                FormFieldStatus(text = it.message, isError = true)
+                FormFieldStatus(text = it.message, isError = true, autoDismiss = {
+                    dispatch(SetStytchError(null))
+                })
             }
             if (!bootstrapData.disableSDKWatermark) {
                 Row(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -141,7 +141,7 @@ internal fun StytchB2BAuthenticationApp(
                     )
                 }
                 composable<Routes.Error> {
-                    ErrorScreen(state = state)
+                    ErrorScreen(state = state, createViewModel = ::createViewModelHelper)
                 }
                 composable<Routes.Main> {
                     MainScreen(state = state, createViewModel = ::createViewModelHelper)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -72,9 +72,8 @@ internal fun StytchB2BAuthenticationApp(
     val currentRoute = state.value.currentRoute
     val authFlowType = state.value.authFlowType
     val deeplinkTokenPair = state.value.deeplinkTokenPair
-    val didParseDeepLink = state.value.didParseDeepLink
     val startDestination =
-        if (deeplinkTokenPair != null && !didParseDeepLink) {
+        if (deeplinkTokenPair != null) {
             Routes.DeeplinkParser
         } else {
             currentRoute ?: Routes.Loading
@@ -83,12 +82,9 @@ internal fun StytchB2BAuthenticationApp(
     LaunchedEffect(currentRoute) {
         currentRoute?.let {
             navController.navigate(it) {
-                // If the user has already completed one form of primary auth, disable going back to a previous page
-                if (state.value.mfaPrimaryInfoState != null) {
-                    popUpTo(navController.graph.findStartDestination().id) {
-                        saveState = false
-                        inclusive = true
-                    }
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = false
+                    inclusive = true
                 }
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -74,7 +75,15 @@ internal fun StytchB2BAuthenticationApp(
 
     LaunchedEffect(currentRoute) {
         currentRoute?.let {
-            navController.navigate(it)
+            navController.navigate(it) {
+                // If the user has already completed one form of primary auth, disable going back to a previous page
+                if (state.value.mfaPrimaryInfoState != null) {
+                    popUpTo(navController.graph.findStartDestination().id) {
+                        saveState = false
+                        inclusive = true
+                    }
+                }
+            }
         }
     }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -48,6 +48,7 @@ import com.stytch.sdk.ui.b2b.screens.SMSOTPEntryScreen
 import com.stytch.sdk.ui.b2b.screens.SuccessScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEnrollmentScreen
 import com.stytch.sdk.ui.b2b.screens.TOTPEntryScreen
+import com.stytch.sdk.ui.shared.components.FormFieldStatus
 import com.stytch.sdk.ui.shared.components.LoadingDialog
 import com.stytch.sdk.ui.shared.theme.LocalStytchBootstrapData
 import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
@@ -188,6 +189,9 @@ internal fun StytchB2BAuthenticationApp(
                 composable<Routes.TOTPEntry> {
                     TOTPEntryScreen(createViewModel = ::createViewModelHelper)
                 }
+            }
+            state.value.stytchError?.let {
+                FormFieldStatus(text = it.message, isError = true)
             }
             if (!bootstrapData.disableSDKWatermark) {
                 Row(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIAction.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIAction.kt
@@ -72,6 +72,10 @@ internal data class SetDeeplinkTokenPair(
     val deeplinkTokenPair: DeeplinkTokenPair?,
 ) : B2BUIAction
 
+internal data class SetDidParseDeepLink(
+    val didParseDeeplink: Boolean,
+) : B2BUIAction
+
 internal data class SetNextRoute(
     val route: Route?,
 ) : B2BUIAction

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIAction.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIAction.kt
@@ -72,10 +72,6 @@ internal data class SetDeeplinkTokenPair(
     val deeplinkTokenPair: DeeplinkTokenPair?,
 ) : B2BUIAction
 
-internal data class SetDidParseDeepLink(
-    val didParseDeeplink: Boolean,
-) : B2BUIAction
-
 internal data class SetNextRoute(
     val route: Route?,
 ) : B2BUIAction

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIState.kt
@@ -31,7 +31,6 @@ internal data class B2BUIState(
     val mfaTOTPState: MFATOTPState? = null,
     val postAuthScreen: Route = Routes.Success,
     val deeplinkTokenPair: DeeplinkTokenPair? = null,
-    val didParseDeepLink: Boolean = false,
     val b2BErrorType: B2BErrorType? = null,
     val uiIncludedMfaMethods: List<MfaMethod> = emptyList(),
     val primaryAuthMethods: List<AllowedAuthMethods> = emptyList(),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIState.kt
@@ -31,6 +31,7 @@ internal data class B2BUIState(
     val mfaTOTPState: MFATOTPState? = null,
     val postAuthScreen: Route = Routes.Success,
     val deeplinkTokenPair: DeeplinkTokenPair? = null,
+    val didParseDeepLink: Boolean = false,
     val b2BErrorType: B2BErrorType? = null,
     val uiIncludedMfaMethods: List<MfaMethod> = emptyList(),
     val primaryAuthMethods: List<AllowedAuthMethods> = emptyList(),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/MFASMSState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/MFASMSState.kt
@@ -6,7 +6,7 @@ import java.util.Date
 
 @Parcelize
 internal data class MFASMSState(
-    val isSending: Boolean = false,
+    val isEnrolling: Boolean = false,
     val codeExpiration: Date? = null,
     val formattedDestination: String? = null,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
@@ -27,7 +27,7 @@ public data class StytchB2BProductConfig
         val passwordOptions: B2BPasswordOptions = B2BPasswordOptions(),
         val oauthOptions: B2BOAuthOptions = B2BOAuthOptions(),
         val directLoginForSingleMembership: DirectLoginForSingleMembershipOptions? = null,
-        val disableCreateOrganization: Boolean = false,
+        val allowCreateOrganization: Boolean = true,
         val mfaProductOrder: List<MfaMethod> = emptyList(),
         val mfaProductInclude: List<MfaMethod> =
             listOf(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
@@ -113,7 +113,12 @@ internal class B2BUIStateMachine(
                 }
                 on<SetNextRoute> { action, state ->
                     state.mutate {
-                        copy(currentRoute = action.route)
+                        copy(
+                            currentRoute = action.route,
+                            isLoading = false,
+                            stytchError = null,
+                            b2BErrorType = null,
+                        )
                     }
                 }
                 on<HandleStepUpAuthentication> { action, state ->

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
@@ -9,7 +9,6 @@ import com.stytch.sdk.ui.b2b.data.SetActiveOrganization
 import com.stytch.sdk.ui.b2b.data.SetAuthFlowType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
-import com.stytch.sdk.ui.b2b.data.SetDidParseDeepLink
 import com.stytch.sdk.ui.b2b.data.SetDiscoveredOrganizations
 import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.data.SetIsSearchingForOrganizationBySlug
@@ -109,11 +108,6 @@ internal class B2BUIStateMachine(
                 on<SetDeeplinkTokenPair> { action, state ->
                     state.mutate {
                         copy(deeplinkTokenPair = action.deeplinkTokenPair)
-                    }
-                }
-                on<SetDidParseDeepLink> { action, state ->
-                    state.mutate {
-                        copy(didParseDeepLink = action.didParseDeeplink)
                     }
                 }
                 on<SetNextRoute> { action, state ->

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.ui.b2b.data.SetActiveOrganization
 import com.stytch.sdk.ui.b2b.data.SetAuthFlowType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
+import com.stytch.sdk.ui.b2b.data.SetDidParseDeepLink
 import com.stytch.sdk.ui.b2b.data.SetDiscoveredOrganizations
 import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.data.SetIsSearchingForOrganizationBySlug
@@ -108,6 +109,11 @@ internal class B2BUIStateMachine(
                 on<SetDeeplinkTokenPair> { action, state ->
                     state.mutate {
                         copy(deeplinkTokenPair = action.deeplinkTokenPair)
+                    }
+                }
+                on<SetDidParseDeepLink> { action, state ->
+                    state.mutate {
+                        copy(didParseDeepLink = action.didParseDeeplink)
                     }
                 }
                 on<SetNextRoute> { action, state ->

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.b2b.domain
 
 import com.freeletics.flowredux.dsl.FlowReduxStateMachine
+import com.stytch.sdk.ui.b2b.data.AuthFlowType
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.HandleStepUpAuthentication
@@ -128,8 +129,11 @@ internal class B2BUIStateMachine(
                 on<ResetEverything> { _, state ->
                     // These are configured post-launch, so we can't just do _all_ defaults
                     val uiIncludedMfaMethods = state.snapshot.uiIncludedMfaMethods
+                    val authFlowType = state.snapshot.authFlowType
                     state.mutate {
                         B2BUIState().copy(
+                            authFlowType = authFlowType,
+                            currentRoute = if (authFlowType == AuthFlowType.DISCOVERY) Routes.Main else null,
                             uiIncludedMfaMethods = uiIncludedMfaMethods,
                         )
                     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/navigation/Route.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/navigation/Route.kt
@@ -11,6 +11,10 @@ internal sealed interface Route : Parcelable
 internal object Routes {
     @Serializable
     @Parcelize
+    internal data object Loading : Route, Parcelable
+
+    @Serializable
+    @Parcelize
     internal data object DeeplinkParser : Route, Parcelable
 
     @Serializable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
@@ -27,7 +27,7 @@ internal class DeepLinkParserScreenViewModel(
     dispatchAction: suspend (B2BUIAction) -> Unit,
     productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
-    private val useMagicLinksAuthenticate = UseMagicLinksAuthenticate(viewModelScope, ::request)
+    private val useMagicLinksAuthenticate = UseMagicLinksAuthenticate(viewModelScope, ::dispatch, ::request)
     private val useMagicLinksDiscoveryAuthenticate =
         UseMagicLinksDiscoveryAuthenticate(viewModelScope, state, ::dispatch, ::request)
     private val useOAuthDiscoveryAuthenticate =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
@@ -8,9 +8,11 @@ import com.stytch.sdk.b2b.B2BTokenType
 import com.stytch.sdk.common.DeeplinkTokenPair
 import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
-import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
+import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDidParseDeepLink
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.navigation.Routes
@@ -44,9 +46,9 @@ internal class DeepLinkParserScreenViewModel(
             B2BTokenType.DISCOVERY_OAUTH -> useOAuthDiscoveryAuthenticate(pair.token)
             B2BTokenType.OAUTH -> useOAuthAuthenticate(pair.token)
             B2BTokenType.SSO -> useSSOAuthenticate(pair.token)
-            B2BTokenType.UNKNOWN -> {}
+            B2BTokenType.UNKNOWN -> dispatch(SetB2BError(B2BErrorType.Default))
         }
-        dispatch(SetDeeplinkTokenPair(null))
+        dispatch(SetDidParseDeepLink(true))
     }
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
@@ -12,7 +12,6 @@ import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetB2BError
-import com.stytch.sdk.ui.b2b.data.SetDidParseDeepLink
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.navigation.Routes
@@ -34,8 +33,8 @@ internal class DeepLinkParserScreenViewModel(
         UseMagicLinksDiscoveryAuthenticate(viewModelScope, state, ::dispatch, ::request)
     private val useOAuthDiscoveryAuthenticate =
         UseOAuthDiscoveryAuthenticate(viewModelScope, state, ::dispatch, ::request)
-    private val useOAuthAuthenticate = UseOAuthAuthenticate(viewModelScope, ::request)
-    private val useSSOAuthenticate = UseSSOAuthenticate(viewModelScope, productConfig, ::request)
+    private val useOAuthAuthenticate = UseOAuthAuthenticate(viewModelScope, ::dispatch, ::request)
+    private val useSSOAuthenticate = UseSSOAuthenticate(viewModelScope, ::dispatch, productConfig, ::request)
 
     internal fun handleDeepLink(pair: DeeplinkTokenPair) {
         if (pair.token.isNullOrEmpty()) return
@@ -48,7 +47,6 @@ internal class DeepLinkParserScreenViewModel(
             B2BTokenType.SSO -> useSSOAuthenticate(pair.token)
             B2BTokenType.UNKNOWN -> dispatch(SetB2BError(B2BErrorType.Default))
         }
-        dispatch(SetDidParseDeepLink(true))
     }
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -167,7 +168,7 @@ internal fun DiscoveryScreen(
                 onGoBack = { viewModel.dispatch(ResetEverything) },
             )
         }
-        PageTitle(text = "Select an organization to continue")
+        PageTitle(textAlign = TextAlign.Left, text = "Select an organization to continue")
         Column(modifier = Modifier.fillMaxWidth()) {
             state.value.discoveredOrganizations?.map { discoveredOrganization ->
                 Row(
@@ -227,7 +228,7 @@ internal fun DiscoveryScreen(
 
 @Composable
 private fun LoggingInView(color: Color) {
-    PageTitle(text = "Logging In...")
+    PageTitle(textAlign = TextAlign.Left, text = "Logging In...")
     CircularProgressIndicator(color = color)
 }
 
@@ -258,7 +259,7 @@ private fun NoOrganizationsDiscovered(
     }
 
     if (createOrganzationsEnabled && !config.disableCreateOrganization) {
-        PageTitle(text = "Create an organization to get started")
+        PageTitle(textAlign = TextAlign.Left, text = "Create an organization to get started")
         StytchButton(enabled = true, text = "Create an organization", onClick = ::handleDiscoveryOrganizationCreate)
         Spacer(modifier = Modifier.height(16.dp))
         BodyText(
@@ -269,7 +270,10 @@ private fun NoOrganizationsDiscovered(
         return
     }
 
-    PageTitle(text = "${state.value.emailState.emailAddress} does not belong to any organizations.")
+    PageTitle(
+        textAlign = TextAlign.Left,
+        text = "${state.value.emailState.emailAddress} does not belong to any organizations.",
+    )
     BodyText(text = "Make sure your email address is correct. Otherwise, you might need to be invited by your admin.")
     StytchButton(enabled = true, onClick = onGoBack, text = "Try a different email address")
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -41,12 +41,11 @@ import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.ResetEverything
 import com.stytch.sdk.ui.b2b.data.SetActiveOrganization
-import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.extensions.jitEligible
 import com.stytch.sdk.ui.b2b.extensions.shouldAllowDirectLoginToOrganization
 import com.stytch.sdk.ui.b2b.extensions.toInternalOrganizationData
-import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseDiscoveryIntermediateSessionExchange
 import com.stytch.sdk.ui.b2b.usecases.UseDiscoveryOrganizationCreate
 import com.stytch.sdk.ui.b2b.usecases.UseSSOStart
@@ -150,24 +149,24 @@ internal fun DiscoveryScreen(
         }
     }
 
-    if (isExchangingState.value) {
-        return LoggingInView(color = Color(theme.inputTextColor))
-    }
-
-    if (isCreatingState.value) {
-        return LoadingView(color = Color(theme.inputTextColor))
-    }
-
-    if (state.value.discoveredOrganizations.isNullOrEmpty()) {
-        return NoOrganizationsDiscovered(
-            state = state,
-            createOrganzationsEnabled = createOrganzationsEnabled,
-            onCreateOrganization = viewModel::createOrganization,
-            isCreatingOrganization = isCreatingState.value,
-            onGoBack = { viewModel.dispatch(SetNextRoute(Routes.Main)) },
-        )
-    }
     Column {
+        if (isExchangingState.value) {
+            return LoggingInView(color = Color(theme.inputTextColor))
+        }
+
+        if (isCreatingState.value) {
+            return LoadingView(color = Color(theme.inputTextColor))
+        }
+
+        if (state.value.discoveredOrganizations.isNullOrEmpty()) {
+            return NoOrganizationsDiscovered(
+                state = state,
+                createOrganzationsEnabled = createOrganzationsEnabled,
+                onCreateOrganization = viewModel::createOrganization,
+                isCreatingOrganization = isCreatingState.value,
+                onGoBack = { viewModel.dispatch(ResetEverything) },
+            )
+        }
         PageTitle(text = "Select an organization to continue")
         Column(modifier = Modifier.fillMaxWidth()) {
             state.value.discoveredOrganizations?.map { discoveredOrganization ->
@@ -261,9 +260,10 @@ private fun NoOrganizationsDiscovered(
     if (createOrganzationsEnabled && !config.disableCreateOrganization) {
         PageTitle(text = "Create an organization to get started")
         StytchButton(enabled = true, text = "Create an organization", onClick = ::handleDiscoveryOrganizationCreate)
+        Spacer(modifier = Modifier.height(16.dp))
         BodyText(
             text =
-                "${state.value.emailState.emailAddress} does not have an account. Think this is a mistake?" +
+                "${state.value.emailState.emailAddress} does not have an account. Think this is a mistake? " +
                     "Try a different email address, or contact your admin.",
         )
         return

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -50,6 +50,7 @@ import com.stytch.sdk.ui.b2b.extensions.toInternalOrganizationData
 import com.stytch.sdk.ui.b2b.usecases.UseDiscoveryIntermediateSessionExchange
 import com.stytch.sdk.ui.b2b.usecases.UseDiscoveryOrganizationCreate
 import com.stytch.sdk.ui.b2b.usecases.UseSSOStart
+import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.StytchButton
@@ -168,6 +169,7 @@ internal fun DiscoveryScreen(
                 onGoBack = { viewModel.dispatch(ResetEverything) },
             )
         }
+        BackButton(onClick = { viewModel.dispatch(ResetEverything) })
         PageTitle(textAlign = TextAlign.Left, text = "Select an organization to continue")
         Column(modifier = Modifier.fillMaxWidth()) {
             state.value.discoveredOrganizations?.map { discoveredOrganization ->

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -258,7 +258,7 @@ private fun NoOrganizationsDiscovered(
         return
     }
 
-    if (createOrganzationsEnabled && !config.disableCreateOrganization) {
+    if (createOrganzationsEnabled && config.allowCreateOrganization) {
         PageTitle(textAlign = TextAlign.Left, text = "Create an organization to get started")
         StytchButton(enabled = true, text = "Create an organization", onClick = ::handleDiscoveryOrganizationCreate)
         Spacer(modifier = Modifier.height(16.dp))

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -267,6 +267,7 @@ private fun NoOrganizationsDiscovered(
                 "${state.value.emailState.emailAddress} does not have an account. Think this is a mistake? " +
                     "Try a different email address, or contact your admin.",
         )
+        StytchButton(enabled = true, onClick = onGoBack, text = "Try a different email address")
         return
     }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/EmailConfirmationScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/EmailConfirmationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
@@ -119,7 +120,7 @@ private fun EmailVerification(
     onBottomTextClicked: () -> Unit,
 ) {
     Column {
-        PageTitle(text = title)
+        PageTitle(textAlign = TextAlign.Left, text = title)
         BodyText(text = message)
         StytchTextButton(text = bottomText.text, onClick = onBottomTextClicked)
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/EmailConfirmationScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/EmailConfirmationScreen.kt
@@ -28,7 +28,8 @@ internal class EmailConfirmationScreenViewModel(
     dispatchAction: suspend (B2BUIAction) -> Unit,
     productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
-    val usePasswordResetByEmailStart = UsePasswordResetByEmailStart(viewModelScope, state, productConfig, ::request)
+    val usePasswordResetByEmailStart =
+        UsePasswordResetByEmailStart(viewModelScope, state, ::dispatch, productConfig, ::request)
 
     fun resetEverything() = dispatch(ResetEverything)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/ErrorScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/ErrorScreen.kt
@@ -38,21 +38,23 @@ internal fun ErrorScreen(
 ) {
     val b2bError = state.value.b2BErrorType ?: return
     val orgName = state.value.activeOrganization?.organizationName ?: "the organization"
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
+    Column {
         // Only show a back button if it's _not_ organization not found, as all others are potentially user-recoverable
         if (b2bError != B2BErrorType.Organization) {
             BackButton { viewModel.dispatch(ResetEverything) }
         }
-        PageTitle(text = "Looks like there was an error!")
-        Image(
-            painter = painterResource(id = R.drawable.big_error_circle),
-            contentDescription = "Error",
-        )
-        Spacer(modifier = Modifier.height(32.dp))
-        BodyText(text = b2bError.description.format(orgName), textAlign = TextAlign.Center)
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PageTitle(text = "Looks like there was an error!")
+            Image(
+                painter = painterResource(id = R.drawable.big_error_circle),
+                contentDescription = "Error",
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            BodyText(text = b2bError.description.format(orgName), textAlign = TextAlign.Center)
+        }
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/ErrorScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/ErrorScreen.kt
@@ -14,12 +14,28 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.stytch.sdk.R
+import com.stytch.sdk.ui.b2b.BaseViewModel
+import com.stytch.sdk.ui.b2b.CreateViewModel
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
+import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.ResetEverything
+import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.PageTitle
+import kotlinx.coroutines.flow.StateFlow
+
+internal class ErrorScreenViewModel(
+    internal val state: StateFlow<B2BUIState>,
+    dispatchAction: suspend (B2BUIAction) -> Unit,
+) : BaseViewModel(state, dispatchAction)
 
 @Composable
-internal fun ErrorScreen(state: State<B2BUIState>) {
+internal fun ErrorScreen(
+    state: State<B2BUIState>,
+    createViewModel: CreateViewModel<ErrorScreenViewModel>,
+    viewModel: ErrorScreenViewModel = createViewModel(ErrorScreenViewModel::class.java),
+) {
     val b2bError = state.value.b2BErrorType ?: return
     val orgName = state.value.activeOrganization?.organizationName ?: "the organization"
     Column(
@@ -27,6 +43,10 @@ internal fun ErrorScreen(state: State<B2BUIState>) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        // Only show a back button if it's _not_ organization not found, as all others are potentially user-recoverable
+        if (b2bError != B2BErrorType.Organization) {
+            BackButton { viewModel.dispatch(ResetEverything) }
+        }
         PageTitle(text = "Looks like there was an error!")
         Image(
             painter = painterResource(id = R.drawable.big_error_circle),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MFAEnrollmentSelection.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MFAEnrollmentSelection.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stytch.sdk.b2b.network.models.MfaMethod
@@ -95,7 +96,7 @@ internal fun MFAEnrollmentSelectionScreen(
     val sortedOptions = viewModel.sortedMfaMethods.collectAsStateWithLifecycle()
     val theme = LocalStytchTheme.current
     Column {
-        PageTitle(text = "Set up Multi-Factor Authentication")
+        PageTitle(textAlign = TextAlign.Left, text = "Set up Multi-Factor Authentication")
         BodyText(
             text = "Your organization requires an additional form of verification to make your account more secure.",
         )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
@@ -98,6 +99,14 @@ internal class MainScreenViewModel(
             }
         }
     }
+
+    fun passwordEMLCombinedSubmit() {
+        if (state.value.activeOrganization != null || state.value.mfaPrimaryInfoState != null) {
+            useMagicLinksEmailLoginOrSignup()
+        } else {
+            useMagicLinksDiscoverySend()
+        }
+    }
 }
 
 @Composable
@@ -153,6 +162,7 @@ internal fun MainScreen(
                         emailState = state.value.emailState,
                         onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
                         onEmailAddressSubmit = { viewModel.useMagicLinksEmailLoginOrSignup() },
+                        keyboardActions = KeyboardActions(onDone = { viewModel.useMagicLinksEmailLoginOrSignup() }),
                     )
                 }
                 ProductComponent.MagicLinkEmailDiscoveryForm -> {
@@ -160,6 +170,7 @@ internal fun MainScreen(
                         emailState = state.value.emailState,
                         onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
                         onEmailAddressSubmit = { viewModel.useMagicLinksDiscoverySend() },
+                        keyboardActions = KeyboardActions(onDone = { viewModel.useMagicLinksDiscoverySend() }),
                     )
                 }
                 ProductComponent.OAuthButtons -> {
@@ -219,13 +230,8 @@ internal fun MainScreen(
                     EmailEntry(
                         emailState = state.value.emailState,
                         onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
-                        onEmailAddressSubmit = {
-                            if (state.value.activeOrganization != null || state.value.mfaPrimaryInfoState != null) {
-                                viewModel.useMagicLinksEmailLoginOrSignup()
-                            } else {
-                                viewModel.useMagicLinksDiscoverySend()
-                            }
-                        },
+                        onEmailAddressSubmit = { viewModel.passwordEMLCombinedSubmit() },
+                        keyboardActions = KeyboardActions(onDone = { viewModel.passwordEMLCombinedSubmit() }),
                     )
                     StytchTextButton(text = "Use a password instead") {
                         viewModel.dispatch(SetNextRoute(Routes.PasswordAuthenticate))

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
@@ -48,6 +48,7 @@ import com.stytch.sdk.ui.b2b.usecases.UsePasswordAuthenticate
 import com.stytch.sdk.ui.b2b.usecases.UseSSOStart
 import com.stytch.sdk.ui.b2b.usecases.UseSearchMember
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberEmailAddress
+import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberEmailShouldBeValidated
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberPassword
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.DividerWithText
@@ -77,6 +78,7 @@ internal class MainScreenViewModel(
     val usePasswordsAuthenticate = UsePasswordAuthenticate(viewModelScope, state, ::dispatch, productConfig, ::request)
     val useNonMemberPasswordReset =
         UseNonMemberPasswordReset(viewModelScope, state, ::dispatch, productConfig, ::request)
+    val useUpdateMemberEmailShouldBeValidated = UseUpdateMemberEmailShouldBeValidated(state, ::dispatch)
 
     fun handleEmailPasswordSubmit() {
         val emailAddress = state.value.emailState.emailAddress
@@ -162,7 +164,11 @@ internal fun MainScreen(
                         emailState = state.value.emailState,
                         onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
                         onEmailAddressSubmit = { viewModel.useMagicLinksEmailLoginOrSignup() },
-                        keyboardActions = KeyboardActions(onDone = { viewModel.useMagicLinksEmailLoginOrSignup() }),
+                        keyboardActions =
+                            KeyboardActions(onDone = {
+                                viewModel.useUpdateMemberEmailShouldBeValidated(true)
+                                viewModel.useMagicLinksEmailLoginOrSignup()
+                            }),
                     )
                 }
                 ProductComponent.MagicLinkEmailDiscoveryForm -> {
@@ -170,7 +176,11 @@ internal fun MainScreen(
                         emailState = state.value.emailState,
                         onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
                         onEmailAddressSubmit = { viewModel.useMagicLinksDiscoverySend() },
-                        keyboardActions = KeyboardActions(onDone = { viewModel.useMagicLinksDiscoverySend() }),
+                        keyboardActions =
+                            KeyboardActions(onDone = {
+                                viewModel.useUpdateMemberEmailShouldBeValidated(true)
+                                viewModel.useMagicLinksDiscoverySend()
+                            }),
                     )
                 }
                 ProductComponent.OAuthButtons -> {
@@ -203,6 +213,7 @@ internal fun MainScreen(
                         passwordState = state.value.passwordState,
                         onPasswordChanged = { viewModel.useUpdateMemberPassword(it) },
                         onSubmit = viewModel::handleEmailPasswordSubmit,
+                        onEmailAddressDone = { viewModel.useUpdateMemberEmailShouldBeValidated(true) },
                     )
                     val signInText =
                         buildAnnotatedString {
@@ -231,7 +242,11 @@ internal fun MainScreen(
                         emailState = state.value.emailState,
                         onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
                         onEmailAddressSubmit = { viewModel.passwordEMLCombinedSubmit() },
-                        keyboardActions = KeyboardActions(onDone = { viewModel.passwordEMLCombinedSubmit() }),
+                        keyboardActions =
+                            KeyboardActions(onDone = {
+                                viewModel.useUpdateMemberEmailShouldBeValidated(true)
+                                viewModel.passwordEMLCombinedSubmit()
+                            }),
                     )
                     StytchTextButton(text = "Use a password instead") {
                         viewModel.dispatch(SetNextRoute(Routes.PasswordAuthenticate))

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordAuthenticateScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordAuthenticateScreen.kt
@@ -25,7 +25,7 @@ import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UsePasswordAuthenticate
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberEmailAddress
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberPassword
-import com.stytch.sdk.ui.shared.components.BodyText
+import com.stytch.sdk.ui.shared.components.Body2Text
 import com.stytch.sdk.ui.shared.components.EmailAndPasswordEntry
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
@@ -59,7 +59,7 @@ internal fun PasswordAuthenticateScreen(
             onSubmit = { viewModel.usePasswordAuthenticate() },
         )
         Spacer(modifier = Modifier.height(16.dp))
-        BodyText(
+        Body2Text(
             text =
                 buildAnnotatedString {
                     append("Having trouble signing in? ")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordAuthenticateScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordAuthenticateScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
@@ -48,7 +49,7 @@ internal fun PasswordAuthenticateScreen(
 ) {
     val theme = LocalStytchTheme.current
     Column {
-        PageTitle(text = "Log in with email and password")
+        PageTitle(textAlign = TextAlign.Left, text = "Log in with email and password")
         EmailAndPasswordEntry(
             emailState = state.value.emailState,
             onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
@@ -78,6 +79,7 @@ internal fun PasswordForgotScreen(
             modifier = Modifier.fillMaxWidth(),
             emailState = state.value.emailState,
             onEmailAddressChanged = { viewModel.useUpdateMemberEmailAddress(it) },
+            keyboardActions = KeyboardActions(onDone = { viewModel.onSubmit() }),
         )
         Spacer(modifier = Modifier.height(16.dp))
         StytchButton(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
@@ -66,7 +67,7 @@ internal fun PasswordForgotScreen(
     viewModel: PasswordForgotScreenViewModel = createViewModel(PasswordForgotScreenViewModel::class.java),
 ) {
     Column {
-        PageTitle(text = "Check your email for help signing in!")
+        PageTitle(textAlign = TextAlign.Left, text = "Check your email for help signing in!")
         BodyText(
             text =
                 "We'll email you a login link to sign in to your account directly or reset your password " +

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
@@ -33,7 +33,8 @@ internal class PasswordForgotScreenViewModel(
     productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
     val useSearchMember = UseSearchMember(::request)
-    val usePasswordResetByEmailStart = UsePasswordResetByEmailStart(viewModelScope, state, productConfig, ::request)
+    val usePasswordResetByEmailStart =
+        UsePasswordResetByEmailStart(viewModelScope, state, ::dispatch, productConfig, ::request)
     val useNonMemberPasswordReset =
         UseNonMemberPasswordReset(viewModelScope, state, ::dispatch, productConfig, ::request)
     val useUpdateMemberEmailAddress = UseUpdateMemberEmailAddress(state, ::dispatch)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordResetScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordResetScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.R
@@ -37,7 +38,7 @@ internal fun PasswordResetScreen(
     viewModel: PasswordResetScreenViewModel = createViewModel(PasswordResetScreenViewModel::class.java),
 ) {
     Column {
-        PageTitle(text = "Set a new password")
+        PageTitle(textAlign = TextAlign.Left, text = "Set a new password")
         PasswordInput(
             label = "Password",
             passwordState = state.value.passwordState,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordResetScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordResetScreen.kt
@@ -26,7 +26,7 @@ internal class PasswordResetScreenViewModel(
     internal val state: StateFlow<B2BUIState>,
     dispatchAction: suspend (B2BUIAction) -> Unit,
 ) : BaseViewModel(state, dispatchAction) {
-    val usePasswordResetByEmail = UsePasswordResetByEmail(viewModelScope, state, ::request)
+    val usePasswordResetByEmail = UsePasswordResetByEmail(viewModelScope, state, ::dispatch, ::request)
     val useUpdateMemberPassword = UseUpdateMemberPassword(state, ::dispatch)
     val usePasswordStrengthCheck = UsePasswordsStrengthCheck(viewModelScope, state, ::dispatch, ::request)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordSetNewScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordSetNewScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
@@ -33,7 +34,7 @@ internal fun PasswordSetNewScreen(
 ) {
     val theme = LocalStytchTheme.current
     Column {
-        PageTitle(text = "Check your email!")
+        PageTitle(textAlign = TextAlign.Left, text = "Check your email!")
         BodyText(
             text = "A login link was sent to you at ${state.value.emailState.emailAddress}",
             color = Color(theme.secondaryTextColor),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordSetNewScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordSetNewScreen.kt
@@ -23,7 +23,8 @@ internal class PasswordSetNewScreenViewModel(
     dispatchAction: suspend (B2BUIAction) -> Unit,
     productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
-    val usePasswordResetByEmailStart = UsePasswordResetByEmailStart(viewModelScope, state, productConfig, ::request)
+    val usePasswordResetByEmailStart =
+        UsePasswordResetByEmailStart(viewModelScope, state, ::dispatch, productConfig, ::request)
 }
 
 @Composable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesEntryScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
@@ -39,7 +40,7 @@ internal fun RecoveryCodesEntryScreen(
 ) {
     var recoveryCode by remember { mutableStateOf("") }
     Column {
-        PageTitle(text = "Enter backup code")
+        PageTitle(textAlign = TextAlign.Left, text = "Enter backup code")
         BodyText(text = "Enter one of the backup codes you saved when setting up your authenticator app.")
         StytchInput(modifier = Modifier.fillMaxWidth(), value = recoveryCode, onValueChange = { recoveryCode = it })
         Spacer(modifier = Modifier.height(16.dp))

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesSaveScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/RecoveryCodesSaveScreen.kt
@@ -79,7 +79,7 @@ internal fun RecoveryCodesSaveScreen(
     val context = LocalContext.current
     var didSaveCodesSomehow by remember { mutableStateOf(false) }
     Column {
-        PageTitle(text = "Save your backup codes!")
+        PageTitle(textAlign = TextAlign.Left, text = "Save your backup codes!")
         BodyText(text = "This is the only time you will be able to access and save your backup codes.")
         Box(
             modifier =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2b.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
@@ -31,7 +32,7 @@ internal fun SMSOTPEnrollmentScreen(
 ) {
     val phoneNumberState = state.value.phoneNumberState
     Column {
-        PageTitle(text = "Enter your phone number to set up Multi-Factor Authentication")
+        PageTitle(textAlign = TextAlign.Left, text = "Enter your phone number to set up Multi-Factor Authentication")
         BodyText(
             text = "Your organization requires an additional form of verification to make your account more secure.",
         )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
@@ -45,7 +45,7 @@ internal fun SMSOTPEnrollmentScreen(
             onCountryCodeChanged = { viewModel.useUpdateMemberPhoneNumber(it, null) },
             phoneNumber = phoneNumberState.phoneNumber,
             onPhoneNumberChanged = { viewModel.useUpdateMemberPhoneNumber(null, it) },
-            onPhoneNumberSubmit = { viewModel.useSmsOtpSend() },
+            onPhoneNumberSubmit = { viewModel.useSmsOtpSend(true) },
         )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
@@ -41,7 +41,6 @@ internal fun SMSOTPEnrollmentScreen(
             phoneNumber = phoneNumberState.phoneNumber,
             onPhoneNumberChanged = { viewModel.useUpdateMemberPhoneNumber(null, it) },
             onPhoneNumberSubmit = { viewModel.useSmsOtpSend() },
-            statusText = state.value.stytchError?.message,
         )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEnrollmentScreen.kt
@@ -9,8 +9,11 @@ import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSSend
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberPhoneNumber
+import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.PhoneEntry
@@ -32,6 +35,7 @@ internal fun SMSOTPEnrollmentScreen(
 ) {
     val phoneNumberState = state.value.phoneNumberState
     Column {
+        BackButton(onClick = { viewModel.dispatch(SetNextRoute(Routes.MFAEnrollmentSelection)) })
         PageTitle(textAlign = TextAlign.Left, text = "Enter your phone number to set up Multi-Factor Authentication")
         BodyText(
             text = "Your organization requires an additional form of verification to make your account more secure.",

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
@@ -88,10 +88,7 @@ internal fun SMSOTPEntryScreen(
                     append(recipientFormatted)
                 },
         )
-        OTPEntry(
-            errorMessage = state.value.stytchError?.message,
-            onCodeComplete = { viewModel.useOTPSMSAuthenticate(it) },
-        )
+        OTPEntry(onCodeComplete = { viewModel.useOTPSMSAuthenticate(it) })
         Text(
             text = stringResource(id = R.string.code_expires_in, expirationTimeFormatted),
             textAlign = TextAlign.Start,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
@@ -80,7 +80,7 @@ internal fun SMSOTPEntryScreen(
     }
 
     Column(modifier = Modifier.padding(bottom = 32.dp)) {
-        PageTitle(text = "Enter passcode")
+        PageTitle(textAlign = TextAlign.Left, text = "Enter passcode")
         BodyText(
             text =
                 buildAnnotatedString {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
@@ -29,8 +29,11 @@ import com.stytch.sdk.ui.b2b.BaseViewModel
 import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSAuthenticate
 import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSSend
+import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.OTPEntry
 import com.stytch.sdk.ui.shared.components.PageTitle
@@ -69,6 +72,7 @@ internal fun SMSOTPEntryScreen(
     var countdownSeconds by remember { mutableLongStateOf(OTP_EXPIRATION_SECONDS) }
     var expirationTimeFormatted by remember { mutableStateOf("2:00") }
     val coroutineScope = rememberCoroutineScope()
+    val isEnrolling = state.value.mfaSMSState?.isEnrolling ?: false
     LaunchedEffect(Unit) {
         coroutineScope.launch {
             while (countdownSeconds > 0) {
@@ -80,6 +84,11 @@ internal fun SMSOTPEntryScreen(
     }
 
     Column(modifier = Modifier.padding(bottom = 32.dp)) {
+        if (isEnrolling) {
+            BackButton {
+                viewModel.dispatch(SetNextRoute(Routes.SMSOTPEnrollment))
+            }
+        }
         PageTitle(textAlign = TextAlign.Left, text = "Enter passcode")
         BodyText(
             text =
@@ -112,7 +121,7 @@ internal fun SMSOTPEntryScreen(
             onCancelClick = { showResendDialog = false },
             acceptText = stringResource(id = R.string.send_code),
             onAcceptClick = {
-                viewModel.useOTPSMSSend()
+                viewModel.useOTPSMSSend(isEnrolling)
                 countdownSeconds = OTP_EXPIRATION_SECONDS
                 showResendDialog = false
             },

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
@@ -41,6 +41,7 @@ import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.data.SetPostAuthScreen
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseTOTPCreate
 import com.stytch.sdk.ui.shared.components.BackButton
@@ -62,6 +63,8 @@ internal class TOTPEnrollmentScreenViewModel(
     private val useTOTPCreate = UseTOTPCreate(viewModelScope, state, ::dispatch, ::request)
 
     init {
+        // if we're enrolling, make sure we always set the postauthscreen to recoverycodesave
+        dispatch(SetPostAuthScreen(Routes.RecoveryCodeSave))
         if (state.value.mfaTOTPState == null) {
             // kick off account creation
             useTOTPCreate()

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
@@ -43,6 +43,7 @@ import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseTOTPCreate
+import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.StytchButton
@@ -90,6 +91,7 @@ internal fun TOTPEnrollmentScreen(
     val secretChunked = secret.chunked(4).joinToString(" ")
     var didCopyCode by remember { mutableStateOf(false) }
     Column {
+        BackButton(onClick = { viewModel.dispatch(SetNextRoute(Routes.MFAEnrollmentSelection)) })
         PageTitle(textAlign = TextAlign.Left, text = "Copy the code below to link your authenticator app")
         BodyText(
             text =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEnrollmentScreen.kt
@@ -90,7 +90,7 @@ internal fun TOTPEnrollmentScreen(
     val secretChunked = secret.chunked(4).joinToString(" ")
     var didCopyCode by remember { mutableStateOf(false) }
     Column {
-        PageTitle(text = "Copy the code below to link your authenticator app")
+        PageTitle(textAlign = TextAlign.Left, text = "Copy the code below to link your authenticator app")
         BodyText(
             text =
                 "Enter the key below into your authenticator app. " +

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEntryScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -22,6 +23,8 @@ import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseTOTPAuthenticate
+import com.stytch.sdk.ui.shared.components.BackButton
+import com.stytch.sdk.ui.shared.components.Body2Text
 import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.OTPEntry
 import com.stytch.sdk.ui.shared.components.PageTitle
@@ -91,6 +94,9 @@ internal fun TOTPEntryScreen(
     val totpEntryState = viewModel.totpEntryState.collectAsStateWithLifecycle().value
     val theme = LocalStytchTheme.current
     Column {
+        if (totpEntryState.isEnrolling) {
+            BackButton { viewModel.dispatch(SetNextRoute(Routes.TOTPEnrollment)) }
+        }
         PageTitle(textAlign = TextAlign.Left, text = "Enter verification code")
         BodyText(text = "Enter the 6-digit code from your authenticator app.")
         OTPEntry(errorMessage = totpEntryState.errorMessage, onCodeComplete = viewModel::validateCode)
@@ -108,8 +114,11 @@ internal fun TOTPEntryScreen(
                 onClick = viewModel::useRecoveryCode,
             )
         } else {
-            BodyText(
-                text = "If the verification code doesn’t work, go back to your authenticator app to get a new code.",
+            Body2Text(
+                text =
+                    AnnotatedString(
+                        "If the verification code doesn’t work, go back to your authenticator app to get a new code.",
+                    ),
             )
         }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/TOTPEntryScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -90,7 +91,7 @@ internal fun TOTPEntryScreen(
     val totpEntryState = viewModel.totpEntryState.collectAsStateWithLifecycle().value
     val theme = LocalStytchTheme.current
     Column {
-        PageTitle(text = "Enter verification code")
+        PageTitle(textAlign = TextAlign.Left, text = "Enter verification code")
         BodyText(text = "Enter the 6-digit code from your authenticator app.")
         OTPEntry(errorMessage = totpEntryState.errorMessage, onCodeComplete = viewModel::validateCode)
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksAuthenticate.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -24,7 +25,10 @@ internal class UseMagicLinksAuthenticate(
                         token = token,
                     ),
                 )
+            }.onSuccess {
+                dispatch(SetDeeplinkTokenPair(null))
             }.onFailure {
+                dispatch(SetDeeplinkTokenPair(null))
                 dispatch(SetB2BError(B2BErrorType.EmailMagicLink))
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksAuthenticate.kt
@@ -3,13 +3,17 @@ package com.stytch.sdk.ui.b2b.usecases
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.magicLinks.B2BMagicLinks
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
+import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
+import com.stytch.sdk.ui.b2b.data.SetB2BError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 internal class UseMagicLinksAuthenticate(
     private val scope: CoroutineScope,
+    private val dispatch: Dispatch,
     private val request: PerformRequest<B2BEMLAuthenticateData>,
 ) {
     operator fun invoke(token: String) {
@@ -20,6 +24,8 @@ internal class UseMagicLinksAuthenticate(
                         token = token,
                     ),
                 )
+            }.onFailure {
+                dispatch(SetB2BError(B2BErrorType.EmailMagicLink))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksDiscoveryAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksDiscoveryAuthenticate.kt
@@ -4,7 +4,9 @@ import com.stytch.sdk.b2b.magicLinks.B2BMagicLinks
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetDiscoveredOrganizations
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.UpdateEmailState
@@ -40,6 +42,8 @@ internal class UseMagicLinksDiscoveryAuthenticate(
                 )
                 dispatch(SetDiscoveredOrganizations(it.discoveredOrganizations))
                 dispatch(SetNextRoute(Routes.Discovery))
+            }.onFailure {
+                dispatch(SetB2BError(B2BErrorType.Default))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksDiscoveryAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksDiscoveryAuthenticate.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
 import com.stytch.sdk.ui.b2b.data.SetDiscoveredOrganizations
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.UpdateEmailState
@@ -32,6 +33,7 @@ internal class UseMagicLinksDiscoveryAuthenticate(
                     ),
                 )
             }.onSuccess {
+                dispatch(SetDeeplinkTokenPair(null))
                 dispatch(
                     UpdateEmailState(
                         state.value.emailState.copy(
@@ -43,6 +45,7 @@ internal class UseMagicLinksDiscoveryAuthenticate(
                 dispatch(SetDiscoveredOrganizations(it.discoveredOrganizations))
                 dispatch(SetNextRoute(Routes.Discovery))
             }.onFailure {
+                dispatch(SetDeeplinkTokenPair(null))
                 dispatch(SetB2BError(B2BErrorType.Default))
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOAuthAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOAuthAuthenticate.kt
@@ -3,13 +3,18 @@ package com.stytch.sdk.ui.b2b.usecases
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.OAuthAuthenticateResponseData
 import com.stytch.sdk.b2b.oauth.OAuth
+import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
+import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 internal class UseOAuthAuthenticate(
     private val scope: CoroutineScope,
+    private val dispatch: Dispatch,
     private val request: PerformRequest<OAuthAuthenticateResponseData>,
 ) {
     operator fun invoke(token: String) {
@@ -20,6 +25,11 @@ internal class UseOAuthAuthenticate(
                         oauthToken = token,
                     ),
                 )
+            }.onSuccess {
+                dispatch(SetDeeplinkTokenPair(null))
+            }.onFailure {
+                dispatch(SetDeeplinkTokenPair(null))
+                dispatch(SetB2BError(B2BErrorType.Default))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOAuthDiscoveryAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOAuthDiscoveryAuthenticate.kt
@@ -5,7 +5,10 @@ import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.oauth.OAuth.Discovery.DiscoveryAuthenticateParameters
 import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
 import com.stytch.sdk.ui.b2b.data.SetDiscoveredOrganizations
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.UpdateEmailState
@@ -31,6 +34,7 @@ internal class UseOAuthDiscoveryAuthenticate(
                     ),
                 )
             }.onSuccess {
+                dispatch(SetDeeplinkTokenPair(null))
                 dispatch(
                     UpdateEmailState(
                         state.value.emailState.copy(
@@ -41,6 +45,9 @@ internal class UseOAuthDiscoveryAuthenticate(
                 )
                 dispatch(SetDiscoveredOrganizations(it.discoveredOrganizations))
                 dispatch(SetNextRoute(Routes.Discovery))
+            }.onFailure {
+                dispatch(SetDeeplinkTokenPair(null))
+                dispatch(SetB2BError(B2BErrorType.Default))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOTPSMSSend.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOTPSMSSend.kt
@@ -6,7 +6,10 @@ import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.MFASMSState
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.data.SetPostAuthScreen
+import com.stytch.sdk.ui.b2b.data.UpdateMfaSmsState
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,7 +22,7 @@ internal class UseOTPSMSSend(
     private val dispatch: Dispatch,
     private val request: PerformRequest<BasicData>,
 ) {
-    operator fun invoke() {
+    operator fun invoke(isEnrolling: Boolean) {
         scope.launch(Dispatchers.IO) {
             request {
                 StytchB2BClient.otp.sms.send(
@@ -30,6 +33,17 @@ internal class UseOTPSMSSend(
                     ),
                 )
             }.onSuccess {
+                dispatch(
+                    UpdateMfaSmsState(
+                        state.value.mfaSMSState?.copy(isEnrolling = isEnrolling)
+                            ?: MFASMSState(isEnrolling = isEnrolling),
+                    ),
+                )
+                if (isEnrolling) {
+                    // It's possible that we created (but didn't verify) TOTP, now that we added back buttons, so make
+                    // sure that we reset the expected post auth screen
+                    dispatch(SetPostAuthScreen(Routes.Success))
+                }
                 dispatch(SetNextRoute(Routes.SMSOTPEntry))
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmail.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmail.kt
@@ -3,8 +3,12 @@ package com.stytch.sdk.ui.b2b.usecases
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.passwords.Passwords
+import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +17,7 @@ import kotlinx.coroutines.launch
 internal class UsePasswordResetByEmail(
     private val scope: CoroutineScope,
     private val state: StateFlow<B2BUIState>,
+    private val dispatch: Dispatch,
     private val request: PerformRequest<EmailResetResponseData>,
 ) {
     operator fun invoke() {
@@ -24,6 +29,11 @@ internal class UsePasswordResetByEmail(
                         password = state.value.passwordState.password,
                     ),
                 )
+            }.onSuccess {
+                dispatch(SetDeeplinkTokenPair(null))
+            }.onFailure {
+                dispatch(SetDeeplinkTokenPair(null))
+                dispatch(SetB2BError(B2BErrorType.Default))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmailStart.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmailStart.kt
@@ -3,9 +3,12 @@ package com.stytch.sdk.ui.b2b.usecases
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.passwords.Passwords
 import com.stytch.sdk.common.network.models.BasicData
+import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
+import com.stytch.sdk.ui.b2b.navigation.Routes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +17,7 @@ import kotlinx.coroutines.launch
 internal class UsePasswordResetByEmailStart(
     private val scope: CoroutineScope,
     private val state: StateFlow<B2BUIState>,
+    private val dispatch: Dispatch,
     private val productConfig: StytchB2BProductConfig,
     private val request: PerformRequest<BasicData>,
 ) {
@@ -29,6 +33,8 @@ internal class UsePasswordResetByEmailStart(
                         resetPasswordTemplateId = productConfig.passwordOptions.resetPasswordTemplateId,
                     ),
                 )
+            }.onSuccess {
+                dispatch(SetNextRoute(Routes.PasswordSetNewConfirmation))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSSOAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSSOAuthenticate.kt
@@ -3,7 +3,11 @@ package com.stytch.sdk.ui.b2b.usecases
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.SSOAuthenticateResponseData
 import com.stytch.sdk.b2b.sso.SSO
+import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BErrorType
+import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,6 +15,7 @@ import kotlinx.coroutines.launch
 
 internal class UseSSOAuthenticate(
     private val scope: CoroutineScope,
+    private val dispatch: Dispatch,
     private val productConfig: StytchB2BProductConfig,
     private val request: PerformRequest<SSOAuthenticateResponseData>,
 ) {
@@ -23,6 +28,11 @@ internal class UseSSOAuthenticate(
                         sessionDurationMinutes = productConfig.sessionOptions.sessionDurationMinutes,
                     ),
                 )
+            }.onSuccess {
+                dispatch(SetDeeplinkTokenPair(null))
+            }.onFailure {
+                dispatch(SetDeeplinkTokenPair(null))
+                dispatch(SetB2BError(B2BErrorType.Default))
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseTOTPCreate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseTOTPCreate.kt
@@ -8,10 +8,8 @@ import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.MFATOTPState
-import com.stytch.sdk.ui.b2b.data.SetPostAuthScreen
 import com.stytch.sdk.ui.b2b.data.TOTPEnrollmentState
 import com.stytch.sdk.ui.b2b.data.UpdateMfaTotpState
-import com.stytch.sdk.ui.b2b.navigation.Routes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +36,6 @@ internal class UseTOTPCreate(
                     ),
                 )
             }.onSuccess {
-                dispatch(SetPostAuthScreen(Routes.RecoveryCodeSave))
                 dispatch(
                     UpdateMfaTotpState(
                         MFATOTPState(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseUpdateMemberEmailShouldBeValidated.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseUpdateMemberEmailShouldBeValidated.kt
@@ -6,20 +6,21 @@ import com.stytch.sdk.ui.b2b.data.UpdateEmailState
 import com.stytch.sdk.ui.shared.utils.isValidEmailAddress
 import kotlinx.coroutines.flow.StateFlow
 
-internal class UseUpdateMemberEmailAddress(
+internal class UseUpdateMemberEmailShouldBeValidated(
     private val state: StateFlow<B2BUIState>,
     private val dispatch: Dispatch,
 ) {
-    operator fun invoke(emailAddress: String) {
+    operator fun invoke(shouldBeValidated: Boolean) {
         dispatch(
             UpdateEmailState(
                 state.value.emailState.copy(
-                    emailAddress = emailAddress,
+                    shouldValidateEmail = shouldBeValidated,
                     validEmail =
-                        if (state.value.emailState.shouldValidateEmail) {
-                            emailAddress.isValidEmailAddress()
+                        if (shouldBeValidated) {
+                            state.value.emailState.emailAddress
+                                .isValidEmailAddress()
                         } else {
-                            null
+                            state.value.emailState.validEmail
                         },
                 ),
             ),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
@@ -8,6 +8,7 @@ import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.screens.DeepLinkParserScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.DiscoveryScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.EmailConfirmationScreenViewModel
+import com.stytch.sdk.ui.b2b.screens.ErrorScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.MFAEnrollmentSelectionScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.MainScreenViewModel
 import com.stytch.sdk.ui.b2b.screens.PasswordAuthenticateScreenViewModel
@@ -84,6 +85,8 @@ internal class B2BUIViewModelFactory(
                 SMSOTPEnrollmentScreenViewModel(state, dispatchAction) as T
             SMSOTPEntryScreenViewModel::class.java ->
                 SMSOTPEntryScreenViewModel(state, dispatchAction) as T
+            ErrorScreenViewModel::class.java ->
+                ErrorScreenViewModel(state, dispatchAction) as T
             else -> super.create(modelClass)
         }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailAndPasswordEntry.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailAndPasswordEntry.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -25,6 +28,7 @@ internal fun EmailAndPasswordEntry(
 ) {
     val isSubmittable = allowInvalidSubmission == true || (emailState.validEmail == true && passwordState.validPassword)
     val semantics = stringResource(id = R.string.semantics_email_password_entry)
+    val localFocusManager = LocalFocusManager.current
     Column(
         modifier = Modifier.semantics { contentDescription = semantics },
     ) {
@@ -36,11 +40,13 @@ internal fun EmailAndPasswordEntry(
             emailState = emailState,
             onEmailAddressChanged = onEmailAddressChanged,
             label = stringResource(id = R.string.email),
+            keyboardActions = KeyboardActions(onDone = { localFocusManager.moveFocus(FocusDirection.Next) }),
         )
         PasswordInput(
             passwordState = passwordState,
             onPasswordChanged = onPasswordChanged,
             label = stringResource(id = R.string.password),
+            keyboardActions = KeyboardActions(onDone = { onSubmit() }),
         )
         StytchButton(
             onClick = onSubmit,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailAndPasswordEntry.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailAndPasswordEntry.kt
@@ -21,12 +21,16 @@ import com.stytch.sdk.ui.shared.data.PasswordState
 internal fun EmailAndPasswordEntry(
     emailState: EmailState,
     onEmailAddressChanged: (String) -> Unit,
+    onEmailAddressDone: (() -> Unit)? = null,
     passwordState: PasswordState,
     onPasswordChanged: (String) -> Unit,
     allowInvalidSubmission: Boolean? = false,
     onSubmit: () -> Unit,
 ) {
-    val isSubmittable = allowInvalidSubmission == true || (emailState.validEmail == true && passwordState.validPassword)
+    val isSubmittable =
+        allowInvalidSubmission == true ||
+            !emailState.shouldValidateEmail ||
+            (emailState.validEmail == true && passwordState.validPassword)
     val semantics = stringResource(id = R.string.semantics_email_password_entry)
     val localFocusManager = LocalFocusManager.current
     Column(
@@ -40,7 +44,11 @@ internal fun EmailAndPasswordEntry(
             emailState = emailState,
             onEmailAddressChanged = onEmailAddressChanged,
             label = stringResource(id = R.string.email),
-            keyboardActions = KeyboardActions(onDone = { localFocusManager.moveFocus(FocusDirection.Next) }),
+            keyboardActions =
+                KeyboardActions(onDone = {
+                    onEmailAddressDone?.invoke()
+                    localFocusManager.moveFocus(FocusDirection.Next)
+                }),
         )
         PasswordInput(
             passwordState = passwordState,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailEntry.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailEntry.kt
@@ -37,7 +37,7 @@ internal fun EmailEntry(
         onClick = onEmailAddressSubmit,
         modifier = Modifier.height(45.dp),
         text = stringResource(id = R.string.button_continue),
-        enabled = emailState.validEmail == true,
+        enabled = !emailState.shouldValidateEmail || emailState.validEmail == true,
     )
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailEntry.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailEntry.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
 @Composable
 internal fun EmailEntry(
     emailState: EmailState,
+    keyboardActions: KeyboardActions? = null,
     onEmailAddressChanged: (String) -> Unit,
     onEmailAddressSubmit: () -> Unit,
 ) {
@@ -29,6 +31,7 @@ internal fun EmailEntry(
         onEmailAddressChanged = onEmailAddressChanged,
         modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
         label = stringResource(id = R.string.email),
+        keyboardActions = keyboardActions,
     )
     StytchButton(
         onClick = onEmailAddressSubmit,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailInput.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailInput.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.shared.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,8 +17,9 @@ import com.stytch.sdk.ui.shared.data.EmailState
 internal fun EmailInput(
     modifier: Modifier = Modifier,
     emailState: EmailState,
-    onEmailAddressChanged: (String) -> Unit,
     label: String? = null,
+    keyboardActions: KeyboardActions? = null,
+    onEmailAddressChanged: (String) -> Unit,
 ) {
     val emailAddress = emailState.emailAddress
     val isError = emailState.errorMessage != null || emailState.validEmail == false
@@ -35,6 +37,7 @@ internal fun EmailInput(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Done,
                 ),
+            keyboardActions = keyboardActions,
             label = label,
             readOnly = emailState.readOnly,
         )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/FormFieldStatus.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/FormFieldStatus.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
 import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun FormFieldStatus(
@@ -17,9 +19,16 @@ internal fun FormFieldStatus(
     isError: Boolean = false,
     text: String,
     textAlign: TextAlign = TextAlign.Start,
+    autoDismiss: (() -> Unit)? = null,
 ) {
     val theme = LocalStytchTheme.current
     val type = LocalStytchTypography.current
+    LaunchedEffect(Unit) {
+        if (autoDismiss != null) {
+            delay(3000L)
+            autoDismiss.invoke()
+        }
+    }
     Text(
         text = text,
         style =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/PasswordInput.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/PasswordInput.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.shared.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Visibility
@@ -29,6 +30,7 @@ import com.stytch.sdk.ui.shared.data.PasswordState
 internal fun PasswordInput(
     passwordState: PasswordState,
     onPasswordChanged: (String) -> Unit,
+    keyboardActions: KeyboardActions? = null,
     label: String? = null,
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
@@ -42,6 +44,7 @@ internal fun PasswordInput(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done,
                 ),
+            keyboardActions = keyboardActions,
             visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
             label = label,
             trailingIcon = {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchInput.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/StytchInput.kt
@@ -40,6 +40,7 @@ internal fun StytchInput(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     placeholder: String = "",
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions? = null,
     trailingIcon: (@Composable () -> Unit)? = null,
     contentPadding: PaddingValues = OutlinedTextFieldDefaults.contentPadding(),
     textAlign: TextAlign = TextAlign.Start,
@@ -49,6 +50,7 @@ internal fun StytchInput(
     val theme = LocalStytchTheme.current
     val type = LocalStytchTypography.current
     val interactionSource = remember { MutableInteractionSource() }
+    val actions = keyboardActions ?: KeyboardActions(onDone = { focusManager.clearFocus() })
     val colors =
         OutlinedTextFieldDefaults.colors(
             focusedContainerColor = Color(theme.inputBackgroundColor),
@@ -80,7 +82,7 @@ internal fun StytchInput(
             ),
         visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions,
-        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+        keyboardActions = actions,
         interactionSource = interactionSource,
         singleLine = true,
         maxLines = 1,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/EmailState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/EmailState.kt
@@ -10,4 +10,5 @@ internal data class EmailState(
     val validEmail: Boolean? = null,
     val errorMessage: String? = null,
     val readOnly: Boolean = false,
+    val shouldValidateEmail: Boolean = false,
 ) : Parcelable


### PR DESCRIPTION
Linear Ticket: [SDK-2302](https://linear.app/stytch/issue/SDK-2302)

## Changes:
Assorted tweaks and refactorings gleaned from hammering on the demo app
1. Reworked when we mark a deeplink token as consumed (because it was broken for password resets 😩)
2. Disabling back navigation _except_ on the MFA Enrollment screens (so you can go back and choose a different method)
3. Better handle code entry
4. Nicer layout on No Orgs Found discovery flow
5. Additional emission of B2B errors, in line with RN implementation
6. Style tweaks (title alignment, etc)
7. Add a loading screen for the initial entry point (prevents seeing the main screen before it's actually ready

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A