### PR TITLE
SDK-2436 Ensure bootstrap data isn't overwritten from a failed network request

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -272,11 +272,13 @@ public object StytchB2BClient {
     }
 
     internal suspend fun refreshBootstrapData() {
-        bootstrapData =
-            when (val res = StytchB2BApi.getBootstrapData()) {
-                is StytchResult.Success -> res.value
-                else -> BootstrapData()
-            }
+        if (NetworkChangeListener.networkIsAvailable) {
+            bootstrapData =
+                when (val res = StytchB2BApi.getBootstrapData()) {
+                    is StytchResult.Success -> res.value
+                    else -> bootstrapData
+                }
+        }
     }
 
     internal fun assertInitialized() {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -249,7 +249,7 @@ public object StytchClient {
                     bootstrapData =
                         when (val res = StytchApi.getBootstrapData()) {
                             is StytchResult.Success -> res.value
-                            else -> BootstrapData()
+                            else -> bootstrapData
                         }
                     StytchApi.configureDFP(
                         dfpProvider = dfpProvider,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -246,11 +246,7 @@ public object StytchClient {
         if (NetworkChangeListener.networkIsAvailable) {
             applicationContext.get()?.let {
                 externalScope.launch(dispatchers.io) {
-                    bootstrapData =
-                        when (val res = StytchApi.getBootstrapData()) {
-                            is StytchResult.Success -> res.value
-                            else -> bootstrapData
-                        }
+                    refreshBootstrapData()
                     StytchApi.configureDFP(
                         dfpProvider = dfpProvider,
                         captchaProvider =
@@ -264,6 +260,16 @@ public object StytchClient {
                     )
                 }
             }
+        }
+    }
+
+    internal suspend fun refreshBootstrapData() {
+        if (NetworkChangeListener.networkIsAvailable) {
+            bootstrapData =
+                when (val res = StytchApi.getBootstrapData()) {
+                    is StytchResult.Success -> res.value
+                    else -> bootstrapData
+                }
         }
     }
 


### PR DESCRIPTION
Linear Ticket: [SDK-2436](https://linear.app/stytch/issue/SDK-2436)

## Changes:

1. For B2B: add a guardrail to only refresh bootstrap data if the network is online
2. For B2B and B2C: fallback to the _previous_ bootstrap data in case of a failed request, to prevent overwriting a potentially good bootstrap response with a default one (we set it to default on init, so there will always be _something_ to fallback to)

## Notes:

- Imagine a scenario where a user is online and has a valid bootstrap response, goes offline (or backgrounds the app), comes back online (or foregrounds the app), and the bootstrap response fails for some reason (transient network issue). Previously we would set the bootstrap data to the _default_ response; now, we will set it to the _previous_ response (which is either the default response if they've never made a successful request OR the last good response that was received).

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A