### PR TITLE
B2B UI - Post launch bugfixes/improvements

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.31.1'
+  PUBLISH_VERSION = '0.31.2'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationViewModel.kt
@@ -17,9 +17,9 @@ import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetActiveOrganization
 import com.stytch.sdk.ui.b2b.data.SetAuthFlowType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
+import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.data.SetIsSearchingForOrganizationBySlug
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
-import com.stytch.sdk.ui.b2b.data.SetStytchError
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.domain.B2BUIStateMachine
 import com.stytch.sdk.ui.b2b.navigation.Routes
@@ -72,7 +72,7 @@ internal class B2BAuthenticationViewModel(
                 }
                 is StytchResult.Error -> {
                     dispatch(SetIsSearchingForOrganizationBySlug(false))
-                    dispatch(SetStytchError(response.exception))
+                    dispatch(SetGenericError(response.exception.message))
                 }
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/BaseViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/BaseViewModel.kt
@@ -9,9 +9,9 @@ import com.stytch.sdk.common.network.models.CommonAuthenticationData
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.HandleStepUpAuthentication
+import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.data.SetLoading
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
-import com.stytch.sdk.ui.b2b.data.SetStytchError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -52,7 +52,7 @@ internal open class BaseViewModel(
                     if (shouldSetLoadingIndicator) {
                         dispatch(SetLoading(false))
                     }
-                    dispatch(SetStytchError(response.exception))
+                    dispatch(SetGenericError(response.exception.message))
                     Result.failure(response.exception)
                 }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -29,7 +29,7 @@ import com.stytch.sdk.ui.b2b.data.AuthFlowType
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetB2BError
-import com.stytch.sdk.ui.b2b.data.SetStytchError
+import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.screens.DeepLinkParserScreen
 import com.stytch.sdk.ui.b2b.screens.DiscoveryScreen
@@ -197,9 +197,9 @@ internal fun StytchB2BAuthenticationApp(
                     TOTPEntryScreen(createViewModel = ::createViewModelHelper)
                 }
             }
