### PR TITLE
SDK-2389 Provide alternative/simpler OAuth and SSO methods

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.35.0"
+extra["PUBLISH_VERSION"] = "0.36.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
@@ -1,9 +1,11 @@
 package com.stytch.sdk.b2b.oauth
 
 import android.app.Activity
+import androidx.activity.ComponentActivity
 import com.stytch.sdk.b2b.OAuthAuthenticateResponse
 import com.stytch.sdk.b2b.OAuthDiscoveryAuthenticateResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -12,6 +14,8 @@ import java.util.concurrent.CompletableFuture
  * configured them within your Stytch Dashboard.
  */
 public interface OAuth {
+    public fun setOAuthReceiverActivity(activity: ComponentActivity?)
+
     /**
      * An interface describing the methods and parameters available for starting an OAuth or OAuth discovery flow
      * for a specific provider
@@ -59,6 +63,28 @@ public interface OAuth {
          * Exposes an instance of the [ProviderDiscovery] interface
          */
         public val discovery: ProviderDiscovery
+
+        public data class GetTokenForProviderParams
+            @JvmOverloads
+            constructor(
+                val organizationId: String? = null,
+                val organizationSlug: String? = null,
+                val loginRedirectUrl: String? = null,
+                val signupRedirectUrl: String? = null,
+                val customScopes: List<String>? = null,
+                val providerParams: Map<String, String>? = null,
+            )
+
+        public suspend fun getTokenForProvider(parameters: GetTokenForProviderParams): StytchResult<String>
+
+        public fun getTokenForProvider(
+            parameters: GetTokenForProviderParams,
+            callback: (StytchResult<String>) -> Unit,
+        )
+
+        public fun getTokenForProviderCompletable(
+            parameters: GetTokenForProviderParams,
+        ): CompletableFuture<StytchResult<String>>
     }
 
     /**
@@ -94,6 +120,39 @@ public interface OAuth {
          * @param parameters the parameters necessary to start the flow
          */
         public fun start(parameters: DiscoveryStartParameters)
