### PR TITLE
Be less aggressive when nulling out the current activity; bump version

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.31.0'
+  PUBLISH_VERSION = '0.31.1'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/ActivityProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/ActivityProvider.kt
@@ -5,13 +5,13 @@ import android.app.Application
 import android.os.Bundle
 import java.lang.ref.WeakReference
 
-internal class ActivityProvider(application: Application) : Application.ActivityLifecycleCallbacks {
+internal class ActivityProvider(
+    application: Application,
+) : Application.ActivityLifecycleCallbacks {
     @Suppress("ktlint:standard:backing-property-naming")
     private var _currentActivity = WeakReference<Activity>(null)
     internal val currentActivity: Activity?
         get() = _currentActivity.get()
-
-    private var lastResumedActivityName: String? = null
 
     init {
         application.registerActivityLifecycleCallbacks(this)
@@ -21,26 +21,23 @@ internal class ActivityProvider(application: Application) : Application.Activity
         activity: Activity,
         bundle: Bundle?,
     ) {
-        _currentActivity = WeakReference(activity)
+        // noop
     }
 
     override fun onActivityStarted(activity: Activity) {
-        _currentActivity = WeakReference(activity)
+        // noop
     }
 
     override fun onActivityResumed(activity: Activity) {
-        lastResumedActivityName = activity.localClassName
         _currentActivity = WeakReference(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {
-        if (lastResumedActivityName != activity.localClassName) return
-        _currentActivity = WeakReference(null)
+        // noop
     }
 
     override fun onActivityStopped(activity: Activity) {
-        if (lastResumedActivityName != activity.localClassName) return
-        _currentActivity = WeakReference(null)
+        // noop
     }
 
     override fun onActivitySaveInstanceState(
@@ -51,7 +48,6 @@ internal class ActivityProvider(application: Application) : Application.Activity
     }
 
     override fun onActivityDestroyed(activity: Activity) {
-        if (lastResumedActivityName != activity.localClassName) return
-        _currentActivity = WeakReference(null)
+        // noop
     }
 }


### PR DESCRIPTION
## Changes:

1. We only actually need to set the current activity in onResumed, as that's the last state when an activity is visible
2. We don't need to explicitly null out the weakreference, as this class is scoped to the lifetime of the application, and it's very difficult to accurately know the exact order that the lifecycle events will fire when launching multiple activities. The previous implementation worked when launching between different activities, but failed when you launched the same activity back-to-back. This solution works in both cases, plus navigating back to an existing activity.

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A