-            state.value.stytchError?.let {
-                FormFieldStatus(text = it.message, isError = true, autoDismiss = {
-                    dispatch(SetStytchError(null))
+            state.value.errorToastText?.let {
+                FormFieldStatus(text = it, isError = true, autoDismiss = {
+                    dispatch(SetGenericError(null))
                 })
             }
             if (!bootstrapData.disableSDKWatermark) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIAction.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIAction.kt
@@ -4,7 +4,6 @@ import com.stytch.sdk.b2b.network.models.DiscoveredOrganization
 import com.stytch.sdk.b2b.network.models.IB2BAuthDataWithMFA
 import com.stytch.sdk.b2b.network.models.InternalOrganizationData
 import com.stytch.sdk.common.DeeplinkTokenPair
-import com.stytch.sdk.common.errors.StytchError
 import com.stytch.sdk.ui.b2b.navigation.Route
 import com.stytch.sdk.ui.shared.data.EmailState
 import com.stytch.sdk.ui.shared.data.PasswordState
@@ -54,10 +53,6 @@ internal data class SetPostAuthScreen(
 
 internal data class SetLoading(
     val value: Boolean,
-) : B2BUIAction
-
-internal data class SetStytchError(
-    val stytchError: StytchError?,
 ) : B2BUIAction
 
 internal data class SetB2BError(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BUIState.kt
@@ -6,7 +6,6 @@ import com.stytch.sdk.b2b.network.models.DiscoveredOrganization
 import com.stytch.sdk.b2b.network.models.InternalOrganizationData
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.common.DeeplinkTokenPair
-import com.stytch.sdk.common.errors.StytchError
 import com.stytch.sdk.ui.b2b.navigation.Route
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.shared.data.EmailState
@@ -18,7 +17,6 @@ import kotlinx.parcelize.Parcelize
 internal data class B2BUIState(
     val currentRoute: Route? = null,
     val isLoading: Boolean = false,
-    val stytchError: StytchError? = null,
     val errorToastText: String? = null,
     val emailState: EmailState = EmailState(shouldValidateEmail = false),
     val phoneNumberState: PhoneNumberState = PhoneNumberState(),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
@@ -16,7 +16,6 @@ import com.stytch.sdk.ui.b2b.data.SetIsSearchingForOrganizationBySlug
 import com.stytch.sdk.ui.b2b.data.SetLoading
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.SetPostAuthScreen
-import com.stytch.sdk.ui.b2b.data.SetStytchError
 import com.stytch.sdk.ui.b2b.data.UpdateEmailState
 import com.stytch.sdk.ui.b2b.data.UpdateMfaPrimaryInfoState
 import com.stytch.sdk.ui.b2b.data.UpdateMfaSmsState
@@ -86,11 +85,6 @@ internal class B2BUIStateMachine(
                 on<SetLoading> { action, state ->
                     state.mutate {
                         copy(isLoading = action.value)
-                    }
-                }
-                on<SetStytchError> { action, state ->
-                    state.mutate {
-                        copy(stytchError = action.stytchError)
                     }
                 }
                 on<SetGenericError> { action, state ->

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/domain/B2BUIStateMachine.kt
@@ -110,7 +110,6 @@ internal class B2BUIStateMachine(
                         copy(
                             currentRoute = action.route,
                             isLoading = false,
-                            stytchError = null,
                             b2BErrorType = null,
                         )
                     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DeepLinkParserScreen.kt
@@ -28,12 +28,13 @@ internal class DeepLinkParserScreenViewModel(
     dispatchAction: suspend (B2BUIAction) -> Unit,
     productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
-    private val useMagicLinksAuthenticate = UseMagicLinksAuthenticate(viewModelScope, ::dispatch, ::request)
+    private val useMagicLinksAuthenticate =
+        UseMagicLinksAuthenticate(viewModelScope, productConfig, ::dispatch, ::request)
     private val useMagicLinksDiscoveryAuthenticate =
         UseMagicLinksDiscoveryAuthenticate(viewModelScope, state, ::dispatch, ::request)
     private val useOAuthDiscoveryAuthenticate =
         UseOAuthDiscoveryAuthenticate(viewModelScope, state, ::dispatch, ::request)
-    private val useOAuthAuthenticate = UseOAuthAuthenticate(viewModelScope, ::dispatch, ::request)
+    private val useOAuthAuthenticate = UseOAuthAuthenticate(viewModelScope, productConfig, ::dispatch, ::request)
     private val useSSOAuthenticate = UseSSOAuthenticate(viewModelScope, ::dispatch, productConfig, ::request)
 
     internal fun handleDeepLink(pair: DeeplinkTokenPair) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -45,6 +45,7 @@ import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.ResetEverything
 import com.stytch.sdk.ui.b2b.data.SetActiveOrganization
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.extensions.jitEligible
 import com.stytch.sdk.ui.b2b.extensions.shouldAllowDirectLoginToOrganization
 import com.stytch.sdk.ui.b2b.extensions.toInternalOrganizationData
@@ -68,9 +69,11 @@ import kotlinx.coroutines.launch
 internal class DiscoveryScreenViewModel(
     internal val state: StateFlow<B2BUIState>,
     dispatchAction: suspend (B2BUIAction) -> Unit,
+    productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
     val useSSOStart = UseSSOStart()
-    private val useDiscoveryIntermediateSessionExchange = UseDiscoveryIntermediateSessionExchange(::request)
+    private val useDiscoveryIntermediateSessionExchange =
+        UseDiscoveryIntermediateSessionExchange(productConfig, ::request)
     private val useDiscoveryOrganizationCreate = UseDiscoveryOrganizationCreate(::request)
 
     private val _isCreatingStateFlow = MutableStateFlow(false)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
@@ -73,7 +73,8 @@ internal class MainScreenViewModel(
     val useUpdateMemberPassword = UseUpdateMemberPassword(state, ::dispatch)
     val useMagicLinksEmailLoginOrSignup =
         UseMagicLinksEmailLoginOrSignup(viewModelScope, state, ::dispatch, productConfig, ::request)
-    val useMagicLinksDiscoverySend = UseMagicLinksDiscoverySend(viewModelScope, state, ::dispatch, ::request)
+    val useMagicLinksDiscoverySend =
+        UseMagicLinksDiscoverySend(viewModelScope, productConfig, state, ::dispatch, ::request)
     val useSSOStart = UseSSOStart()
     val useOAuthStart = UseOAuthStart(state)
     val useSearchMember = UseSearchMember(::request)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordResetScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordResetScreen.kt
@@ -16,6 +16,7 @@ import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.ResetEverything
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.usecases.UsePasswordResetByEmail
 import com.stytch.sdk.ui.b2b.usecases.UsePasswordsStrengthCheck
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberPassword
@@ -28,8 +29,9 @@ import kotlinx.coroutines.flow.StateFlow
 internal class PasswordResetScreenViewModel(
     internal val state: StateFlow<B2BUIState>,
     dispatchAction: suspend (B2BUIAction) -> Unit,
+    productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
-    val usePasswordResetByEmail = UsePasswordResetByEmail(viewModelScope, state, ::dispatch, ::request)
+    val usePasswordResetByEmail = UsePasswordResetByEmail(viewModelScope, productConfig, state, ::dispatch, ::request)
     val useUpdateMemberPassword = UseUpdateMemberPassword(state, ::dispatch)
     val usePasswordStrengthCheck = UsePasswordsStrengthCheck(viewModelScope, state, ::dispatch, ::request)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/SMSOTPEntryScreen.kt
@@ -31,6 +31,7 @@ import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSAuthenticate
 import com.stytch.sdk.ui.b2b.usecases.UseOTPSMSSend
@@ -51,9 +52,10 @@ private const val ONE_SECOND = 1000L
 internal class SMSOTPEntryScreenViewModel(
     internal val state: StateFlow<B2BUIState>,
     dispatchAction: suspend (B2BUIAction) -> Unit,
+    productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
     val useOTPSMSSend = UseOTPSMSSend(viewModelScope, state, ::dispatch, ::request)
-    val useOTPSMSAuthenticate = UseOTPSMSAuthenticate(viewModelScope, state, ::request)
+    val useOTPSMSAuthenticate = UseOTPSMSAuthenticate(viewModelScope, productConfig, state, ::request)
 
     init {
         val smsImplicitlySent = state.value.mfaPrimaryInfoState?.smsImplicitlySent == true

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseDiscoveryIntermediateSessionExchange.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseDiscoveryIntermediateSessionExchange.kt
@@ -4,8 +4,10 @@ import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.discovery.Discovery
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 
 internal class UseDiscoveryIntermediateSessionExchange(
+    private val productConfig: StytchB2BProductConfig,
     private val request: PerformRequest<IntermediateSessionExchangeResponseData>,
 ) {
     suspend operator fun invoke(organizationId: String): Result<IntermediateSessionExchangeResponseData> =
@@ -13,6 +15,7 @@ internal class UseDiscoveryIntermediateSessionExchange(
             StytchB2BClient.discovery.exchangeIntermediateSession(
                 Discovery.SessionExchangeParameters(
                     organizationId = organizationId,
+                    sessionDurationMinutes = productConfig.sessionOptions.sessionDurationMinutes,
                 ),
             )
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksAuthenticate.kt
@@ -8,12 +8,14 @@ import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 internal class UseMagicLinksAuthenticate(
     private val scope: CoroutineScope,
+    private val productConfig: StytchB2BProductConfig,
     private val dispatch: Dispatch,
     private val request: PerformRequest<B2BEMLAuthenticateData>,
 ) {
@@ -23,6 +25,7 @@ internal class UseMagicLinksAuthenticate(
                 StytchB2BClient.magicLinks.authenticate(
                     B2BMagicLinks.AuthParameters(
                         token = token,
+                        sessionDurationMinutes = productConfig.sessionOptions.sessionDurationMinutes,
                     ),
                 )
             }.onSuccess {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksDiscoverySend.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseMagicLinksDiscoverySend.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,6 +15,7 @@ import kotlinx.coroutines.launch
 
 internal class UseMagicLinksDiscoverySend(
     private val scope: CoroutineScope,
+    private val productConfig: StytchB2BProductConfig,
     private val state: StateFlow<B2BUIState>,
     private val dispatch: Dispatch,
     private val request: PerformRequest<BasicData>,
@@ -25,6 +27,7 @@ internal class UseMagicLinksDiscoverySend(
                     B2BMagicLinks.EmailMagicLinks.DiscoverySendParameters(
                         emailAddress = state.value.emailState.emailAddress,
                         discoveryRedirectUrl = getRedirectUrl(),
+                        loginTemplateId = productConfig.emailMagicLinksOptions.loginTemplateId,
                     ),
                 )
             }.onSuccess {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOAuthAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOAuthAuthenticate.kt
@@ -8,12 +8,14 @@ import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 internal class UseOAuthAuthenticate(
     private val scope: CoroutineScope,
+    private val productConfig: StytchB2BProductConfig,
     private val dispatch: Dispatch,
     private val request: PerformRequest<OAuthAuthenticateResponseData>,
 ) {
@@ -23,6 +25,7 @@ internal class UseOAuthAuthenticate(
                 StytchB2BClient.oauth.authenticate(
                     OAuth.AuthenticateParameters(
                         oauthToken = token,
+                        sessionDurationMinutes = productConfig.sessionOptions.sessionDurationMinutes,
                     ),
                 )
             }.onSuccess {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOTPSMSAuthenticate.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseOTPSMSAuthenticate.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.network.models.SMSAuthenticateResponseData
 import com.stytch.sdk.b2b.otp.OTP
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -12,6 +13,7 @@ import kotlinx.coroutines.launch
 
 internal class UseOTPSMSAuthenticate(
     private val scope: CoroutineScope,
+    private val productConfig: StytchB2BProductConfig,
     private val state: StateFlow<B2BUIState>,
     private val request: PerformRequest<SMSAuthenticateResponseData>,
 ) {
@@ -23,6 +25,7 @@ internal class UseOTPSMSAuthenticate(
                         organizationId = state.value.mfaPrimaryInfoState?.organizationId ?: "",
                         memberId = state.value.mfaPrimaryInfoState?.memberId ?: "",
                         code = code,
+                        sessionDurationMinutes = productConfig.sessionOptions.sessionDurationMinutes,
                     ),
                 )
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmail.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmail.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.ui.b2b.data.B2BErrorType
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetB2BError
 import com.stytch.sdk.ui.b2b.data.SetDeeplinkTokenPair
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +17,7 @@ import kotlinx.coroutines.launch
 
 internal class UsePasswordResetByEmail(
     private val scope: CoroutineScope,
+    private val productConfig: StytchB2BProductConfig,
     private val state: StateFlow<B2BUIState>,
     private val dispatch: Dispatch,
     private val request: PerformRequest<EmailResetResponseData>,
@@ -27,6 +29,7 @@ internal class UsePasswordResetByEmail(
                     Passwords.ResetByEmailParameters(
                         token = state.value.deeplinkTokenPair?.token ?: "",
                         password = state.value.passwordState.password,
+                        sessionDurationMinutes = productConfig.sessionOptions.sessionDurationMinutes,
                     ),
                 )
             }.onSuccess {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/utils/B2BUIViewModelFactory.kt
@@ -37,7 +37,7 @@ internal class B2BUIViewModelFactory(
                     dispatchAction,
                     productConfig,
                 ) as T
-            DiscoveryScreenViewModel::class.java -> DiscoveryScreenViewModel(state, dispatchAction) as T
+            DiscoveryScreenViewModel::class.java -> DiscoveryScreenViewModel(state, dispatchAction, productConfig) as T
             EmailConfirmationScreenViewModel::class.java ->
                 EmailConfirmationScreenViewModel(
                     state,
@@ -54,6 +54,7 @@ internal class B2BUIViewModelFactory(
                 PasswordResetScreenViewModel(
                     state,
                     dispatchAction,
+                    productConfig,
                 ) as T
             PasswordAuthenticateScreenViewModel::class.java ->
                 PasswordAuthenticateScreenViewModel(
@@ -84,7 +85,7 @@ internal class B2BUIViewModelFactory(
             SMSOTPEnrollmentScreenViewModel::class.java ->
                 SMSOTPEnrollmentScreenViewModel(state, dispatchAction) as T
             SMSOTPEntryScreenViewModel::class.java ->
-                SMSOTPEntryScreenViewModel(state, dispatchAction) as T
+                SMSOTPEntryScreenViewModel(state, dispatchAction, productConfig) as T
             ErrorScreenViewModel::class.java ->
                 ErrorScreenViewModel(state, dispatchAction) as T
             else -> super.create(modelClass)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/FormFieldStatus.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/FormFieldStatus.kt
@@ -25,7 +25,7 @@ internal fun FormFieldStatus(
     val type = LocalStytchTypography.current
     LaunchedEffect(Unit) {
         if (autoDismiss != null) {
-            delay(3000L)
+            delay(5000L)
             autoDismiss.invoke()
         }
     }


### PR DESCRIPTION
## Changes:

1. GenericErrorMessage was being used for JIT errors, but never surfaced. Since we are only using the error message from the StytchError, unify the two into a single setter/source of truth, so all will be displayed as expected
2. Increase the timeout of the error autodismissal from 3 seconds to 5 seconds
3. #241 

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A