### PR TITLE
SDK-2418 Use new explicit StytchAPIErrorType enum

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
@@ -3,14 +3,14 @@ package com.stytch.sdk.common.errors
 /**
  * An error class representing a non-schema error that occurs in the Stytch API
  * @property requestId the request id of the request that triggered this error
- * @property errorType a Stytch-specific string representing the type of error that occurred
+ * @property errorType a Stytch-specific error type representing the type of error that occurred
  * @property message a string providing more information about what went wrong. This may or may not be user-friendly
  * @property url a url linking to the Stytch documentation that describes this error
  * @property statusCode the HTTP status code that was returned for this request
  */
 public data class StytchAPIError(
     public val requestId: String? = null,
-    public val errorType: String,
+    public val errorType: StytchAPIErrorType,
     public override val message: String,
     public val url: String? = null,
     public val statusCode: Int,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIErrorType.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIErrorType.kt
@@ -1,7 +1,9 @@
 package com.stytch.sdk.common.errors
 import java.util.Locale
 
-public enum class StytchAPIErrorType(public val type: String) {
+public enum class StytchAPIErrorType(
+    public val type: String,
+) {
     ACTION_AVAILABLE_ONLY_FOR_ACTIVE_MEMBERS(
         type = "action_available_only_for_active_members",
     ),
@@ -2175,8 +2177,10 @@ public enum class StytchAPIErrorType(public val type: String) {
 
     internal companion object {
         fun fromString(typeString: String?): StytchAPIErrorType =
-            typeString?.uppercase(Locale.ENGLISH)?.let {
-                valueOf(it)
-            } ?: UNKNOWN_ERROR
+            try {
+                valueOf(typeString?.uppercase(Locale.ENGLISH)!!)
+            } catch (_: Exception) {
+                UNKNOWN_ERROR
+            }
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/extensions/HttpExceptionExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/extensions/HttpExceptionExt.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.common.extensions
 import com.squareup.moshi.Moshi
 import com.stytch.sdk.common.StytchLog
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchAPISchemaError
 import com.stytch.sdk.common.errors.StytchAPIUnreachableError
 import com.stytch.sdk.common.errors.StytchError
@@ -42,7 +43,7 @@ internal fun HttpException.toStytchError(): StytchError {
     return when (parsedErrorResponse) {
         is StytchErrorResponse ->
             StytchAPIError(
-                errorType = parsedErrorResponse.errorType,
+                errorType = StytchAPIErrorType.fromString(parsedErrorResponse.errorType),
                 message = parsedErrorResponse.errorMessage ?: "",
                 url = parsedErrorResponse.errorUrl,
                 requestId = parsedErrorResponse.requestId,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/extensions/HttpExceptionExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/extensions/HttpExceptionExt.kt
@@ -41,14 +41,18 @@ internal fun HttpException.toStytchError(): StytchError {
         }
     StytchLog.w("http error code: $errorCode, errorResponse: $parsedErrorResponse")
     return when (parsedErrorResponse) {
-        is StytchErrorResponse ->
+        is StytchErrorResponse -> {
+            val errorType = StytchAPIErrorType.fromString(parsedErrorResponse.errorType)
             StytchAPIError(
-                errorType = StytchAPIErrorType.fromString(parsedErrorResponse.errorType),
-                message = parsedErrorResponse.errorMessage ?: "",
+                errorType = errorType,
+                message =
+                    (if (errorType == StytchAPIErrorType.UNKNOWN_ERROR) source else parsedErrorResponse.errorMessage)
+                        ?: "",
                 url = parsedErrorResponse.errorUrl,
                 requestId = parsedErrorResponse.requestId,
                 statusCode = parsedErrorResponse.statusCode,
             )
+        }
         is StytchSchemaError ->
             StytchAPISchemaError(
                 message = "Request does not match expected schema: ${parsedErrorResponse.body}",

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.passwords.Passwords
 import com.stytch.sdk.ui.b2c.data.ApplicationUIState
@@ -93,7 +94,7 @@ internal class ReturningUserScreenViewModel(
                 is StytchResult.Error -> {
                     when (val exception = result.exception) {
                         is StytchAPIError -> {
-                            if (exception.errorType.contains("reset_password")) {
+                            if (exception.errorType == StytchAPIErrorType.RESET_PASSWORD) {
                                 sendPasswordResetAndNavigateAppropriately(
                                     email = uiState.value.emailState.emailAddress,
                                     passwordOptions = passwordOptions,

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -15,6 +15,7 @@ import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchDataResponse
@@ -945,7 +946,7 @@ internal class StytchB2BApiTest {
             every { StytchB2BApi.isInitialized } returns true
 
             fun mockApiCall(): StytchDataResponse<Boolean> =
-                throw StytchAPIError(errorType = "", message = "", statusCode = 400)
+                throw StytchAPIError(errorType = StytchAPIErrorType.UNKNOWN_ERROR, message = "", statusCode = 400)
             val result = StytchB2BApi.safeB2BApiCall { mockApiCall() }
             assert(result is StytchResult.Error)
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
@@ -96,7 +97,7 @@ internal class OAuthImplTest {
             every { mockPKCEPairManager.getPKCECodePair() } returns PKCECodePair("code-challenge", "code-verifier")
             coEvery { mockApi.authenticate(any(), any(), any(), any(), any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "something_went_wrong", message = "testing", statusCode = 400),
+                    StytchAPIError(errorType = StytchAPIErrorType.UNKNOWN_ERROR, message = "testing", statusCode = 400),
                 )
             val result = impl.authenticate(mockk(relaxed = true))
             require(result is StytchResult.Error)

--- a/source/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/common/errors/StytchErrorTests.kt
@@ -10,13 +10,13 @@ internal class StytchErrorTests {
         val error =
             StytchAPIError(
                 requestId = "request-id-1234",
-                errorType = "error_name",
+                errorType = StytchAPIErrorType.UNKNOWN_ERROR,
                 message = "error_description",
                 url = "https://stytch.com",
                 statusCode = 400,
             )
         assert(error.requestId == "request-id-1234")
-        assert(error.errorType == "error_name")
+        assert(error.errorType == StytchAPIErrorType.UNKNOWN_ERROR)
         assert(error.message == "error_description")
         assert(error.url == "https://stytch.com")
     }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchBiometricAuthenticationFailed
 import com.stytch.sdk.common.errors.StytchChallengeSigningFailed
 import com.stytch.sdk.common.errors.StytchInternalError
@@ -226,7 +227,7 @@ internal class BiometricsImplTest {
             } returns Pair(base64EncodedString, base64EncodedString)
             coEvery { mockApi.registerStart(base64EncodedString) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "", statusCode = 400),
+                    StytchAPIError(errorType = StytchAPIErrorType.UNKNOWN_ERROR, message = "", statusCode = 400),
                 )
             val result = impl.register(mockk(relaxed = true))
             require(result is StytchResult.Error)
@@ -377,7 +378,7 @@ internal class BiometricsImplTest {
             } returns "publicKey"
             coEvery { mockApi.authenticateStart("publicKey") } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "", statusCode = 400),
+                    StytchAPIError(errorType = StytchAPIErrorType.UNKNOWN_ERROR, message = "", statusCode = 400),
                 )
             val result = impl.authenticate(mockk(relaxed = true))
             require(result is StytchResult.Error)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchDataResponse
@@ -743,7 +744,7 @@ internal class StytchApiTest {
             every { StytchApi.isInitialized } returns true
 
             fun mockApiCall(): StytchDataResponse<Boolean> =
-                throw StytchAPIError(errorType = "", message = "", statusCode = 400)
+                throw StytchAPIError(errorType = StytchAPIErrorType.UNKNOWN_ERROR, message = "", statusCode = 400)
             val result = StytchApi.safeConsumerApiCall { mockApiCall() }
             assert(result is StytchResult.Error)
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
@@ -120,7 +121,7 @@ internal class OAuthImplTest {
             every { mockPKCEPairManager.getPKCECodePair() } returns PKCECodePair("code-challenge", "code-verifier")
             coEvery { mockApi.authenticateWithThirdPartyToken(any(), any(), any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "something_went_wrong", message = "testing", statusCode = 400),
+                    StytchAPIError(errorType = StytchAPIErrorType.UNKNOWN_ERROR, message = "testing", statusCode = 400),
                 )
             val result = impl.authenticate(mockk(relaxed = true))
             require(result is StytchResult.Error)

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.screens
 import androidx.lifecycle.SavedStateHandle
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.models.UserType
 import com.stytch.sdk.ui.b2c.data.EventState
@@ -330,7 +331,11 @@ internal class MainScreenViewModelTest {
             every { mockStytchClient.publicToken } returns "publicToken"
             coEvery { mockStytchClient.magicLinks.email.loginOrCreate(any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "Something went wrong", statusCode = 400),
+                    StytchAPIError(
+                        errorType = StytchAPIErrorType.UNKNOWN_ERROR,
+                        message = "Something went wrong",
+                        statusCode = 400,
+                    ),
                 )
             val route = viewModel.sendEmailMagicLinkForReturningUserAndGetNavigationRoute("", mockk(relaxed = true))
             assert(route == null)
@@ -360,7 +365,11 @@ internal class MainScreenViewModelTest {
         runTest(dispatcher) {
             coEvery { mockStytchClient.otps.email.loginOrCreate(any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "Something went wrong", statusCode = 400),
+                    StytchAPIError(
+                        errorType = StytchAPIErrorType.UNKNOWN_ERROR,
+                        message = "Something went wrong",
+                        statusCode = 400,
+                    ),
                 )
             val route = viewModel.sendEmailOTPForReturningUserAndGetNavigationRoute("", mockk(relaxed = true))
             assert(route == null)
@@ -389,7 +398,11 @@ internal class MainScreenViewModelTest {
             every { mockStytchClient.publicToken } returns "publicToken"
             coEvery { mockStytchClient.passwords.resetByEmailStart(any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "Something went wrong", statusCode = 400),
+                    StytchAPIError(
+                        errorType = StytchAPIErrorType.UNKNOWN_ERROR,
+                        message = "Something went wrong",
+                        statusCode = 400,
+                    ),
                 )
             val route = viewModel.sendResetPasswordForReturningUserAndGetNavigationRoute("", mockk(relaxed = true))
             assert(route == null)
@@ -428,7 +441,11 @@ internal class MainScreenViewModelTest {
             // error state
             coEvery { mockStytchClient.otps.sms.loginOrCreate(any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "Something went wrong", statusCode = 400),
+                    StytchAPIError(
+                        errorType = StytchAPIErrorType.UNKNOWN_ERROR,
+                        message = "Something went wrong",
+                        statusCode = 400,
+                    ),
                 )
             viewModel.sendSmsOTP(mockOptions, this)
             assert(!viewModel.uiState.value.showLoadingDialog)
@@ -467,7 +484,11 @@ internal class MainScreenViewModelTest {
             // error state
             coEvery { mockStytchClient.otps.whatsapp.loginOrCreate(any()) } returns
                 StytchResult.Error(
-                    StytchAPIError(errorType = "", message = "Something went wrong", statusCode = 400),
+                    StytchAPIError(
+                        errorType = StytchAPIErrorType.UNKNOWN_ERROR,
+                        message = "Something went wrong",
+                        statusCode = 400,
+                    ),
                 )
             viewModel.sendWhatsAppOTP(mockOptions, this)
             assert(!viewModel.uiState.value.showLoadingDialog)

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.screens
 import androidx.lifecycle.SavedStateHandle
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
@@ -109,7 +110,7 @@ internal class ReturningUserScreenViewModelTest {
                 mockk(relaxed = true) {
                     every { exception } returns
                         mockk<StytchAPIError> {
-                            every { errorType } returns "reset_password"
+                            every { errorType } returns StytchAPIErrorType.RESET_PASSWORD
                         }
                 }
             coEvery { mockStytchClient.passwords.authenticate(any()) } returns result
@@ -139,7 +140,7 @@ internal class ReturningUserScreenViewModelTest {
                 mockk(relaxed = true) {
                     every { exception } returns
                         mockk<StytchAPIError> {
-                            every { errorType } returns "reset_password"
+                            every { errorType } returns StytchAPIErrorType.RESET_PASSWORD
                         }
                 }
             coEvery { mockStytchClient.passwords.authenticate(any()) } returns result
@@ -161,7 +162,7 @@ internal class ReturningUserScreenViewModelTest {
                 mockk(relaxed = true) {
                     every { exception } returns
                         mockk<StytchAPIError> {
-                            every { errorType } returns "something_else"
+                            every { errorType } returns StytchAPIErrorType.UNKNOWN_ERROR
                             every { message } returns "Something happened in the API"
                         }
                 }


### PR DESCRIPTION
Linear Ticket: [SDK-2418](https://linear.app/stytch/issue/SDK-2418)

## Changes:

1. Updates all places that were using/expecting a string for API error types to use the new explicit enums

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A