### PR TITLE
SDK-2348 only search users if passwords enabled

### DIFF
--- a/source/sdk/build.gradle
+++ b/source/sdk/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.32.0'
+  PUBLISH_VERSION = '0.33.0'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 


### PR DESCRIPTION
Linear Ticket: [SDK-2348](https://linear.app/stytch/issue/SDK-2348)

## Changes:

1. If passwords are not enabled in the dashboard, we were failing when calling the user search. This change is to ONLY make the user search if passwords are a configured option. Without this change, if a developer had passwords disabled in their dashboard, and only wanted to support EML or EOTP, we would fail with a "Passwords not enabled" error.

## Notes:

- Yes, if passwords are disabled in the dashboard, but passed in as an option in the config it will still fail; this is intentional and makes sense.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A