### PR TITLE
SDK-2382 direct org creation on zero memberships

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.34.2"
+extra["PUBLISH_VERSION"] = "0.35.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
@@ -28,6 +28,7 @@ public data class StytchB2BProductConfig
         val oauthOptions: B2BOAuthOptions = B2BOAuthOptions(),
         val directLoginForSingleMembership: DirectLoginForSingleMembershipOptions? = null,
         val allowCreateOrganization: Boolean = true,
+        val directCreateOrganizationForNoMembership: Boolean = false,
         val mfaProductOrder: List<MfaMethod> = emptyList(),
         val mfaProductInclude: List<MfaMethod> =
             listOf(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/DiscoveryScreen.kt
@@ -120,6 +120,8 @@ internal fun DiscoveryScreen(
     val isCreatingState = viewModel.isCreatingStateFlow.collectAsStateWithLifecycle()
     val isExchangingState = viewModel.isExchangingStateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current as Activity
+    val shouldAutomaticallyCreateOrganization =
+        createOrganzationsEnabled && config.directCreateOrganizationForNoMembership
 
     fun handleDiscoveryOrganizationStart(discoveredOrganization: DiscoveredOrganization) {
         val organization = discoveredOrganization.organization
@@ -155,6 +157,12 @@ internal fun DiscoveryScreen(
             )
         if (directLoginOrganization != null && shouldDirectLoginConfigEnabled) {
             handleDiscoveryOrganizationStart(directLoginOrganization)
+        }
+    }
+
+    LaunchedEffect(shouldAutomaticallyCreateOrganization) {
+        if (shouldAutomaticallyCreateOrganization) {
+            handleDiscoveryOrganizationCreate()
         }
     }
 

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/UIWorkbenchActivity.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/UIWorkbenchActivity.kt
@@ -177,6 +177,19 @@ class UIWorkbenchActivity : ComponentActivity() {
                 )
                 onAuthenticated(::onAuthentication)
             }.build()
+    private val discoveryConfigWithDirectCreateOrganization =
+        StytchB2BUI
+            .Builder()
+            .apply {
+                activity(this@UIWorkbenchActivity)
+                productConfig(
+                    defaultConfig.copy(
+                        authFlowType = AuthFlowType.DISCOVERY,
+                        directCreateOrganizationForNoMembership = true,
+                    ),
+                )
+                onAuthenticated(::onAuthentication)
+            }.build()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -211,6 +224,9 @@ class UIWorkbenchActivity : ComponentActivity() {
                 }
                 Button(onClick = discoveryConfigWithEOTP::authenticate) {
                     Text("Launch Discovery Flow With EOTP Authentication")
+                }
+                Button(onClick = discoveryConfigWithDirectCreateOrganization::authenticate) {
+                    Text("Launch Discovery Flow With Direct Create Org")
                 }
                 Button(onClick = { StytchB2BClient.sessions.revoke(B2BSessions.RevokeParams(true)) {} }) {
                     Text("Log out")


### PR DESCRIPTION
Linear Ticket: [SDK-2382](https://linear.app/stytch/issue/SDK-2382)

## Changes:

1. Adds support for directOrgCreationOnZeroMemberships configuration option, for parity with JS SDK

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A