### PR TITLE
B2B UI: Add member/non-member distinction in email confirmation screen resend method

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.34.1"
+extra["PUBLISH_VERSION"] = "0.34.2"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/PasswordForgotScreen.kt
@@ -17,12 +17,8 @@ import com.stytch.sdk.ui.b2b.CreateViewModel
 import com.stytch.sdk.ui.b2b.data.B2BUIAction
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.ResetEverything
-import com.stytch.sdk.ui.b2b.data.SetLoading
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
-import com.stytch.sdk.ui.b2b.usecases.UseNonMemberPasswordReset
-import com.stytch.sdk.ui.b2b.usecases.UsePasswordDiscoveryResetByEmailStart
-import com.stytch.sdk.ui.b2b.usecases.UsePasswordResetByEmailStart
-import com.stytch.sdk.ui.b2b.usecases.UseSearchMember
+import com.stytch.sdk.ui.b2b.usecases.UseSendCorrectPasswordReset
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberEmailAddress
 import com.stytch.sdk.ui.b2b.usecases.UseUpdateMemberEmailShouldBeValidated
 import com.stytch.sdk.ui.shared.components.BackButton
@@ -31,47 +27,18 @@ import com.stytch.sdk.ui.shared.components.EmailInput
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.StytchButton
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 internal class PasswordForgotScreenViewModel(
     internal val state: StateFlow<B2BUIState>,
     dispatchAction: suspend (B2BUIAction) -> Unit,
     productConfig: StytchB2BProductConfig,
 ) : BaseViewModel(state, dispatchAction) {
-    val useSearchMember = UseSearchMember(::request)
-    val usePasswordResetByEmailStart =
-        UsePasswordResetByEmailStart(viewModelScope, state, ::dispatch, productConfig, ::request)
-    val useNonMemberPasswordReset =
-        UseNonMemberPasswordReset(viewModelScope, state, ::dispatch, productConfig, ::request)
     val useUpdateMemberEmailAddress = UseUpdateMemberEmailAddress(state, ::dispatch)
     val useUpdateMemberEmailShouldBeValidated = UseUpdateMemberEmailShouldBeValidated(state, ::dispatch)
-    val usePasswordDiscoveryResetByEmailStart =
-        UsePasswordDiscoveryResetByEmailStart(viewModelScope, state, productConfig, ::dispatch, ::request)
+    private val useSendCorrectPasswordReset =
+        UseSendCorrectPasswordReset(viewModelScope, state, ::dispatch, productConfig, ::request, ::request)
 
-    fun onSubmit() {
-        dispatch(SetLoading(true))
-        val organizationId = state.value.activeOrganization?.organizationId
-        if (organizationId == null) {
-            usePasswordDiscoveryResetByEmailStart()
-            return
-        }
-        viewModelScope.launch {
-            useSearchMember(
-                emailAddress = state.value.emailState.emailAddress,
-                organizationId = organizationId,
-            ).onSuccess {
-                dispatch(SetLoading(false))
-                if (it.member?.memberPasswordId.isNullOrEmpty()) {
-                    // no memberPasswordId == no password, so drop them in the nonMemberReset flow
-                    return@onSuccess useNonMemberPasswordReset()
-                }
-                // there IS a password for this user, so send them a reset
-                usePasswordResetByEmailStart()
-            }.onFailure {
-                dispatch(SetLoading(false))
-            }
-        }
-    }
+    fun onSubmit() = useSendCorrectPasswordReset()
 }
 
 @Composable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSendCorrectPasswordReset.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSendCorrectPasswordReset.kt
@@ -1,0 +1,54 @@
+package com.stytch.sdk.ui.b2b.usecases
+
+import com.stytch.sdk.b2b.network.models.B2BSearchMemberResponseData
+import com.stytch.sdk.common.network.models.BasicData
+import com.stytch.sdk.ui.b2b.Dispatch
+import com.stytch.sdk.ui.b2b.PerformRequest
+import com.stytch.sdk.ui.b2b.data.B2BUIState
+import com.stytch.sdk.ui.b2b.data.SetLoading
+import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+internal class UseSendCorrectPasswordReset(
+    private val scope: CoroutineScope,
+    private val state: StateFlow<B2BUIState>,
+    private val dispatch: Dispatch,
+    productConfig: StytchB2BProductConfig,
+    memberSearchRequest: PerformRequest<B2BSearchMemberResponseData>,
+    emailSendRequest: PerformRequest<BasicData>,
+) {
+    val useSearchMember = UseSearchMember(memberSearchRequest)
+    val usePasswordResetByEmailStart =
+        UsePasswordResetByEmailStart(scope, state, dispatch, productConfig, emailSendRequest)
+    val useNonMemberPasswordReset =
+        UseNonMemberPasswordReset(scope, state, dispatch, productConfig, emailSendRequest)
+    val usePasswordDiscoveryResetByEmailStart =
+        UsePasswordDiscoveryResetByEmailStart(scope, state, productConfig, dispatch, emailSendRequest)
+
+    operator fun invoke() {
+        dispatch(SetLoading(true))
+        val organizationId = state.value.activeOrganization?.organizationId
+        if (organizationId == null) {
+            usePasswordDiscoveryResetByEmailStart()
+            return
+        }
+        scope.launch {
+            useSearchMember(
+                emailAddress = state.value.emailState.emailAddress,
+                organizationId = organizationId,
+            ).onSuccess {
+                dispatch(SetLoading(false))
+                if (it.member?.memberPasswordId.isNullOrEmpty()) {
+                    // no memberPasswordId == no password, so drop them in the nonMemberReset flow
+                    return@onSuccess useNonMemberPasswordReset()
+                }
+                // there IS a password for this user, so send them a reset
+                usePasswordResetByEmailStart()
+            }.onFailure {
+                dispatch(SetLoading(false))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Linear Ticket: None

## Changes:

1. Add the same "does member have a password?" check from PasswordForgot flow to EmailConfirmation resend flow
2. Unify it all in one reusable usecase

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A