### PR TITLE
Fix leaking webview in DFPProvider

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ ktlint = "12.1.0"
 detekt = "1.23.6"
 ksp = "2.1.0-1.0.29"
 kotlinCompilerExtension="1.5.15"
+leakCanary = "2.14"
 
 [libraries]
 activity = { module = "androidx.activity:activity", version.ref = "activityKtx" }
@@ -134,6 +135,7 @@ flowRedux-jvm = { module = "com.freeletics.flowredux:flowredux-jvm", version.ref
 flowRedux-compose = { module = "com.freeletics.flowredux:compose", version.ref = "flowRedux" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+leakCanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakCanary"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "gradle" }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
@@ -46,11 +46,14 @@ internal class DFPProviderImpl(
         object {
             @JavascriptInterface
             fun reportTelemetryId(telemetryId: String) {
-                activityProvider.currentActivity?.let {
-                    it.runOnUiThread {
-                        (webview.parent as? ViewGroup)?.removeView(webview)
+                activityProvider.currentActivity?.let { currentActivity ->
+                    webview?.let {
+                        currentActivity.runOnUiThread {
+                            (it.parent as? ViewGroup)?.removeView(it)
+                        }
                     }
                 }
+                webview = null
                 if (continuation.isActive) {
                     continuation.resume(telemetryId, null)
                 }
@@ -59,7 +62,7 @@ internal class DFPProviderImpl(
 
     private lateinit var continuation: CancellableContinuation<String>
 
-    private lateinit var webview: WebView
+    private var webview: WebView? = null
 
     override suspend fun getTelemetryId(): String =
         suspendCancellableCoroutine { cont ->

--- a/workbench-apps/b2b-workbench/build.gradle.kts
+++ b/workbench-apps/b2b-workbench/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    debugImplementation(libs.leakCanary)
 
     // Compose
     implementation(platform(libs.compose.bom))

--- a/workbench-apps/consumer-workbench/build.gradle.kts
+++ b/workbench-apps/consumer-workbench/build.gradle.kts
@@ -71,6 +71,8 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
+    debugImplementation(libs.leakCanary)
+
     // Compose
     implementation(platform(libs.compose.bom))
     implementation(libs.ui)


### PR DESCRIPTION
Linear Ticket: [SDK-2379](https://linear.app/stytch/issue/SDK-2379)

## Changes:

1. Fixes reported webview leak in DFPProvider
2. Adds leakcanary to workbench apps for verification (and alerting us to future issues!)

## Notes:

- This leak (I believe) only happens in multiactivity workflows, and I was able to reproduce/fix/validate in the b2b workbench

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A