### PR TITLE
SDK-2113 Refresh bootstrap data when network comes online or app returns from background

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -136,6 +136,8 @@ flowRedux-compose = { module = "com.freeletics.flowredux:compose", version.ref =
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 leakCanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakCanary"}
+lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
+lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycleRuntimeKtx" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "gradle" }

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -162,6 +162,8 @@ dependencies {
     implementation(libs.credentials.play.services.auth)
     implementation(libs.googleid)
     implementation(libs.play.services.auth.api.phone)
+    implementation(libs.lifecycle.common)
+    implementation(libs.lifecycle.process)
 
     // UI SDK dependencies
     implementation(libs.activity.ktx)

--- a/source/sdk/src/main/AndroidManifest.xml
+++ b/source/sdk/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:allowBackup="true"
         android:supportsRtl="true">

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -70,6 +70,8 @@ import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManagerImpl
 import com.stytch.sdk.common.smsRetriever.StytchSMSRetriever
 import com.stytch.sdk.common.smsRetriever.StytchSMSRetrieverImpl
+import com.stytch.sdk.consumer.StytchClient.events
+import com.stytch.sdk.consumer.StytchClient.parseDeeplink
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -250,20 +252,22 @@ public object StytchB2BClient {
     }
 
     private fun refreshBootstrapAndAPIClient() {
-        applicationContext.get()?.let {
-            externalScope.launch(dispatchers.io) {
-                refreshBootstrapData()
-                StytchB2BApi.configureDFP(
-                    dfpProvider = dfpProvider,
-                    captchaProvider =
-                        CaptchaProviderImpl(
-                            it.applicationContext as Application,
-                            externalScope,
-                            bootstrapData.captchaSettings.siteKey,
-                        ),
-                    bootstrapData.dfpProtectedAuthEnabled,
-                    bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
-                )
+        if (NetworkChangeListener.networkIsAvailable) {
+            applicationContext.get()?.let {
+                externalScope.launch(dispatchers.io) {
+                    refreshBootstrapData()
+                    StytchB2BApi.configureDFP(
+                        dfpProvider = dfpProvider,
+                        captchaProvider =
+                            CaptchaProviderImpl(
+                                it.applicationContext as Application,
+                                externalScope,
+                                bootstrapData.captchaSettings.siteKey,
+                            ),
+                        bootstrapData.dfpProtectedAuthEnabled,
+                        bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+                    )
+                }
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -70,8 +70,6 @@ import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManagerImpl
 import com.stytch.sdk.common.smsRetriever.StytchSMSRetriever
 import com.stytch.sdk.common.smsRetriever.StytchSMSRetrieverImpl
-import com.stytch.sdk.consumer.StytchClient.events
-import com.stytch.sdk.consumer.StytchClient.parseDeeplink
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -153,7 +153,8 @@ public object StytchB2BClient {
                 )
             configureSmsRetriever(context.applicationContext)
             NetworkChangeListener.configure(context.applicationContext, ::refreshBootstrapAndAPIClient)
-            AppLifecycleListener.configureCallback(::refreshBootstrapAndAPIClient)
+            AppLifecycleListener.configure(::refreshBootstrapAndAPIClient)
+            refreshBootstrapAndAPIClient()
             externalScope.launch(dispatchers.io) {
                 // if there are session identifiers on device start the auto updater to ensure it is still valid
                 if (sessionStorage.persistedSessionIdentifiersExist) {
@@ -258,7 +259,7 @@ public object StytchB2BClient {
                         dfpProvider = dfpProvider,
                         captchaProvider =
                             CaptchaProviderImpl(
-                                it.applicationContext as Application,
+                                it as Application,
                                 externalScope,
                                 bootstrapData.captchaSettings.siteKey,
                             ),

--- a/source/sdk/src/main/java/com/stytch/sdk/common/AppLifecycleListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/AppLifecycleListener.kt
@@ -25,7 +25,7 @@ internal object AppLifecycleListener {
             }
         }
 
-    fun configureCallback(callback: () -> Unit) {
+    fun configure(callback: () -> Unit) {
         this.callback = callback
         ProcessLifecycleOwner.get().lifecycle.addObserver(listener)
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/AppLifecycleListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/AppLifecycleListener.kt
@@ -1,0 +1,32 @@
+package com.stytch.sdk.common
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+
+internal object AppLifecycleListener {
+    private var callback: () -> Unit = {}
+
+    private val listener =
+        object : DefaultLifecycleObserver {
+            var wasBackgrounded = false
+
+            override fun onStart(owner: LifecycleOwner) {
+                super.onStart(owner)
+                if (wasBackgrounded) {
+                    callback()
+                }
+                wasBackgrounded = false
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                super.onStop(owner)
+                wasBackgrounded = true
+            }
+        }
+
+    fun configureCallback(callback: () -> Unit) {
+        this.callback = callback
+        ProcessLifecycleOwner.get().lifecycle.addObserver(listener)
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
@@ -8,12 +8,14 @@ import android.net.NetworkRequest
 
 internal object NetworkChangeListener {
     private var callback: () -> Unit = {}
+    var networkIsAvailable: Boolean = false
     private val networkCallback =
         object : ConnectivityManager.NetworkCallback() {
             var networkWasLost = false
 
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
+                networkIsAvailable = true
                 if (networkWasLost) {
                     callback()
                 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
@@ -1,0 +1,45 @@
+package com.stytch.sdk.common
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+
+internal object NetworkChangeListener {
+    private var callback: () -> Unit = {}
+    private val networkCallback =
+        object : ConnectivityManager.NetworkCallback() {
+            var networkWasLost = false
+
+            override fun onAvailable(network: Network) {
+                super.onAvailable(network)
+                if (networkWasLost) {
+                    callback()
+                }
+                networkWasLost = false
+            }
+
+            override fun onLost(network: Network) {
+                super.onLost(network)
+                networkWasLost = true
+            }
+        }
+    private val networkRequest =
+        NetworkRequest
+            .Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+            .build()
+
+    fun configure(
+        context: Context,
+        callback: () -> Unit,
+    ) {
+        this.callback = callback
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java) as ConnectivityManager
+        connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+        callback()
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
@@ -11,7 +11,7 @@ internal object NetworkChangeListener {
     var networkIsAvailable: Boolean = false
     private val networkCallback =
         object : ConnectivityManager.NetworkCallback() {
-            var networkWasLost = false
+            var networkWasLost = true // in the case of launching WHILE offline
 
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
@@ -27,21 +27,20 @@ internal object NetworkChangeListener {
                 networkWasLost = true
             }
         }
-    private val networkRequest =
-        NetworkRequest
-            .Builder()
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
-            .build()
 
     fun configure(
         context: Context,
         callback: () -> Unit,
     ) {
         this.callback = callback
+        val networkRequest =
+            NetworkRequest
+                .Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                .build()
         val connectivityManager = context.getSystemService(ConnectivityManager::class.java) as ConnectivityManager
         connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
-        callback()
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
@@ -25,6 +25,7 @@ internal object NetworkChangeListener {
             override fun onLost(network: Network) {
                 super.onLost(network)
                 networkWasLost = true
+                networkIsAvailable = false
             }
         }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/NetworkChangeListener.kt
@@ -11,20 +11,16 @@ internal object NetworkChangeListener {
     var networkIsAvailable: Boolean = false
     private val networkCallback =
         object : ConnectivityManager.NetworkCallback() {
-            var networkWasLost = true // in the case of launching WHILE offline
-
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
-                networkIsAvailable = true
-                if (networkWasLost) {
+                if (!networkIsAvailable) {
                     callback()
                 }
-                networkWasLost = false
+                networkIsAvailable = true
             }
 
             override fun onLost(network: Network) {
                 super.onLost(network)
-                networkWasLost = true
                 networkIsAvailable = false
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/CaptchaProvider.kt
@@ -25,9 +25,9 @@ internal class CaptchaProviderImpl(
         get() = ::recaptchaClient.isInitialized
 
     init {
-        scope.launch(Dispatchers.Main) {
-            siteKey?.let {
-                recaptchaClient = Recaptcha.fetchClient(application, it)
+        if (!siteKey.isNullOrBlank()) {
+            scope.launch(Dispatchers.Main) {
+                recaptchaClient = Recaptcha.fetchClient(application, siteKey)
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -3,7 +3,6 @@ package com.stytch.sdk.consumer
 import android.app.Application
 import android.content.Context
 import android.net.Uri
-import com.stytch.sdk.b2b.StytchB2BClient.events
 import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeeplinkHandledStatus

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import com.stytch.sdk.b2b.StytchB2BClient.events
 import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeeplinkHandledStatus
@@ -242,24 +243,26 @@ public object StytchClient {
     }
 
     private fun refreshBootstrapAndAPIClient() {
-        applicationContext.get()?.let {
-            externalScope.launch(dispatchers.io) {
-                bootstrapData =
-                    when (val res = StytchApi.getBootstrapData()) {
-                        is StytchResult.Success -> res.value
-                        else -> BootstrapData()
-                    }
-                StytchApi.configureDFP(
-                    dfpProvider = dfpProvider,
-                    captchaProvider =
-                        CaptchaProviderImpl(
-                            it.applicationContext as Application,
-                            externalScope,
-                            bootstrapData.captchaSettings.siteKey,
-                        ),
-                    bootstrapData.dfpProtectedAuthEnabled,
-                    bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
-                )
+        if (NetworkChangeListener.networkIsAvailable) {
+            applicationContext.get()?.let {
+                externalScope.launch(dispatchers.io) {
+                    bootstrapData =
+                        when (val res = StytchApi.getBootstrapData()) {
+                            is StytchResult.Success -> res.value
+                            else -> BootstrapData()
+                        }
+                    StytchApi.configureDFP(
+                        dfpProvider = dfpProvider,
+                        captchaProvider =
+                            CaptchaProviderImpl(
+                                it.applicationContext as Application,
+                                externalScope,
+                                bootstrapData.captchaSettings.siteKey,
+                            ),
+                        bootstrapData.dfpProtectedAuthEnabled,
+                        bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+                    )
+                }
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -2,6 +2,10 @@ package com.stytch.sdk.consumer
 
 import android.app.Application
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import android.net.Uri
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeeplinkHandledStatus
@@ -139,24 +143,9 @@ public object StytchClient {
                     activityProvider = activityProvider,
                 )
             configureSmsRetriever(context.applicationContext)
+            configureNetworkListener(context.applicationContext)
             maybeClearBadSessionToken()
             externalScope.launch(dispatchers.io) {
-                bootstrapData =
-                    when (val res = StytchApi.getBootstrapData()) {
-                        is StytchResult.Success -> res.value
-                        else -> BootstrapData()
-                    }
-                StytchApi.configureDFP(
-                    dfpProvider = dfpProvider,
-                    captchaProvider =
-                        CaptchaProviderImpl(
-                            context.applicationContext as Application,
-                            externalScope,
-                            bootstrapData.captchaSettings.siteKey,
-                        ),
-                    bootstrapData.dfpProtectedAuthEnabled,
-                    bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
-                )
                 // if there are session identifiers on device start the auto updater to ensure it is still valid
                 if (sessionStorage.persistedSessionIdentifiersExist) {
                     sessionStorage.session?.let {
@@ -247,6 +236,57 @@ public object StytchClient {
                     )
                 }
             }
+    }
+
+    private fun configureNetworkListener(context: Context) {
+        val networkCallback =
+            object : ConnectivityManager.NetworkCallback() {
+                var networkWasLost = false
+
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    if (networkWasLost) {
+                        refreshBootstrapAndAPIClient(context)
+                    }
+                    networkWasLost = false
+                }
+
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    networkWasLost = true
+                }
+            }
+        val networkRequest =
+            NetworkRequest
+                .Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                .build()
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java) as ConnectivityManager
+        connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+        refreshBootstrapAndAPIClient(context.applicationContext)
+    }
+
+    private fun refreshBootstrapAndAPIClient(context: Context) {
+        externalScope.launch(dispatchers.io) {
+            bootstrapData =
+                when (val res = StytchApi.getBootstrapData()) {
+                    is StytchResult.Success -> res.value
+                    else -> BootstrapData()
+                }
+            StytchApi.configureDFP(
+                dfpProvider = dfpProvider,
+                captchaProvider =
+                    CaptchaProviderImpl(
+                        context.applicationContext as Application,
+                        externalScope,
+                        bootstrapData.captchaSettings.siteKey,
+                    ),
+                bootstrapData.dfpProtectedAuthEnabled,
+                bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+            )
+        }
     }
 
     internal fun assertInitialized() {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -146,7 +146,8 @@ public object StytchClient {
                 )
             configureSmsRetriever(context.applicationContext)
             NetworkChangeListener.configure(context.applicationContext, ::refreshBootstrapAndAPIClient)
-            AppLifecycleListener.configureCallback(::refreshBootstrapAndAPIClient)
+            AppLifecycleListener.configure(::refreshBootstrapAndAPIClient)
+            refreshBootstrapAndAPIClient()
             maybeClearBadSessionToken()
             externalScope.launch(dispatchers.io) {
                 // if there are session identifiers on device start the auto updater to ensure it is still valid
@@ -254,7 +255,7 @@ public object StytchClient {
                         dfpProvider = dfpProvider,
                         captchaProvider =
                             CaptchaProviderImpl(
-                                it.applicationContext as Application,
+                                it as Application,
                                 externalScope,
                                 bootstrapData.captchaSettings.siteKey,
                             ),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -9,10 +9,12 @@ import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.network.models.B2BSessionData
 import com.stytch.sdk.b2b.network.models.SessionsAuthenticateResponseData
+import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.EndpointOptions
+import com.stytch.sdk.common.NetworkChangeListener
 import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchClientOptions
@@ -75,6 +77,11 @@ internal class StytchB2BClientTest {
         )
         mockkObject(EncryptionManager)
         every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        mockkObject(NetworkChangeListener)
+        every { NetworkChangeListener.configure(any(), any()) } just runs
+        every { NetworkChangeListener.networkIsAvailable } returns true
+        mockkObject(AppLifecycleListener)
+        every { AppLifecycleListener.configure(any()) } just runs
         val mockApplication: Application =
             mockk {
                 every { registerActivityLifecycleCallbacks(any()) } just runs

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -11,8 +11,10 @@ import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
+import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
+import com.stytch.sdk.common.NetworkChangeListener
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
 import com.stytch.sdk.common.errors.StytchAPIErrorType
@@ -70,6 +72,11 @@ internal class StytchB2BApiTest {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
         mockkObject(StytchB2BApi)
+        mockkObject(NetworkChangeListener)
+        every { NetworkChangeListener.configure(any(), any()) } just runs
+        every { NetworkChangeListener.networkIsAvailable } returns true
+        mockkObject(AppLifecycleListener)
+        every { AppLifecycleListener.configure(any()) } just runs
         MockKAnnotations.init(this, true, true)
         every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.net.Uri
 import com.google.android.recaptcha.Recaptcha
 import com.squareup.moshi.Moshi
+import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.EndpointOptions
+import com.stytch.sdk.common.NetworkChangeListener
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchDispatchers
@@ -74,6 +76,11 @@ internal class StytchClientTest {
         )
         mockkObject(EncryptionManager)
         every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        mockkObject(NetworkChangeListener)
+        every { NetworkChangeListener.configure(any(), any()) } just runs
+        every { NetworkChangeListener.networkIsAvailable } returns true
+        mockkObject(AppLifecycleListener)
+        every { AppLifecycleListener.configure(any()) } just runs
         val mockApplication: Application =
             mockk {
                 every { registerActivityLifecycleCallbacks(any()) } just runs


### PR DESCRIPTION
Linear Ticket: [SDK-2113](https://linear.app/stytch/issue/SDK-2113)

## Changes:

1. Adds listeners to refresh bootstrap (and DFP/CAPTCHA settings) when a device returns from being offline OR from being backgrounded
2. Use a WeakReference to the application context in callbacks to avoid potential memory leaks
3. Fix (potential) bug in instantiating a CAPTCHA client with an empty siteKey

## Notes:

- Tested on device and simulator

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A