### PR TITLE
SDK-2390 Prevent duplicate configure calls

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -133,6 +133,7 @@ public object StytchB2BClient {
         try {
             deviceInfo = context.getDeviceInfo()
             this.publicToken = publicToken
+            this.stytchClientOptions = options
             appSessionId = "app-session-id-${UUID.randomUUID()}"
             StorageHelper.initialize(context)
             sessionStorage = B2BSessionStorage(StorageHelper)

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -108,6 +108,8 @@ public object StytchB2BClient {
     @VisibleForTesting
     internal lateinit var appSessionId: String
 
+    private var stytchClientOptions: StytchClientOptions? = null
+
     /**
      * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
      * across app launches.
@@ -125,6 +127,9 @@ public object StytchB2BClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
+        if (::publicToken.isInitialized && publicToken == this.publicToken && options == this.stytchClientOptions) {
+            return callback(true)
+        }
         try {
             deviceInfo = context.getDeviceInfo()
             this.publicToken = publicToken

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -101,6 +101,8 @@ public object StytchClient {
     @VisibleForTesting
     internal lateinit var appSessionId: String
 
+    private var stytchClientOptions: StytchClientOptions? = null
+
     /**
      * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
      * across app launches.
@@ -118,8 +120,12 @@ public object StytchClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
+        if (::publicToken.isInitialized && publicToken == this.publicToken && options == this.stytchClientOptions) {
+            return callback(true)
+        }
         try {
             this.publicToken = publicToken
+            this.stytchClientOptions = options
             deviceInfo = context.getDeviceInfo()
             appSessionId = "app-session-id-${UUID.randomUUID()}"
             StorageHelper.initialize(context)
@@ -166,7 +172,6 @@ public object StytchClient {
                 callback(_isInitialized.value)
             }
         } catch (ex: Exception) {
-            println(ex)
             events.logEvent("client_initialization_failure", null, ex)
             throw StytchInternalError(
                 message = "Failed to initialize the SDK",

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -8,6 +8,7 @@ import com.squareup.moshi.Moshi
 import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
+import com.stytch.sdk.common.EndpointOptions
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchDispatchers
@@ -50,6 +51,7 @@ import org.junit.Before
 import org.junit.Test
 import java.security.KeyStore
 import java.util.Date
+import java.util.UUID
 
 internal class StytchClientTest {
     private var mContextMock = mockk<Context>(relaxed = true)
@@ -132,8 +134,9 @@ internal class StytchClientTest {
         val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
         val deviceInfo = DeviceInfo()
         every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(mContextMock, "")
-        verify { StytchApi.configure("", deviceInfo) }
+        val publicToken = UUID.randomUUID().toString()
+        stytchClientObject.configure(mContextMock, publicToken)
+        verify { StytchApi.configure(publicToken, deviceInfo) }
     }
 
     @Test
@@ -141,14 +144,14 @@ internal class StytchClientTest {
         val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
         val deviceInfo = DeviceInfo()
         every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(mContextMock, "")
+        stytchClientObject.configure(mContextMock, UUID.randomUUID().toString())
         verify { StorageHelper.initialize(mContextMock) }
     }
 
     @Test
     fun `should fetch bootstrap data when calling StytchClient configure`() {
         runBlocking {
-            StytchClient.configure(mContextMock, "")
+            StytchClient.configure(mContextMock, UUID.randomUUID().toString())
             coVerify { StytchApi.getBootstrapData() }
         }
     }
@@ -156,7 +159,7 @@ internal class StytchClientTest {
     @Test
     fun `configures DFP when calling StytchClient configure`() {
         runBlocking {
-            StytchClient.configure(mContextMock, "")
+            StytchClient.configure(mContextMock, UUID.randomUUID().toString())
             verify(exactly = 1) { StytchApi.configureDFP(any(), any(), any(), any()) }
         }
     }
@@ -171,7 +174,7 @@ internal class StytchClientTest {
             coEvery { StytchApi.Sessions.authenticate(any()) } returns mockResponse
             // no session data == no authentication/updater
             every { StorageHelper.loadValue(any()) } returns null
-            StytchClient.configure(mContextMock, "")
+            StytchClient.configure(mContextMock, UUID.randomUUID().toString())
             coVerify(exactly = 0) { StytchApi.Sessions.authenticate() }
             verify(exactly = 0) { mockResponse.launchSessionUpdater(any(), any()) }
             // yes session data, but expired, no authentication/updater
@@ -187,7 +190,7 @@ internal class StytchClientTest {
                     .lenient()
                     .toJson(mockExpiredSession)
             every { StorageHelper.loadValue(any()) } returns mockExpiredSessionJSON
-            StytchClient.configure(mContextMock, "")
+            StytchClient.configure(mContextMock, UUID.randomUUID().toString())
             coVerify(exactly = 0) { StytchApi.Sessions.authenticate() }
             verify(exactly = 0) { mockResponse.launchSessionUpdater(any(), any()) }
             // yes session data, and valid, yes authentication/updater
@@ -215,7 +218,7 @@ internal class StytchClientTest {
                 }
             coEvery { StytchApi.Sessions.authenticate(any()) } returns mockResponse
             val callback = spyk<(Boolean) -> Unit>()
-            StytchClient.configure(mContextMock, "", StytchClientOptions(), callback)
+            StytchClient.configure(mContextMock, UUID.randomUUID().toString(), StytchClientOptions(), callback)
             // callback is called with expected value
             verify(exactly = 1) { callback(true) }
             // isInitialized has fired
@@ -229,7 +232,98 @@ internal class StytchClientTest {
         val deviceInfo = DeviceInfo()
         val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
         every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(mContextMock, "")
+        stytchClientObject.configure(mContextMock, UUID.randomUUID().toString())
+    }
+
+    @Test
+    fun `calling StytchClient configure with the same public token and no options short circuits`() {
+        val deviceInfo = DeviceInfo()
+        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
+        every { mContextMock.getDeviceInfo() } returns deviceInfo
+        stytchClientObject.configure(mContextMock, "publicToken")
+        stytchClientObject.configure(mContextMock, "publicToken")
+        stytchClientObject.configure(mContextMock, "publicToken")
+        verify(exactly = 1) { mContextMock.getDeviceInfo() }
+    }
+
+    @Test
+    fun `calling StytchClient configure with different public tokens and no options doesn't short circuit`() {
+        val deviceInfo = DeviceInfo()
+        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
+        every { mContextMock.getDeviceInfo() } returns deviceInfo
+        stytchClientObject.configure(mContextMock, "publicToken1")
+        stytchClientObject.configure(mContextMock, "publicToken2")
+        stytchClientObject.configure(mContextMock, "publicToken3")
+        verify(exactly = 3) { mContextMock.getDeviceInfo() }
+    }
+
+    @Test
+    fun `calling StytchClient configure with the same public token and the same options short circuits`() {
+        val deviceInfo = DeviceInfo()
+        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
+        every { mContextMock.getDeviceInfo() } returns deviceInfo
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken",
+            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
+        )
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken",
+            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
+        )
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken",
+            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
+        )
+        verify(exactly = 1) { mContextMock.getDeviceInfo() }
+    }
+
+    @Test
+    fun `calling StytchClient configure with different public tokens and the same options doesn't short circuit`() {
+        val deviceInfo = DeviceInfo()
+        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
+        every { mContextMock.getDeviceInfo() } returns deviceInfo
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken1",
+            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
+        )
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken2",
+            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
+        )
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken3",
+            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
+        )
+        verify(exactly = 3) { mContextMock.getDeviceInfo() }
+    }
+
+    @Test
+    fun `calling StytchClient configure with the same public tokens and different options doesn't short circuit`() {
+        val deviceInfo = DeviceInfo()
+        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
+        every { mContextMock.getDeviceInfo() } returns deviceInfo
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken",
+            StytchClientOptions(EndpointOptions("dfppa-domain1.com")),
+        )
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken",
+            StytchClientOptions(EndpointOptions("dfppa-domain2.com")),
+        )
+        stytchClientObject.configure(
+            mContextMock,
+            "publicToken",
+            StytchClientOptions(EndpointOptions("dfppa-domain3.com")),
+        )
+        verify(exactly = 3) { mContextMock.getDeviceInfo() }
     }
 
     @Test(expected = StytchSDKNotConfiguredError::class)


### PR DESCRIPTION
Linear Ticket: [SDK-2390](https://linear.app/stytch/issue/SDK-2390)

## Changes:

1. Persists the passed options to enable short-circuiting
2. Short circuits if configure is called with the same public token and options
3. Adds tests for the above behavior

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A