+
+        /**
+         * Data class used for wrapping parameters to start a third party OAuth flow and retrieve a token
+         * @property loginRedirectUrl The url an existing user is redirected to after authenticating with the identity
+         * provider. This should be a url that redirects back to your app. If this value is not passed, the default
+         * login redirect URL set in the Stytch Dashboard is used. If you have not set a default login redirect URL,
+         * an error is returned.
+         * @property signupRedirectUrl The url a new user is redirected to after authenticating with the identity
+         * provider.
+         * This should be a url that redirects back to your app. If this value is not passed, the default sign-up
+         * redirect URL set in the Stytch Dashboard is used. If you have not set a default sign-up redirect URL, an
+         * error is returned.
+         * @property customScopes Any additional scopes to be requested from the identity provider
+         * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
+         */
+        public data class GetTokenForProviderParams
+            @JvmOverloads
+            constructor(
+                val discoveryRedirectUrl: String? = null,
+                val customScopes: List<String>? = null,
+                val providerParams: Map<String, String>? = null,
+            )
+
+        public suspend fun getTokenForProvider(parameters: GetTokenForProviderParams): StytchResult<String>
+
+        public fun getTokenForProvider(
+            parameters: GetTokenForProviderParams,
+            callback: (StytchResult<String>) -> Unit,
+        )
+
+        public fun getTokenForProviderCompletable(
+            parameters: GetTokenForProviderParams,
+        ): CompletableFuture<StytchResult<String>>
     }
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import android.app.Activity
+import androidx.activity.ComponentActivity
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
@@ -13,6 +14,7 @@ import com.stytch.sdk.b2b.SSOAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -26,6 +28,8 @@ import java.util.concurrent.CompletableFuture
  * - SAML
  */
 public interface SSO {
+    public fun setSSOReceiverActivity(activity: ComponentActivity?)
+
     /**
      * Data class used for wrapping parameters used in SSO start calls
      * @property context
@@ -55,6 +59,39 @@ public interface SSO {
      * @param params required for beginning an SSO authentication flow
      */
     public fun start(params: StartParams)
+
+    /**
+     * Data class used for wrapping parameters to start a third party OAuth flow and retrieve a token
+     * @property loginRedirectUrl The url an existing user is redirected to after authenticating with the identity
+     * provider. This should be a url that redirects back to your app. If this value is not passed, the default
+     * login redirect URL set in the Stytch Dashboard is used. If you have not set a default login redirect URL,
+     * an error is returned.
+     * @property signupRedirectUrl The url a new user is redirected to after authenticating with the identity
+     * provider.
+     * This should be a url that redirects back to your app. If this value is not passed, the default sign-up
+     * redirect URL set in the Stytch Dashboard is used. If you have not set a default sign-up redirect URL, an
+     * error is returned.
+     * @property customScopes Any additional scopes to be requested from the identity provider
+     * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
+     */
+    public data class GetTokenForProviderParams
+        @JvmOverloads
+        constructor(
+            val connectionId: String,
+            val loginRedirectUrl: String? = null,
+            val signupRedirectUrl: String? = null,
+        )
+
+    public suspend fun getTokenForProvider(parameters: GetTokenForProviderParams): StytchResult<String>
+
+    public fun getTokenForProvider(
+        parameters: GetTokenForProviderParams,
+        callback: (StytchResult<String>) -> Unit,
+    )
+
+    public fun getTokenForProviderCompletable(
+        parameters: GetTokenForProviderParams,
+    ): CompletableFuture<StytchResult<String>>
 
     /**
      * Data class used for wrapping parameters used in SSO Authenticate calls

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -202,3 +202,5 @@ public data object NoURIFound : StytchSDKError("No OAuth URI could be found in t
 public data object UserCanceled : StytchSDKError("The user canceled the OAuth flow")
 
 public data object NoActivityProvided : StytchSDKError("You must supply a receiver activity before calling this method")
+
+public data object UnknownOAuthOrSSOError : StytchSDKError("The OAuth or SSO flow completed unexpectedly")

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -194,3 +194,11 @@ public data class UnexpectedCredentialType(
 ) : StytchSDKError(
         message = "Unexpected type of credential: $credentialType",
     )
+
+public data object NoBrowserFound : StytchSDKError("No supported browser was found on this device")
+
+public data object NoURIFound : StytchSDKError("No OAuth URI could be found in the bundle")
+
+public data object UserCanceled : StytchSDKError("The user canceled the OAuth flow")
+
+public data object NoActivityProvided : StytchSDKError("You must supply a receiver activity before calling this method")

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sso/ProvidedReceiverManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sso/ProvidedReceiverManager.kt
@@ -53,5 +53,8 @@ internal object ProvidedReceiverManager {
                 continuation?.resume(response)
                 continuation = null
             }
+        if (activity == null) {
+            continuation = null
+        }
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sso/ProvidedReceiverManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sso/ProvidedReceiverManager.kt
@@ -1,0 +1,57 @@
+package com.stytch.sdk.common.sso
+
+import android.app.Activity.RESULT_OK
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import com.stytch.sdk.common.QUERY_TOKEN
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.NoBrowserFound
+import com.stytch.sdk.common.errors.NoURIFound
+import com.stytch.sdk.common.errors.UnknownOAuthOrSSOError
+import com.stytch.sdk.common.errors.UserCanceled
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+
+internal object ProvidedReceiverManager {
+    private var activity: ComponentActivity? = null
+    private var continuation: Continuation<StytchResult<String>>? = null
+    private var launcher: ActivityResultLauncher<Intent>? = null
+
+    internal fun getReceiverConfiguration(
+        continuation: Continuation<StytchResult<String>>,
+    ): Pair<ComponentActivity?, ActivityResultLauncher<Intent>?> {
+        this.continuation = continuation
+        return Pair(activity, launcher)
+    }
+
+    internal fun configureReceiver(activity: ComponentActivity?) {
+        this.activity = activity
+        launcher =
+            activity?.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                val response =
+                    when (result.resultCode) {
+                        RESULT_OK -> {
+                            result.data?.data?.getQueryParameter(QUERY_TOKEN)?.let {
+                                StytchResult.Success(it)
+                            } ?: StytchResult.Error(NoURIFound)
+                        }
+
+                        else -> {
+                            val error =
+                                result.data?.extras?.getSerializable(SSOError.SSO_EXCEPTION)?.let {
+                                    when (it as SSOError) {
+                                        is SSOError.UserCanceled -> UserCanceled
+                                        is SSOError.NoBrowserFound -> NoBrowserFound
+                                        is SSOError.NoURIFound -> NoURIFound
+                                    }
+                                } ?: UnknownOAuthOrSSOError
+                            StytchResult.Error(error)
+                        }
+                    }
+                continuation?.resume(response)
+                continuation = null
+            }
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sso/SSOManagerActivity.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sso/SSOManagerActivity.kt
@@ -146,9 +146,7 @@ internal class SSOManagerActivity : Activity() {
             return intent
         }
 
-        internal fun createBaseIntent(context: Context): Intent {
-            return Intent(context, SSOManagerActivity::class.java)
-        }
+        internal fun createBaseIntent(context: Context): Intent = Intent(context, SSOManagerActivity::class.java)
 
         internal const val URI_KEY = "uri"
         private const val KEY_AUTHORIZATION_STARTED = "authStarted"

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
@@ -1,7 +1,9 @@
 package com.stytch.sdk.consumer.oauth
 
 import android.app.Activity
+import androidx.activity.ComponentActivity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.consumer.NativeOAuthResponse
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 import java.util.concurrent.CompletableFuture
@@ -167,6 +169,8 @@ public interface OAuth {
         public fun signOut(activity: Activity)
     }
 
+    public fun setOAuthReceiverActivity(activity: ComponentActivity?)
+
     /**
      * Provides a method for starting Third Party OAuth authentications
      */
@@ -220,6 +224,40 @@ public interface OAuth {
          * @param parameters required to start the OAuth flow
          */
         public fun start(parameters: StartParameters)
+
+        /**
+         * Data class used for wrapping parameters to start a third party OAuth flow and retrieve a token
+         * @property loginRedirectUrl The url an existing user is redirected to after authenticating with the identity
+         * provider. This should be a url that redirects back to your app. If this value is not passed, the default
+         * login redirect URL set in the Stytch Dashboard is used. If you have not set a default login redirect URL,
+         * an error is returned.
+         * @property signupRedirectUrl The url a new user is redirected to after authenticating with the identity
+         * provider.
+         * This should be a url that redirects back to your app. If this value is not passed, the default sign-up
+         * redirect URL set in the Stytch Dashboard is used. If you have not set a default sign-up redirect URL, an
+         * error is returned.
+         * @property customScopes Any additional scopes to be requested from the identity provider
+         * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
+         */
+        public data class GetTokenForProviderParams
+            @JvmOverloads
+            constructor(
+                val loginRedirectUrl: String? = null,
+                val signupRedirectUrl: String? = null,
+                val customScopes: List<String>? = null,
+                val providerParams: Map<String, String>? = null,
+            )
+
+        public suspend fun getTokenForProvider(parameters: GetTokenForProviderParams): StytchResult<String>
+
+        public fun getTokenForProvider(
+            parameters: GetTokenForProviderParams,
+            callback: (StytchResult<String>) -> Unit,
+        )
+
+        public fun getTokenForProviderCompletable(
+            parameters: GetTokenForProviderParams,
+        ): CompletableFuture<StytchResult<String>>
     }
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
@@ -1,8 +1,17 @@
 package com.stytch.sdk.consumer.oauth
 
+import android.app.Activity.RESULT_CANCELED
+import android.app.Activity.RESULT_OK
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import com.stytch.sdk.common.QUERY_TOKEN
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.NoURIFound
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
+import com.stytch.sdk.common.errors.UserCanceled
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 import com.stytch.sdk.consumer.StytchClient
@@ -15,6 +24,8 @@ import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
 
 internal class OAuthImpl(
     private val externalScope: CoroutineScope,
@@ -23,6 +34,42 @@ internal class OAuthImpl(
     private val api: StytchApi.OAuth,
     private val pkcePairManager: PKCEPairManager,
 ) : OAuth {
+    private var oauthReceiverActivity: ComponentActivity? = null
+
+    private var continuation: Continuation<StytchResult<String>>? = null
+    private var launcher: ActivityResultLauncher<Intent>? = null
+
+    private fun getOAuthReceiver(
+        continuation: Continuation<StytchResult<String>>,
+    ): Pair<ComponentActivity?, ActivityResultLauncher<Intent>?> {
+        this.continuation = continuation
+        return Pair(oauthReceiverActivity, launcher)
+    }
+
+    override fun setOAuthReceiverActivity(activity: ComponentActivity?) {
+        oauthReceiverActivity = activity
+        launcher =
+            activity?.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                val response =
+                    when (result.resultCode) {
+                        RESULT_OK -> {
+                            result.data?.data?.getQueryParameter(QUERY_TOKEN)?.let {
+                                StytchResult.Success(it)
+                            } ?: StytchResult.Error(NoURIFound)
+                        }
+
+                        RESULT_CANCELED -> {
+                            StytchResult.Error(UserCanceled)
+                        }
+
+                        else -> {
+                            StytchResult.Error(UserCanceled) // TODO: Fix this
+                        }
+                    }
+                continuation?.resume(response)
+            }
+    }
+
     override val googleOneTap: OAuth.GoogleOneTap =
         GoogleOneTapImpl(
             externalScope,
@@ -32,25 +79,158 @@ internal class OAuthImpl(
             GoogleCredentialManagerProviderImpl(),
             pkcePairManager,
         )
-    override val apple: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "apple")
-    override val amazon: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "amazon")
-    override val bitbucket: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "bitbucket")
-    override val coinbase: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "coinbase")
-    override val discord: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "discord")
-    override val facebook: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "facebook")
-    override val figma: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "figma")
-    override val github: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "github")
-    override val gitlab: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "gitlab")
-    override val google: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "google")
-    override val linkedin: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "linkedin")
-    override val microsoft: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "microsoft")
-    override val salesforce: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "salesforce")
-    override val slack: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "slack")
-    override val snapchat: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "snapchat")
-    override val tiktok: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "tiktok")
-    override val twitch: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "twitch")
-    override val twitter: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "twitter")
-    override val yahoo: OAuth.ThirdParty = ThirdPartyOAuthImpl(pkcePairManager, providerName = "yahoo")
+    override val apple: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "apple",
+            ::getOAuthReceiver,
+        )
+    override val amazon: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "amazon",
+            ::getOAuthReceiver,
+        )
+    override val bitbucket: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "bitbucket",
+            ::getOAuthReceiver,
+        )
+    override val coinbase: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "coinbase",
+            ::getOAuthReceiver,
+        )
+    override val discord: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "discord",
+            ::getOAuthReceiver,
+        )
+    override val facebook: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "facebook",
+            ::getOAuthReceiver,
+        )
+    override val figma: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "figma",
+            ::getOAuthReceiver,
+        )
+    override val github: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "github",
+            ::getOAuthReceiver,
+        )
+    override val gitlab: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "gitlab",
+            ::getOAuthReceiver,
+        )
+    override val google: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "google",
+            ::getOAuthReceiver,
+        )
+    override val linkedin: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "linkedin",
+            ::getOAuthReceiver,
+        )
+    override val microsoft: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "microsoft",
+            ::getOAuthReceiver,
+        )
+    override val salesforce: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "salesforce",
+            ::getOAuthReceiver,
+        )
+    override val slack: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "slack",
+            ::getOAuthReceiver,
+        )
+    override val snapchat: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "snapchat",
+            ::getOAuthReceiver,
+        )
+    override val tiktok: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "tiktok",
+            ::getOAuthReceiver,
+        )
+    override val twitch: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "twitch",
+            ::getOAuthReceiver,
+        )
+    override val twitter: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "twitter",
+            ::getOAuthReceiver,
+        )
+    override val yahoo: OAuth.ThirdParty =
+        ThirdPartyOAuthImpl(
+            externalScope,
+            dispatchers,
+            pkcePairManager,
+            providerName = "yahoo",
+            ::getOAuthReceiver,
+        )
 
     override suspend fun authenticate(parameters: OAuth.ThirdParty.AuthenticateParameters): OAuthAuthenticatedResponse {
         return withContext(dispatchers.io) {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
@@ -1,17 +1,35 @@
 package com.stytch.sdk.consumer.oauth
 
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
 import com.stytch.sdk.common.LIVE_API_URL
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.TEST_API_URL
+import com.stytch.sdk.common.errors.NoActivityProvided
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.sso.SSOManagerActivity.Companion.URI_KEY
 import com.stytch.sdk.common.utils.buildUri
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.StytchApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.Continuation
 
 internal class ThirdPartyOAuthImpl(
+    private val externalScope: CoroutineScope,
+    private val dispatchers: StytchDispatchers,
     private val pkcePairManager: PKCEPairManager,
     override val providerName: String,
+    private val getOAuthReceiver: (
+        Continuation<StytchResult<String>>,
+    ) -> Pair<ComponentActivity?, ActivityResultLauncher<Intent>?>,
 ) : OAuth.ThirdParty {
     override fun start(parameters: OAuth.ThirdParty.StartParameters) {
         val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
@@ -35,4 +53,55 @@ internal class ThirdPartyOAuthImpl(
         intent.putExtra(URI_KEY, requestUri.toString())
         parameters.context.startActivityForResult(intent, parameters.oAuthRequestIdentifier)
     }
+
+    override suspend fun getTokenForProvider(
+        parameters: OAuth.ThirdParty.GetTokenForProviderParams,
+    ): StytchResult<String> =
+        suspendCancellableCoroutine { continuation ->
+            getOAuthReceiver(continuation).let { (activity, launcher) ->
+                if (activity == null || launcher == null) {
+                    continuation.resume(
+                        StytchResult.Error(NoActivityProvided),
+                    ) { cause, _, _ -> continuation.cancel(cause) }
+                    return@suspendCancellableCoroutine
+                }
+                val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
+                val token = StytchApi.publicToken
+                val host =
+                    StytchClient.bootstrapData.cnameDomain?.let {
+                        "https://$it/v1/"
+                    } ?: if (StytchApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                val baseUrl = "${host}public/oauth/$providerName/start"
+                val potentialParameters =
+                    mapOf(
+                        "public_token" to token,
+                        "code_challenge" to pkce,
+                        "login_redirect_url" to parameters.loginRedirectUrl,
+                        "signup_redirect_url" to parameters.signupRedirectUrl,
+                        "custom_scopes" to parameters.customScopes,
+                        "provider_params" to parameters.providerParams,
+                    )
+                val requestUri = buildUri(baseUrl, potentialParameters)
+                val intent = SSOManagerActivity.createBaseIntent(activity)
+                intent.putExtra(URI_KEY, requestUri.toString())
+                launcher.launch(intent)
+            }
+        }
+
+    override fun getTokenForProvider(
+        parameters: OAuth.ThirdParty.GetTokenForProviderParams,
+        callback: (StytchResult<String>) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            callback(getTokenForProvider(parameters))
+        }
+    }
+
+    override fun getTokenForProviderCompletable(
+        parameters: OAuth.ThirdParty.GetTokenForProviderParams,
+    ): CompletableFuture<StytchResult<String>> =
+        externalScope
+            .async {
+                getTokenForProvider(parameters)
+            }.asCompletableFuture()
 }

--- a/tutorials/OAuth.md
+++ b/tutorials/OAuth.md
@@ -1,21 +1,25 @@
-# OAuth
-The Stytch Android SDK supports two types of OAuth flows: Third Party (redirect) and Native (Google OneTap/CredentialManager), both of which can be configured in the Stytch Dashboard.
+# OAuth / SSO
+The Stytch Android SDK supports browser-based redirect flows for OAuth and SSO (B2B SDK only), as well as Native OAuth (Google OneTap/CredentialManager; Consumer SDK only)
 
 The configuration necessary for each type of flow is different, so read on to see how to set each up.
 
-To see all of the currently supported providers, check the properties of the [OAuth interface](../source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt).
+To see all of the currently supported OAuth providers, check the properties of the [Consumer ](../source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt) and [B2B](../source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt) OAuth interfaces.
 
-## Third Party (Redirect)
-Third-party/Redirect OAuth is the OAuth you may be most familiar with on the web: You click a button, are redirected to the selected IdP, login, and are redirected back to the original webpage. The same concept applies with the Stytch Android SDK, except the redirects are handled in a browser activity, and the backstack is managed by the SDK.
+## Redirect
+Redirect OAuth/SSO is the OAuth/SSO you may be most familiar with on the web: You click a button, are redirected to the selected IdP, login, and are redirected back to the original webpage. The same concept applies with the Stytch Android SDK, except the redirects are handled in a browser activity, and the backstack is managed by the SDK.
 
 To accomplish this, the SDK uses a multi-activity pattern that handles all of the redirect and backstack management logic to ensure the backstack stays clean, and activities are finished in the correct order. If you were wondering why, in the getting started [README](../README.md), you needed to add manifest-placeholders for `stytchOAuthRedirectScheme` and `stytchOAuthRedirectHost`, it's to enable this functionality. Let's dig into those placeholders a little more.
 
-When you provide these placeholders, the SDK registers an activity intent-filter for our "receiver" activity. When you `start` a third-party OAuth flow, the SDK launches a "manager" activity, which launches an "authorization" activity (the best system browser we can detect on device). Depending on the outcome of that authorization activity (user sign in, user canceled, etc), the authorization activity will either `finish` itself and return to the manager activity, or launch our receiver activity (identified by the manifest-placeholders), which will in turn launch our manager activity in such a way that ensures all previous activities in the flow are removed from the backstack. The manager activity will then report an activity intent result back to your activity, which you can listen for to authenticate the user and direct them as appropriate.
+When you provide these placeholders, the SDK registers an activity intent-filter for our "receiver" activity. When you start a redirect-based OAuth flow, the SDK launches a "manager" activity, which launches an "authorization" activity (the best system browser we can detect on device). Depending on the outcome of that authorization activity (user sign in, user canceled, etc), the authorization activity will either `finish` itself and return to the manager activity, or launch our receiver activity (identified by the manifest-placeholders), which will in turn launch our manager activity in such a way that ensures all previous activities in the flow are removed from the backstack.
 
 For a deeper understanding of the third-party OAuth architecture, check out the [OAuth/SSO README](../source/sdk/src/main/java/com/stytch/sdk/common/sso/README.md).
 
+There are two ways to listen for the result of this flow:
+1. **Activity Result Callback -** Define an activity result callback in your activity, and use the appropriate `.start()` method. The manager activity will then report back to your activity, which you can listen for to authenticate the user and direct them as appropriate.
+2. **Direct Token Capture -** Configure the OAuth/SSO client with your currently running activity (using `oauth.setOAuthReceiverActivity()`/`sso.setSSOReceiverActivity()`, and use the appropriate `getTokenForProvider()` method. Under the hood, this works the same way as the first option, but will return the final token to the coroutine/callback/CompletableFuture. This method is a little easier to setup, as you don't need to specify an activity result listener, or parse the returned link manually
+
 ### Example Code
-For this example, we're going to use a redirect path of `my-app://oauth?type={}`, so make sure to add that as a valid redirect URL for the `Login` and `Signup` types in your Stytch Dashboard's [Redirect URL settings](stytch.com/dashboard/redirect-urls). You will also need to configure an [OAuth provider](https://stytch.com/dashboard/oauth). In this example, we are using GitHub.
+For both flows in the following examples, we're going to use a redirect path of `my-app://oauth?type={}`, so make sure to add that as a valid redirect URL for the `Login` and `Signup` types in your Stytch Dashboard's [Redirect URL settings](stytch.com/dashboard/redirect-urls). You will also need to configure an [OAuth provider](https://stytch.com/dashboard/oauth). In this example, we are using GitHub.
 
 Next, in your app's `build.gradle(.kts)`,  add the appropriate manifest placeholders:
 ```gradle
@@ -30,8 +34,8 @@ android {
     }
 }
 ```
-Third, create the activity result handler in your main activity:
-
+#### Activity Result Callback flow:
+For this flow,  you will need to create an activity result handler in your main activity:
 ```kotlin
 class MainActivity : FragmentActivity() {
     ...
@@ -49,7 +53,7 @@ class MainActivity : FragmentActivity() {
     }
 }
 ```
-Fourth, jump into the viewmodel to define your `start` and `authenticate` handlers:
+Then, jump into the viewmodel to define your `start` and `authenticate` handlers:
 ```kotlin
 class MyViewModel : ViewModel() {
     // you'll call this method from your activity and pass in the activity context in order to launch intents
@@ -100,6 +104,65 @@ class MyViewModel : ViewModel() {
 Put it all together by calling your start method from your activity:
 ```kotlin
 viewModel.loginWithGitHub(this)
+```
+
+#### Direct Token Capture flow:
+For the Direct Token Capture flow, you will need to configure the OAuth/SSO client with a compatible `ComponentActivity` (required for using the `registerForActivityResult` API) and use the `getTokenForProvider()` method (instead of `start()`).
+
+First, configure the Stytch client from your calling activity:
+```kotlin
+class MainActivity : FragmentActivity() {
+	override fun onCreate(savedInstanceState: Bundle?) {
+	    super.onCreate(savedInstanceState)
+        StytchClient.oauth.setOAuthReceiverActivity(this)
+        ...
+    }
+    override fun onDestroy() {  
+	    super.onDestroy()  
+	    StytchClient.oauth.setOAuthReceiverActivity(null)
+	    ...
+	}
+	...
+}
+```
+
+Second, configure your authentication flow in your viewmodel:
+```kotlin
+class MyViewModel : ViewModel() {
+    fun loginWithGithub() {
+        val startParameters =
+            OAuth.ThirdParty.GetTokenForProviderParams(
+                loginRedirectUrl = "app://oauth?type={}",
+                signupRedirectUrl = "app://oauth?type={}",
+            )
+        viewModelScope.launch {
+            when (val token = StytchClient.oauth.github.getTokenForProvider(startParameters)) {
+                is StytchResult.Success -> {
+                    val authenticateParameters =
+                        OAuth.ThirdParty.AuthenticateParameters(
+                            token = token.value,
+                            sessionDurationMinutes = 30,
+                        )
+                    when (val result = StytchClient.oauth.authenticate(authenticateParameters)) {
+                        is StytchResult.Success -> {
+                            // OAuth authentication succeeded
+                        }
+                        is StytchResult.Error -> {
+                            // OAuth authentication failed
+                        }
+                    }
+                }
+                is StytchResult.Error -> {
+                    // OAuth start flow failed
+                }
+            }
+        }
+    }
+}
+```
+Lastly, call the method from your UI:
+```kotlin
+viewmodel.loginWithGitHub()
 ```
 
 ## Native (Google OneTap/CredentialManager)

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/HeadlessWorkbenchActivity.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/HeadlessWorkbenchActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.fragment.app.FragmentActivity
 import com.stytch.exampleapp.b2b.theme.AppTheme
 import com.stytch.exampleapp.b2b.ui.AppScreen
+import com.stytch.sdk.b2b.StytchB2BClient
 
 internal const val SSO_REQUEST_ID = 2
 internal const val B2B_OAUTH_REQUEST = 3
@@ -26,6 +27,8 @@ class HeadlessWorkbenchActivity : FragmentActivity() {
     private val scimViewModel: SCIMViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        StytchB2BClient.oauth.setOAuthReceiverActivity(this)
+        StytchB2BClient.sso.setSSOReceiverActivity(this)
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
@@ -47,6 +50,12 @@ class HeadlessWorkbenchActivity : FragmentActivity() {
         if (intent.action == Intent.ACTION_VIEW) {
             handleIntent(intent)
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        StytchB2BClient.oauth.setOAuthReceiverActivity(null)
+        StytchB2BClient.sso.setSSOReceiverActivity(null)
     }
 
     private fun handleIntent(intent: Intent) {

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/OAuthScreen.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/OAuthScreen.kt
@@ -41,6 +41,16 @@ fun OAuthScreen(viewModel: OAuthViewModel) {
                 text = stringResource(id = R.string.oauth_discovery_start),
                 onClick = { viewModel.startGoogleDiscoveryOAuthFlow(context) },
             )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.oauth_start_oneshot),
+                onClick = { viewModel.startGoogleOauthFlowOneShot() },
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.oauth_discovery_start_oneshot),
+                onClick = { viewModel.startGoogleDiscoveryOauthFlowOneShot() },
+            )
         }
         Column(
             modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/SSOScreen.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/SSOScreen.kt
@@ -78,6 +78,11 @@ fun SSOScreen(viewModel: SSOViewModel) {
             )
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.sso_start_oneshot),
+                onClick = { viewModel.startSSOOneShot() },
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.sso_get_connections),
                 onClick = viewModel::getConnections,
             )

--- a/workbench-apps/b2b-workbench/src/main/res/values/strings.xml
+++ b/workbench-apps/b2b-workbench/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="sso">SSO</string>
     <string name="sso_connection_id">Connection ID</string>
     <string name="sso_start">Start SSO Flow</string>
+    <string name="sso_start_oneshot">Start SSO Oneshot Flow</string>
     <string name="sso_metadata_url">Metadata URL</string>
     <string name="sso_certificate_id">Certificate ID</string>
     <string name="sso_get_connections">Get Connections</string>
@@ -77,6 +78,8 @@
     <string name="oauth">OAuth</string>
     <string name="oauth_start">Start Google OAuth flow</string>
     <string name="oauth_discovery_start">Start Google Discovery OAuth flow</string>
+    <string name="oauth_start_oneshot">Start Google OAuth Oneshot flow</string>
+    <string name="oauth_discovery_start_oneshot">Start Google Discovery OAuth Oneshot flow</string>
     <string name="organization_search">Search Orgs By Slug</string>
     <string name="organization_member_search">Search Member By Email &amp; Org Id</string>
     <string name="get_pkce_code_pair">Get PKCE Code Pair</string>

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/MainActivity.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.auth.api.phone.SmsRetriever
 import com.stytch.exampleapp.theme.AppTheme
 import com.stytch.exampleapp.ui.AppScreen
+import com.stytch.sdk.consumer.StytchClient
 
 private const val SMS_CONSENT_REQUEST = 2
 const val THIRD_PARTY_OAUTH_REQUEST = 4
@@ -20,6 +21,7 @@ class MainActivity : FragmentActivity() {
     private val oauthViewModel: OAuthViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        StytchClient.oauth.setOAuthReceiverActivity(this)
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
@@ -29,6 +31,11 @@ class MainActivity : FragmentActivity() {
         if (intent.action == Intent.ACTION_VIEW) {
             handleIntent(intent)
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        StytchClient.oauth.setOAuthReceiverActivity(null)
     }
 
     private fun handleIntent(intent: Intent) {

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/ui/OAuthScreen.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/ui/OAuthScreen.kt
@@ -79,6 +79,11 @@ fun OAuthScreen(viewModel: OAuthViewModel) {
             )
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.oauth_github_oneshot),
+                onClick = { viewModel.loginWithThirdPartyOAuthOneShot(OAuthProvider.GITHUB) },
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.oauth_gitlab),
                 onClick = { viewModel.loginWithThirdPartyOAuth(context, OAuthProvider.GITLAB) },
             )

--- a/workbench-apps/consumer-workbench/src/main/res/values/strings.xml
+++ b/workbench-apps/consumer-workbench/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="oauth_google_onetap">Login with Google OneTap</string>
     <string name="oauth_google_thirdparty">Login with Google (Legacy)</string>
     <string name="oauth_github">Login with Github</string>
+    <string name="oauth_github_oneshot">Login with Github (Oneshot)</string>
     <string name="oauth_gitlab">Login With Gitlab</string>
     <string name="oauth_linkedin">Login With Linkedin</string>
     <string name="oauth_microsoft">Login With Microsoft</string>


### PR DESCRIPTION
Linear Ticket: [SDK-2389](https://linear.app/stytch/issue/SDK-2389)

## Changes:

1. Adds new `getTokenForProvider` methods to B2C OAuth, B2B OAuth, B2B OAuth Discovery, and B2B SSO flows. This method allows developers to create "oneshot" login methods, similar to the iOS implementation, where we have a "start" flow that just returns a token, and can be combined/chained with the `authenticate` method. This makes configuring/using OAuth/SSO a bit simpler, as it removes the need for configuring activity result listeners and URL parsing the result.
2. Adds methods to workbench apps for testing
3. Updates OAuth tutorial to explain this new flow
4. Bumps version

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A