### PR TITLE
SDK-1038 Add lastAuthMethod used to clients

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/B2BAuthMethod.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/B2BAuthMethod.kt
@@ -1,0 +1,9 @@
+package com.stytch.sdk.b2b
+
+public enum class B2BAuthMethod {
+    EMAIL_MAGIC_LINKS,
+    EMAIL_OTP,
+    OAUTH,
+    PASSWORDS,
+    SSO,
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -650,4 +650,11 @@ public object StytchB2BClient {
             token = uri.getQueryParameter(QUERY_TOKEN),
             redirectType = B2BRedirectType.fromString(uri.getQueryParameter(QUERY_REDIRECT_TYPE)),
         )
+
+    /**
+     * Retrieve the last used authentication method, if available
+     */
+    @JvmStatic
+    public val lastAuthMethodUsed: B2BAuthMethod?
+        get() = sessionStorage.lastAuthMethodUsed
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImpl.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.magicLinks
 
+import com.stytch.sdk.b2b.B2BAuthMethod
 import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
 import com.stytch.sdk.b2b.EMLAuthenticateResponse
 import com.stytch.sdk.b2b.MemberResponse
@@ -39,6 +40,7 @@ internal class B2BMagicLinksImpl internal constructor(
                     intermediateSessionToken = sessionStorage.intermediateSessionToken,
                 ).apply {
                     pkcePairManager.clearPKCECodePair()
+                    sessionStorage.lastAuthMethodUsed = B2BAuthMethod.EMAIL_MAGIC_LINKS
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }
@@ -73,6 +75,7 @@ internal class B2BMagicLinksImpl internal constructor(
                     token = parameters.token,
                     codeVerifier = codeVerifier,
                 ).apply {
+                    sessionStorage.lastAuthMethodUsed = B2BAuthMethod.EMAIL_MAGIC_LINKS
                     pkcePairManager.clearPKCECodePair()
                     if (this is StytchResult.Success) {
                         sessionStorage.intermediateSessionToken = value.intermediateSessionToken

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.oauth
 import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import com.stytch.sdk.b2b.B2BAuthMethod
 import com.stytch.sdk.b2b.OAuthAuthenticateResponse
 import com.stytch.sdk.b2b.OAuthDiscoveryAuthenticateResponse
 import com.stytch.sdk.b2b.StytchB2BClient
@@ -75,6 +76,7 @@ internal class OAuthImpl(
                                 this.exception,
                             )
                     }
+                    sessionStorage.lastAuthMethodUsed = B2BAuthMethod.OAUTH
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }
@@ -275,6 +277,7 @@ internal class OAuthImpl(
                         discoveryOauthToken = parameters.discoveryOauthToken,
                     ).apply {
                         pkcePairManager.clearPKCECodePair()
+                        sessionStorage.lastAuthMethodUsed = B2BAuthMethod.OAUTH
                         when (this) {
                             is StytchResult.Success -> {
                                 StytchB2BClient.events.logEvent("b2b_discovery_oauth_success")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTPImpl.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.otp
 
+import com.stytch.sdk.b2b.B2BAuthMethod
 import com.stytch.sdk.b2b.BasicResponse
 import com.stytch.sdk.b2b.EmailOTPAuthenticateResponse
 import com.stytch.sdk.b2b.EmailOTPDiscoveryAuthenticateResponse
@@ -184,6 +185,7 @@ internal class OTPImpl(
                             code = parameters.code,
                             emailAddress = parameters.emailAddress,
                         ).apply {
+                            sessionStorage.lastAuthMethodUsed = B2BAuthMethod.EMAIL_OTP
                             if (this is StytchResult.Success) {
                                 // This endpoint doesn't send back a full "Needs MFA" response, ONLY the bare minimum
                                 // so we have to do it manually since we can't use `launchSessionUpdater`

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.passwords
 
+import com.stytch.sdk.b2b.B2BAuthMethod
 import com.stytch.sdk.b2b.B2BPasswordDiscoveryAuthenticateResponse
 import com.stytch.sdk.b2b.B2BPasswordDiscoveryResetByEmailResponse
 import com.stytch.sdk.b2b.EmailResetResponse
@@ -44,6 +45,7 @@ internal class PasswordsImpl internal constructor(
                     intermediateSessionToken = sessionStorage.intermediateSessionToken,
                     locale = parameters.locale,
                 ).apply {
+                    sessionStorage.lastAuthMethodUsed = B2BAuthMethod.PASSWORDS
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import androidx.activity.ComponentActivity
+import com.stytch.sdk.b2b.B2BAuthMethod
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
@@ -121,6 +122,7 @@ internal class SSOImpl(
                     locale = params.locale,
                 ).apply {
                     pkcePairManager.clearPKCECodePair()
+                    sessionStorage.lastAuthMethodUsed = B2BAuthMethod.SSO
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
@@ -38,3 +38,4 @@ internal const val PREFERENCES_NAME_MEMBER_SESSION_DATA = "stytch_member_session
 internal const val PREFERENCES_NAME_MEMBER_DATA = "stytch_member_data"
 internal const val PREFERENCES_NAME_ORGANIZATION_DATA = "stytch_organization_data"
 internal const val IST_EXPIRATION_TIME = 10 * 60 * 1000L // 10 minutes
+internal const val PREFERENCES_NAME_LAST_AUTH_METHOD_USED = "stytch_last_auth_method_used"

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerAuthMethod.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerAuthMethod.kt
@@ -1,0 +1,12 @@
+package com.stytch.sdk.consumer
+
+public enum class ConsumerAuthMethod {
+    BIOMETRICS,
+    CRYPTO,
+    EMAIL_MAGIC_LINKS,
+    OAUTH,
+    OTP,
+    PASSKEYS,
+    PASSWORDS,
+    TOTP,
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -588,4 +588,11 @@ public object StytchClient {
             tokenType = ConsumerTokenType.fromString(uri.getQueryParameter(QUERY_TOKEN_TYPE)),
             token = uri.getQueryParameter(QUERY_TOKEN),
         )
+
+    /**
+     * Retrieve the last used authentication method, if available
+     */
+    @JvmStatic
+    public val lastAuthMethodUsed: ConsumerAuthMethod?
+        get() = sessionStorage.lastAuthMethodUsed
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
@@ -18,6 +18,7 @@ import com.stytch.sdk.common.extensions.toBase64DecodedByteArray
 import com.stytch.sdk.common.extensions.toBase64EncodedString
 import com.stytch.sdk.common.getValueOrThrow
 import com.stytch.sdk.consumer.BiometricsAuthResponse
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.DeleteFactorResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
@@ -169,6 +170,7 @@ internal class BiometricsImpl internal constructor(
                             storageHelper.saveValue(CIPHER_IV_KEY, cipher.iv.toBase64EncodedString())
                             storageHelper.saveBoolean(ALLOW_DEVICE_CREDENTIALS_KEY, parameters.allowDeviceCredentials)
                         }
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.BIOMETRICS
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
             } catch (e: StytchError) {
@@ -234,6 +236,7 @@ internal class BiometricsImpl internal constructor(
                         biometricRegistrationId = startResponse.biometricRegistrationId,
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.BIOMETRICS
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
             } catch (e: StytchError) {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWalletImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWalletImpl.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer.crypto
 
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
@@ -62,6 +63,7 @@ internal class CryptoWalletImpl(
                     signature = parameters.signature,
                     sessionDurationMinutes = parameters.sessionDurationMinutes,
                 ).apply {
+                    sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.CRYPTO
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImpl.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.errors.StytchFailedToCreateCodeChallengeError
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
@@ -37,6 +38,7 @@ internal class MagicLinksImpl internal constructor(
                     codeVerifier,
                 ).apply {
                     pkcePairManager.clearPKCECodePair()
+                    sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.EMAIL_MAGIC_LINKS
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
@@ -16,6 +16,7 @@ import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.errors.UnexpectedCredentialType
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.NativeOAuthResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
@@ -104,6 +105,7 @@ internal class GoogleOneTapImpl(
                         nonce = nonce,
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.OAUTH
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuthImpl.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.ProvidedReceiverManager
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
@@ -211,6 +212,7 @@ internal class OAuthImpl(
                         is StytchResult.Success -> StytchClient.events.logEvent("oauth_success")
                         is StytchResult.Error -> StytchClient.events.logEvent("oauth_failure", null, this.exception)
                     }
+                    sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.OAUTH
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTPImpl.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.otp
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
 import com.stytch.sdk.consumer.OTPSendResponse
 import com.stytch.sdk.consumer.StytchClient
@@ -38,6 +39,7 @@ internal class OTPImpl internal constructor(
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
                         sessionStorage.methodId = null
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.OTP
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
@@ -16,6 +16,7 @@ import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.errors.StytchPasskeysNotSupportedError
 import com.stytch.sdk.common.getValueOrThrow
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
@@ -118,6 +119,7 @@ internal class PasskeysImpl internal constructor(
                     .register(
                         publicKeyCredential = credentialResponse.registrationResponseJson,
                     ).apply {
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.PASSKEYS
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
             }
@@ -173,6 +175,7 @@ internal class PasskeysImpl internal constructor(
                         publicKeyCredential = credentialResponse.authenticationResponseJson,
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.PASSKEYS
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/PasswordsImpl.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.errors.StytchFailedToCreateCodeChallengeError
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.PasswordsCreateResponse
 import com.stytch.sdk.consumer.PasswordsStrengthCheckResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
@@ -36,6 +37,7 @@ internal class PasswordsImpl internal constructor(
                         password = parameters.password,
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.PASSWORDS
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
         }
@@ -69,6 +71,7 @@ internal class PasswordsImpl internal constructor(
                         password = parameters.password,
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.PASSWORDS
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTPImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTPImpl.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.consumer.totp
 
 import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.TOTPAuthenticateResponse
 import com.stytch.sdk.consumer.TOTPCreateResponse
 import com.stytch.sdk.consumer.TOTPRecoverResponse
@@ -50,6 +51,7 @@ internal class TOTPImpl(
                     totpCode = parameters.totpCode,
                     sessionDurationMinutes = parameters.sessionDurationMinutes,
                 ).apply {
+                    sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.TOTP
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }
@@ -95,6 +97,7 @@ internal class TOTPImpl(
                     recoveryCode = parameters.recoveryCode,
                     sessionDurationMinutes = parameters.sessionDurationMinutes,
                 ).apply {
+                    sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.TOTP
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -70,6 +70,7 @@ internal class B2BMagicLinksImplTest {
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockB2BSessionStorage.intermediateSessionToken } returns ""
         every { mockPKCEPairManager.clearPKCECodePair() } just runs
+        every { mockB2BSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             B2BMagicLinksImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
@@ -64,6 +64,9 @@ internal class OAuthImplTest {
         every { StytchB2BApi.isInitialized } returns true
         every { mockSessionStorage.intermediateSessionToken } returns null
         every { mockSessionStorage.lastValidatedAt } returns Date(0)
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
+        mockkObject(StytchB2BClient)
+        every { StytchB2BClient.events } returns mockk(relaxed = true)
         StytchB2BClient.deviceInfo = mockk(relaxed = true)
         StytchB2BClient.appSessionId = "app-session-id"
         impl =

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/otp/OTPImplTest.kt
@@ -93,6 +93,7 @@ internal class OTPImplTest {
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         spiedSessionStorage = spyk(B2BSessionStorage(StorageHelper), recordPrivateCalls = true)
+        every { spiedSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             OTPImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -75,6 +75,7 @@ internal class PasswordsImplTest {
         MockKAnnotations.init(this, true, true)
         every { mockSessionStorage.intermediateSessionToken } returns ""
         every { mockSessionStorage.intermediateSessionToken = any() } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         every { mockPKCEPairManager.clearPKCECodePair() } just runs
         impl =
             PasswordsImpl(

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -65,6 +65,7 @@ internal class SSOImplTest {
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockB2BSessionStorage.intermediateSessionToken } returns ""
+        every { mockB2BSessionStorage.lastAuthMethodUsed = any() } just runs
         every { mockPKCEPairManager.clearPKCECodePair() } just runs
         impl =
             SSOImpl(

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -93,6 +93,7 @@ internal class BiometricsImplTest {
         every { mockStorageHelper.saveBoolean(any(), any()) } just runs
         every { any<String>().toBase64DecodedByteArray() } returns base64DecodedByteArray
         every { any<ByteArray>().toBase64EncodedString() } returns base64EncodedString
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             BiometricsImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/crypto/CryptoWalletImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/crypto/CryptoWalletImplTest.kt
@@ -47,6 +47,7 @@ internal class CryptoWalletImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             CryptoWalletImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
@@ -66,6 +66,7 @@ internal class MagicLinksImplTest {
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockPKCEPairManager.clearPKCECodePair() } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             MagicLinksImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
@@ -60,6 +60,7 @@ internal class GoogleOneTapImplTest {
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns mockk(relaxed = true)
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             GoogleOneTapImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -59,7 +59,10 @@ internal class OAuthImplTest {
         mockkObject(SessionAutoUpdater)
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         every { mockPKCEPairManager.clearPKCECodePair() } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         mockkObject(StytchApi)
+        mockkObject(StytchClient)
+        every { StytchClient.events } returns mockk(relaxed = true)
         every { StytchApi.isInitialized } returns true
         StytchClient.deviceInfo = mockk(relaxed = true)
         StytchClient.appSessionId = "app-session-id"

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
@@ -56,6 +56,7 @@ internal class OTPImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         every { mockSessionStorage.methodId = any() } just runs
         impl =
             OTPImpl(

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
@@ -54,6 +54,7 @@ internal class PasskeysImplTest {
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             spyk(
                 PasskeysImpl(

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -80,6 +80,7 @@ internal class PasswordsImplTest {
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
         MockKAnnotations.init(this, true, true)
         every { mockPKCEPairManager.clearPKCECodePair() } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             PasswordsImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/totp/TOTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/totp/TOTPImplTest.kt
@@ -51,6 +51,7 @@ internal class TOTPImplTest {
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")
         every { SessionAutoUpdater.startSessionUpdateJob(any(), any(), any()) } just runs
+        every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         impl =
             TOTPImpl(
                 externalScope = TestScope(),

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/App.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/App.kt
@@ -16,7 +16,9 @@ class App : Application() {
         StytchB2BClient.configure(
             context = applicationContext,
             publicToken = BuildConfig.STYTCH_B2B_PUBLIC_TOKEN,
-        )
+        ) {
+            println("Last Auth Method Used: ${StytchB2BClient.lastAuthMethodUsed}")
+        }
         CoroutineScope(Dispatchers.Main).launch {
             StytchB2BClient.sessions.onChange.collect {
                 println("Collected session data: $it")

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/App.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/App.kt
@@ -18,6 +18,7 @@ class App : Application() {
             publicToken = BuildConfig.STYTCH_PUBLIC_TOKEN,
         ) {
             println("Stytch has been initialized and configured and is ready for use")
+            println("Last Auth Method Used: ${StytchClient.lastAuthMethodUsed}")
         }
         CoroutineScope(Dispatchers.Main).launch {
             StytchClient.sessions.onChange.collect {


### PR DESCRIPTION
Linear Ticket: [SDK-1038](https://linear.app/stytch/issue/SDK-1038)

## Changes:

1. Adds a `lastAuthMethodUsed` property to Consumer and B2B clients that retrieves a persisted value representing one of the appropriate authentication methods
2. Persists the last used authentication method enum to SharedPreferences (like we do for other persisted data)
3. Saves the last used authentication method everywhere we authenticate with a method. **NOTE**: for B2B this _only_ pertains to _primary_ auth methods, as that's probably whats most useful

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A