### PR TITLE
SDK-2443 Eliminate manifestPlaceholders

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -33,12 +33,8 @@ jobs:
             - name: Get current version
               id: version
               env:
-                STYTCH_PUBLIC_TOKEN: 'abc123'
                 GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-                STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-                STYTCH_B2B_ORG_ID: 'abc123'
                 PASSKEYS_DOMAIN: 'abc123'
-                UI_GOOGLE_CLIENT_ID: 'abc123'
               run: |
                 VERSION=$(./gradlew -q printVersion)
                 echo "Found version $VERSION"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,12 +79,8 @@ jobs:
          echo "Run, Build Application using script"
          ./gradlew --no-daemon assemble
       env:
-        STYTCH_PUBLIC_TOKEN: 'abc123'
         GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-        STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-        STYTCH_B2B_ORG_ID: 'abc123'
         PASSKEYS_DOMAIN: 'abc123'
-        UI_GOOGLE_CLIENT_ID: 'abc123'
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -26,12 +26,8 @@ jobs:
         build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
         build-scan-terms-of-use-agree: "yes"
       env:
-        STYTCH_PUBLIC_TOKEN: 'abc123'
         GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-        STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-        STYTCH_B2B_ORG_ID: 'abc123'
         PASSKEYS_DOMAIN: 'abc123'
-        UI_GOOGLE_CLIENT_ID: 'abc123'
        
         # Exclude all dependencies that originate solely in the following projects
         DEPENDENCY_GRAPH_EXCLUDE_PROJECTS: ':workbench-apps:consumer-workbench|:workbench-apps:b2b-workbench|:workbench-apps:uiworkbench|:example-apps:stytchexampleapp'       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,8 @@ jobs:
     name: Release build and publish
     runs-on: ubuntu-latest
     env:
-      STYTCH_PUBLIC_TOKEN: 'abc123'
       GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-      STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-      STYTCH_B2B_ORG_ID: 'abc123'
       PASSKEYS_DOMAIN: 'abc123'
-      UI_GOOGLE_CLIENT_ID: 'abc123'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -26,9 +26,5 @@ jobs:
         with:
           arguments: runOnGitHub
         env:
-          STYTCH_PUBLIC_TOKEN: 'abc123'
           GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-          STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-          STYTCH_B2B_ORG_ID: 'abc123'
           PASSKEYS_DOMAIN: 'abc123'
-          UI_GOOGLE_CLIENT_ID: 'abc123'

--- a/.github/workflows/uiTests.yml
+++ b/.github/workflows/uiTests.yml
@@ -39,9 +39,5 @@ jobs:
           disable-animations: true
           script: ./gradlew :source:sdk:connectedCheck
         env:
-          STYTCH_PUBLIC_TOKEN: 'abc123'
           GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-          STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-          STYTCH_B2B_ORG_ID: 'abc123'
           PASSKEYS_DOMAIN: 'abc123'
-          UI_GOOGLE_CLIENT_ID: 'abc123'

--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -27,12 +27,8 @@ jobs:
         java-version: 17
     - name: Generate docs
       env:
-        STYTCH_PUBLIC_TOKEN: 'abc123'
         GOOGLE_OAUTH_CLIENT_ID: 'abc123'
-        STYTCH_B2B_PUBLIC_TOKEN: 'abc123'
-        STYTCH_B2B_ORG_ID: 'abc123'
         PASSKEYS_DOMAIN: 'abc123'
-        UI_GOOGLE_CLIENT_ID: 'abc123'
       working-directory: main
       run: ./gradlew dokkaHtmlMultiModule
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ captures
 .cxx
 local.properties
 sdk/build
+stytch-strings.xml

--- a/README.md
+++ b/README.md
@@ -29,25 +29,15 @@ dependencies {
 }
 ```
 
-Lastly, you must modify your applications build.gradle(.kts) to supply three `manifestPlaceholders`; two of them are for enabling OAuth deeplinks, and one is for enabling our UI SDK. If you are not using either, you still need to supply these placeholders, but they can be blank. The OAuth manifest placeholder values can be any valid scheme or host, and do not relate to your OAuth settings in the Stytch Dashboard. These are only used internally within your app to register an OAuth receiver activity. More information is available in our [OAuth tutorial](./tutorials/OAuth.md). The STYTCH_PUBLIC_TOKEN is your public token, which you can get from your project dashboard
-```gradle
-android {
-    ...
-    defaultConfig {
-        ...
-        manifestPlaceholders = [
-            'stytchOAuthRedirectScheme': '[YOUR_AUTH_SCHEME]', // eg: 'app'
-            'stytchOAuthRedirectHost': '[YOUR_AUTH_HOST]', // eg: 'myhost'
-            'STYTCH_PUBLIC_TOKEN': '[STYTCH_PUBLIC_TOKEN]', // if using B2C, else empty string
-            'STYTCH_B2B_PUBLIC_TOKEN': '[STYTCH_B2B_PUBLIC_TOKEN'], // if using B2B, else empty string
-        ]
-        ...
-    }
-}
+Lastly, add a new string resource called `STYTCH_PUBLIC_TOKEN` with the value of your public token from the Stytch Dashboard. This will automatically enable the necessary activities for handling [OAuth deeplinks](./tutorials/OAuth.md) and our pre-built UI components, as well as automatic configuration of the Stytch client:
+```xml
+<resources>
+    <string name="STYTCH_PUBLIC_TOKEN">YOUR_PUBLIC_TOKEN</string>
+</resources>
 ```
 
 ## Configuration
-Before using any part of the Stytch SDK, you must call configure to set the application context and public token as specified in your project dashboard.
+Before using any part of the Stytch SDK, you must call configure to set the application context, which is used for retrieving the public token and registering necessary activities/receivers/deeplinks.
 
 If configuring from an Application Class:
 ``` kotlin
@@ -56,10 +46,7 @@ class App : Application() {
     override fun onCreate() {  
         super.onCreate()
         ...
-        StytchClient.configure(  
-            context = this,
-            publicToken = [STYTCH_PUBLIC_TOKEN],
-        )
+        StytchClient.configure(this)
         ...
     }
 }
@@ -72,10 +59,7 @@ class MainActivity : FragmentActivity() {
     override fun onCreate() {  
         super.onCreate()
         ...
-        StytchClient.configure(  
-            context = applicationContext,
-            publicToken = [STYTCH_PUBLIC_TOKEN],
-        )
+        StytchClient.configure(applicationContext)
         ...
     }
 }

--- a/README.md
+++ b/README.md
@@ -156,11 +156,7 @@ This repository is organized in three main parts:
 * **source/sdk/** - This is the actual source code of the Stytch Android SDK
 
 If you wish to run any of the example or workbench apps from within this repository, you should add some, or all, of the following properties to your `local.properties` file:
-* **STYTCH_PUBLIC_TOKEN** - Your Consumer Project public token. Used in both of the example apps and the consumer workbench app
 * **GOOGLE_OAUTH_CLIENT_ID** - A Google OAuth client ID, created in your Google Console (linked to `com.stytch.exampleapp`) and added to your Stytch Dashboard, used in the consumer workbench app for testing Google One Tap
-* **STYTCH_B2B_PUBLIC_TOKEN** - Your B2B Project public token. Used in the B2B workbench app
-* **STYTCH_B2B_ORG_ID** - The ID of one of your B2B organizations. This is used as a convenience property in the B2B workbench app, so you don't have to type it in manually on your device
-* **UI_GOOGLE_CLIENT_ID** - A Google OAuth client ID, created in your Google Console (linked to `com.stytch.uiworkbench`) and added to your Stytch Dashboard, used in the UI workbench app for testing Google One Tap
 * **PASSKEYS_DOMAIN** - The domain where you host your `/.well-known/assetlinks.json` file, used in the consumer workbench app to test Passkeys flows
 
 If you do not add these properties, the applications should still build, but will not function as expected.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,11 +94,7 @@ tasks.dokkaHtmlMultiModule.configure {
 }
 
 // Create variables with empty default values
-extra["STYTCH_PUBLIC_TOKEN"] = ""
 extra["GOOGLE_OAUTH_CLIENT_ID"] = ""
-extra["STYTCH_B2B_PUBLIC_TOKEN"] = ""
-extra["STYTCH_B2B_ORG_ID"] = ""
-extra["UI_GOOGLE_CLIENT_ID"] = ""
 extra["PASSKEYS_DOMAIN"] = ""
 
 val localProperties = project.rootProject.file("local.properties")
@@ -112,10 +108,6 @@ if (localProperties.exists()) {
     }
 } else {
     // Use envvars
-    extra["STYTCH_PUBLIC_TOKEN"] = System.getenv("STYTCH_PUBLIC_TOKEN")
     extra["GOOGLE_OAUTH_CLIENT_ID"] = System.getenv("GOOGLE_OAUTH_CLIENT_ID")
-    extra["STYTCH_B2B_PUBLIC_TOKEN"] = System.getenv("STYTCH_B2B_PUBLIC_TOKEN")
-    extra["STYTCH_B2B_ORG_ID"] = System.getenv("STYTCH_B2B_ORG_ID")
-    extra["UI_GOOGLE_CLIENT_ID"] = System.getenv("UI_GOOGLE_CLIENT_ID")
     extra["PASSKEYS_DOMAIN"] = System.getenv("PASSKEYS_DOMAIN")
 }

--- a/example-apps/javademoapp/build.gradle.kts
+++ b/example-apps/javademoapp/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.androidApplication)
 }
-val publicToken = rootProject.ext["STYTCH_PUBLIC_TOKEN"] as String
 
 android {
     namespace = "com.stytch.javademoapp"
@@ -15,13 +14,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-        manifestPlaceholders["stytchOAuthRedirectScheme"] = "stytchjavademoapp"
-        manifestPlaceholders["stytchOAuthRedirectHost"] = "oauth"
-        manifestPlaceholders["STYTCH_PUBLIC_TOKEN"] = publicToken
-        manifestPlaceholders["STYTCH_B2B_PUBLIC_TOKEN"] = ""
-
-        buildConfigField("String", "STYTCH_PUBLIC_TOKEN", "\"$publicToken\"")
     }
 
     buildTypes {

--- a/example-apps/javademoapp/src/main/java/com/stytch/javademoapp/MainActivity.java
+++ b/example-apps/javademoapp/src/main/java/com/stytch/javademoapp/MainActivity.java
@@ -78,7 +78,6 @@ public class MainActivity extends AppCompatActivity {
 
         StytchClient.configure(
             this.getApplicationContext(),
-            BuildConfig.STYTCH_PUBLIC_TOKEN,
             viewModel::handleInitializationChange
         );
 

--- a/example-apps/stytchexampleapp/build.gradle.kts
+++ b/example-apps/stytchexampleapp/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
     kotlin("kapt")
 }
 
-val publicToken: String = rootProject.ext["STYTCH_PUBLIC_TOKEN"] as String
-
 android {
     namespace = "com.stytch.stytchexampleapp"
     compileSdk = 35
@@ -24,12 +22,6 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        manifestPlaceholders["stytchOAuthRedirectScheme"] = ""
-        manifestPlaceholders["stytchOAuthRedirectHost"] = ""
-        manifestPlaceholders["STYTCH_PUBLIC_TOKEN"] = publicToken
-        manifestPlaceholders["STYTCH_B2B_PUBLIC_TOKEN"] = ""
-
-        buildConfigField("String", "STYTCH_PUBLIC_TOKEN", "\"$publicToken\"")
     }
 
     buildTypes {

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainApplication.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainApplication.kt
@@ -8,6 +8,6 @@ import dagger.hilt.android.HiltAndroidApp
 class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        StytchClient.configure(applicationContext, BuildConfig.STYTCH_PUBLIC_TOKEN)
+        StytchClient.configure(applicationContext)
     }
 }

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -72,18 +72,6 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.kotlinCompilerExtension.get()
     }
-    testVariants.all {
-        mergedFlavor.manifestPlaceholders["stytchOAuthRedirectScheme"] = "test://"
-        mergedFlavor.manifestPlaceholders["stytchOAuthRedirectHost"] = "oauth"
-        mergedFlavor.manifestPlaceholders["STYTCH_PUBLIC_TOKEN"] = "test"
-        mergedFlavor.manifestPlaceholders["STYTCH_B2B_PUBLIC_TOKEN"] = "test"
-    }
-    unitTestVariants.all {
-        mergedFlavor.manifestPlaceholders["stytchOAuthRedirectScheme"] = "test://"
-        mergedFlavor.manifestPlaceholders["stytchOAuthRedirectHost"] = "oauth"
-        mergedFlavor.manifestPlaceholders["STYTCH_PUBLIC_TOKEN"] = "test"
-        mergedFlavor.manifestPlaceholders["STYTCH_B2B_PUBLIC_TOKEN"] = "test"
-    }
 }
 
 tasks.named<DokkaTaskPartial>("dokkaHtmlPartial").configure {

--- a/source/sdk/src/main/AndroidManifest.xml
+++ b/source/sdk/src/main/AndroidManifest.xml
@@ -21,8 +21,8 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <!-- These manifestPlaceholders in are defined in the application build.gradle -->
                 <data
-                    android:scheme="${stytchOAuthRedirectScheme}"
-                    android:host="${stytchOAuthRedirectHost}" />
+                    android:scheme="@string/STYTCH_PUBLIC_TOKEN"
+                    android:host="oauth" />
             </intent-filter>
         </activity>
         <activity
@@ -38,8 +38,8 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <!-- These manifestPlaceholders in are defined in the application build.gradle -->
                 <data
-                    android:scheme="stytchui-${STYTCH_PUBLIC_TOKEN}"
-                    android:host="deeplink" />
+                    android:scheme="@string/STYTCH_PUBLIC_TOKEN"
+                    android:host="b2c-ui" />
             </intent-filter>
         </activity>
         <activity
@@ -55,8 +55,8 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <!-- These manifestPlaceholders in are defined in the application build.gradle -->
                 <data
-                    android:scheme="stytchui-${STYTCH_B2B_PUBLIC_TOKEN}"
-                    android:host="deeplink" />
+                    android:scheme="@string/STYTCH_PUBLIC_TOKEN"
+                    android:host="b2b-ui" />
             </intent-filter>
         </activity>
     </application>

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import com.stytch.sdk.R
 import com.stytch.sdk.b2b.discovery.Discovery
 import com.stytch.sdk.b2b.discovery.DiscoveryImpl
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
@@ -50,6 +51,7 @@ import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchLazyDelegate
+import com.stytch.sdk.common.StytchLog
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.ActivityProvider
 import com.stytch.sdk.common.dfp.CaptchaProviderImpl
@@ -120,6 +122,73 @@ public object StytchB2BClient {
      * across app launches.
      * You must call this method before making any Stytch authentication requests.
      * @param context The applicationContext of your app
+     * @param callback An optional callback that is triggered after configuration and initialization has completed
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(context: Context) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, StytchClientOptions(), {})
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
+     * @param options Optional options to configure the StytchClient
+     * @param callback An optional callback that is triggered after configuration and initialization has completed
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(
+        context: Context,
+        options: StytchClientOptions = StytchClientOptions(),
+        callback: ((Boolean) -> Unit) = {},
+    ) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, options, callback)
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
+     * @param callback An optional callback that is triggered after configuration and initialization has completed
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(
+        context: Context,
+        callback: ((Boolean) -> Unit) = {},
+    ) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, StytchClientOptions(), callback)
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
+     * @param options Optional options to configure the StytchClient
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(
+        context: Context,
+        options: StytchClientOptions = StytchClientOptions(),
+    ) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, options, {})
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
      * @param publicToken Available via the Stytch dashboard in the API keys section
      * @param options Optional options to configure the StytchB2BClient
      * @param callback An optional callback that is triggered after configuration and initialization has completed
@@ -132,6 +201,7 @@ public object StytchB2BClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
+        StytchLog.d("Using public token=$publicToken")
         if (::publicToken.isInitialized && publicToken == this.publicToken && options == this.stytchClientOptions) {
             return callback(true)
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import com.stytch.sdk.R
 import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeeplinkHandledStatus
@@ -18,6 +19,7 @@ import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchLazyDelegate
+import com.stytch.sdk.common.StytchLog
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.ActivityProvider
 import com.stytch.sdk.common.dfp.CaptchaProviderImpl
@@ -113,6 +115,73 @@ public object StytchClient {
      * across app launches.
      * You must call this method before making any Stytch authentication requests.
      * @param context The applicationContext of your app
+     * @param callback An optional callback that is triggered after configuration and initialization has completed
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(context: Context) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, StytchClientOptions(), {})
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
+     * @param options Optional options to configure the StytchClient
+     * @param callback An optional callback that is triggered after configuration and initialization has completed
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(
+        context: Context,
+        options: StytchClientOptions = StytchClientOptions(),
+        callback: ((Boolean) -> Unit) = {},
+    ) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, options, callback)
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
+     * @param callback An optional callback that is triggered after configuration and initialization has completed
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(
+        context: Context,
+        callback: ((Boolean) -> Unit) = {},
+    ) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, StytchClientOptions(), callback)
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
+     * @param options Optional options to configure the StytchClient
+     * @throws StytchInternalError - if we failed to initialize for any reason
+     */
+    @JvmStatic
+    public fun configure(
+        context: Context,
+        options: StytchClientOptions = StytchClientOptions(),
+    ) {
+        val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
+        configure(context, publicToken, options, {})
+    }
+
+    /**
+     * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
+     * across app launches.
+     * You must call this method before making any Stytch authentication requests.
+     * @param context The applicationContext of your app
      * @param publicToken Available via the Stytch dashboard in the API keys section
      * @param options Optional options to configure the StytchClient
      * @param callback An optional callback that is triggered after configuration and initialization has completed
@@ -125,6 +194,7 @@ public object StytchClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
+        StytchLog.d("Using public token=$publicToken")
         if (::publicToken.isInitialized && publicToken == this.publicToken && options == this.stytchClientOptions) {
             return callback(true)
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseGetRedirectUrl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseGetRedirectUrl.kt
@@ -2,4 +2,4 @@ package com.stytch.sdk.ui.b2b.usecases
 
 import com.stytch.sdk.b2b.StytchB2BClient
 
-internal fun getRedirectUrl(): String = "stytchui-${StytchB2BClient.publicToken}://deeplink"
+internal fun getRedirectUrl(): String = "${StytchB2BClient.publicToken}://b2b-ui"

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptions.kt
@@ -31,8 +31,8 @@ public data class EmailMagicLinksOptions
             locale: Locale,
         ) = MagicLinks.EmailMagicLinks.Parameters(
             email = emailAddress,
-            loginMagicLinkUrl = "stytchui-$publicToken://deeplink",
-            signupMagicLinkUrl = "stytchui-$publicToken://deeplink",
+            loginMagicLinkUrl = "$publicToken://b2c-ui",
+            signupMagicLinkUrl = "$publicToken://b2c-ui",
             loginExpirationMinutes = loginExpirationMinutes,
             signupExpirationMinutes = signupExpirationMinutes,
             loginTemplateId = loginTemplateId,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/PasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/PasswordOptions.kt
@@ -29,9 +29,9 @@ public data class PasswordOptions
             locale: Locale,
         ) = Passwords.ResetByEmailStartParameters(
             email = emailAddress,
-            loginRedirectUrl = "stytchui-$publicToken://deeplink",
+            loginRedirectUrl = "$publicToken://b2c-ui",
             loginExpirationMinutes = loginExpirationMinutes,
-            resetPasswordRedirectUrl = "stytchui-$publicToken://deeplink",
+            resetPasswordRedirectUrl = "$publicToken://b2c-ui",
             resetPasswordExpirationMinutes = resetPasswordExpirationMinutes,
             resetPasswordTemplateId = resetPasswordTemplateId,
             locale = locale,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
@@ -84,8 +84,8 @@ internal class MainScreenViewModel(
             OAuth.ThirdParty.StartParameters(
                 context = context,
                 oAuthRequestIdentifier = STYTCH_THIRD_PARTY_OAUTH_REQUEST_ID,
-                loginRedirectUrl = oAuthOptions?.loginRedirectURL,
-                signupRedirectUrl = oAuthOptions?.signupRedirectURL,
+                loginRedirectUrl = "${StytchClient.publicToken}://oauth",
+                signupRedirectUrl = "${StytchClient.publicToken}://oauth",
             )
         when (provider) {
             OAuthProvider.AMAZON -> stytchClient.oauth.amazon.start(parameters)

--- a/source/sdk/src/main/res/values/strings.xml
+++ b/source/sdk/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- ACTIVITY DEEPLINK STRINGS -->
+    <string name="STYTCH_PUBLIC_TOKEN" />
     <!-- Headless SDK strings -->
     <string name="stytch_biometric_prompt_title">Biometric Authentication</string>
     <string name="stytch_biometric_prompt_subtitle">Authenticate using your biometric credential</string>

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptionsTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptionsTest.kt
@@ -17,8 +17,8 @@ internal class EmailMagicLinksOptionsTest {
         val expected =
             MagicLinks.EmailMagicLinks.Parameters(
                 email = "my@email.com",
-                loginMagicLinkUrl = "stytchui-publicToken://deeplink",
-                signupMagicLinkUrl = "stytchui-publicToken://deeplink",
+                loginMagicLinkUrl = "publicToken://b2c-ui",
+                signupMagicLinkUrl = "publicToken://b2c-ui",
                 loginExpirationMinutes = options.loginExpirationMinutes,
                 signupExpirationMinutes = options.signupExpirationMinutes,
                 loginTemplateId = options.loginTemplateId,

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/data/PasswordOptionsTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/data/PasswordOptionsTest.kt
@@ -16,9 +16,9 @@ internal class PasswordOptionsTest {
         val expected =
             Passwords.ResetByEmailStartParameters(
                 email = "my@email.com",
-                loginRedirectUrl = "stytchui-publicToken://deeplink",
+                loginRedirectUrl = "publicToken://b2c-ui",
                 loginExpirationMinutes = options.loginExpirationMinutes,
-                resetPasswordRedirectUrl = "stytchui-publicToken://deeplink",
+                resetPasswordRedirectUrl = "publicToken://b2c-ui",
                 resetPasswordExpirationMinutes = options.resetPasswordExpirationMinutes,
                 resetPasswordTemplateId = options.resetPasswordTemplateId,
                 locale = Locale.EN,

--- a/tutorials/OAuth.md
+++ b/tutorials/OAuth.md
@@ -8,9 +8,9 @@ To see all of the currently supported OAuth providers, check the properties of t
 ## Redirect
 Redirect OAuth/SSO is the OAuth/SSO you may be most familiar with on the web: You click a button, are redirected to the selected IdP, login, and are redirected back to the original webpage. The same concept applies with the Stytch Android SDK, except the redirects are handled in a browser activity, and the backstack is managed by the SDK.
 
-To accomplish this, the SDK uses a multi-activity pattern that handles all of the redirect and backstack management logic to ensure the backstack stays clean, and activities are finished in the correct order. If you were wondering why, in the getting started [README](../README.md), you needed to add manifest-placeholders for `stytchOAuthRedirectScheme` and `stytchOAuthRedirectHost`, it's to enable this functionality. Let's dig into those placeholders a little more.
+To accomplish this, the SDK uses a multi-activity pattern that handles all of the redirect and backstack management logic to ensure the backstack stays clean, and activities are finished in the correct order. 
 
-When you provide these placeholders, the SDK registers an activity intent-filter for our "receiver" activity. When you start a redirect-based OAuth flow, the SDK launches a "manager" activity, which launches an "authorization" activity (the best system browser we can detect on device). Depending on the outcome of that authorization activity (user sign in, user canceled, etc), the authorization activity will either `finish` itself and return to the manager activity, or launch our receiver activity (identified by the manifest-placeholders), which will in turn launch our manager activity in such a way that ensures all previous activities in the flow are removed from the backstack.
+The SDK registers an activity intent-filter for our "receiver" activity. When you start a redirect-based OAuth flow, the SDK launches a "manager" activity, which launches an "authorization" activity (the best system browser we can detect on device). Depending on the outcome of that authorization activity (user sign in, user canceled, etc), the authorization activity will either `finish` itself and return to the manager activity, or launch our receiver activity (identified by the manifest-placeholders), which will in turn launch our manager activity in such a way that ensures all previous activities in the flow are removed from the backstack.
 
 For a deeper understanding of the third-party OAuth architecture, check out the [OAuth/SSO README](../source/sdk/src/main/java/com/stytch/sdk/common/sso/README.md).
 
@@ -19,21 +19,8 @@ There are two ways to listen for the result of this flow:
 2. **Direct Token Capture -** Configure the OAuth/SSO client with your currently running activity (using `oauth.setOAuthReceiverActivity()`/`sso.setSSOReceiverActivity()`, and use the appropriate `getTokenForProvider()` method. Under the hood, this works the same way as the first option, but will return the final token to the coroutine/callback/CompletableFuture. This method is a little easier to setup, as you don't need to specify an activity result listener, or parse the returned link manually
 
 ### Example Code
-For both flows in the following examples, we're going to use a redirect path of `my-app://oauth?type={}`, so make sure to add that as a valid redirect URL for the `Login` and `Signup` types in your Stytch Dashboard's [Redirect URL settings](stytch.com/dashboard/redirect-urls). You will also need to configure an [OAuth provider](https://stytch.com/dashboard/oauth). In this example, we are using GitHub.
+For both flows in the following examples, we're going to use a redirect path of `app://oauth?type={}`, so make sure to add that as a valid redirect URL for the `Login` and `Signup` types in your Stytch Dashboard's [Redirect URL settings](stytch.com/dashboard/redirect-urls). You will also need to configure an [OAuth provider](https://stytch.com/dashboard/oauth). In this example, we are using GitHub.
 
-Next, in your app's `build.gradle(.kts)`,  add the appropriate manifest placeholders:
-```gradle
-android {
-    ...
-    defaultConfig {
-        ...
-        manifestPlaceholders = [  
-            'stytchOAuthRedirectScheme': 'my-app',
-            'stytchOAuthRedirectHost': 'oauth'
-        ]
-    }
-}
-```
 #### Activity Result Callback flow:
 For this flow,  you will need to create an activity result handler in your main activity:
 ```kotlin

--- a/tutorials/UI.md
+++ b/tutorials/UI.md
@@ -1,5 +1,7 @@
 # StytchUI Usage
-The UI SDK automatically handles all necessary OAuth, Email Magic Link, and Password Reset deeplinks. To enable this functionality, you need to add a specific redirect URL in your [Stytch Dashboard](https://stytch.com/dashboard/redirect-urls): `stytchui-[YOUR_PUBLIC_TOKEN]://deeplink`, and set it as valid for Signups, Logins, and Password Resets.
+The UI SDK automatically handles all necessary OAuth, Email Magic Link, and Password Reset deeplinks. To enable this functionality, you need to add two specific redirect URLs in your [Stytch Dashboard](https://stytch.com/dashboard/redirect-urls):
+1. `[YOUR_PUBLIC_TOKEN]://b2c-ui` or `[YOUR_PUBLIC_TOKEN]://b2b-ui`, depending on if you are using a Consumer or B2B application, and set it as valid for all redirect types.
+2. `[YOUR_PUBLIC_TOKEN]://oauth`, for handling OAuth login and redirect URLs
 
 The Stytch UI uses the Builder pattern to initialize the UI, and allows you to fully customize the look, feel, and supported products.
 
@@ -24,8 +26,6 @@ private val stytchUi = StytchUI.Builder().apply {
                 clientId = BuildConfig.GOOGLE_OAUTH_CLIENT_ID
             ),
             oAuthOptions = OAuthOptions(
-                loginRedirectURL = "uiworkbench://oauth", // This should match what you defined in your manifestPlaceholders
-                signupRedirectURL = "uiworkbench://oauth", // This should match what you defined in your manifestPlaceholders
                 providers = listOf(OAuthProvider.GOOGLE, OAuthProvider.APPLE, OAuthProvider.GITHUB)
             ),
             otpOptions = OTPOptions(

--- a/workbench-apps/b2b-workbench/build.gradle.kts
+++ b/workbench-apps/b2b-workbench/build.gradle.kts
@@ -15,11 +15,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        // Placeholders for OAuth redirect
-        manifestPlaceholders["stytchOAuthRedirectScheme"] = "app"
-        manifestPlaceholders["stytchOAuthRedirectHost"] = "b2bOAuth"
-        manifestPlaceholders["STYTCH_PUBLIC_TOKEN"] = rootProject.ext["STYTCH_PUBLIC_TOKEN"] as String
-        manifestPlaceholders["STYTCH_B2B_PUBLIC_TOKEN"] = rootProject.ext["STYTCH_B2B_PUBLIC_TOKEN"] as String
     }
 
     buildFeatures {
@@ -28,13 +23,6 @@ android {
     }
 
     buildTypes {
-        all {
-            val b2bPublicToken = rootProject.ext["STYTCH_B2B_PUBLIC_TOKEN"] as String
-            buildConfigField("String", "STYTCH_B2B_PUBLIC_TOKEN", "\"$b2bPublicToken\"")
-
-            val b2bOrganizationId = rootProject.ext["STYTCH_B2B_ORG_ID"] as String
-            buildConfigField("String", "STYTCH_B2B_ORG_ID", "\"$b2bOrganizationId\"")
-        }
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")

--- a/workbench-apps/b2b-workbench/src/main/AndroidManifest.xml
+++ b/workbench-apps/b2b-workbench/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="app"
-                    android:host="@string/host" />
+                    android:host="b2bworkbench" />
             </intent-filter>
         </activity>
         <activity android:name="com.stytch.exampleapp.b2b.UIWorkbenchActivity"  android:exported="true">
@@ -39,7 +39,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="app"
-                    android:host="@string/host" />
+                    android:host="b2bworkbenchui" />
             </intent-filter>
         </activity>
     </application>

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/App.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/App.kt
@@ -13,10 +13,7 @@ class App : Application() {
         super.onCreate()
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         Timber.plant(Timber.DebugTree())
-        StytchB2BClient.configure(
-            context = applicationContext,
-            publicToken = BuildConfig.STYTCH_B2B_PUBLIC_TOKEN,
-        )
+        StytchB2BClient.configure(applicationContext)
         CoroutineScope(Dispatchers.Main).launch {
             StytchB2BClient.sessions.onChange.collect {
                 println("Collected session data: $it")

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
@@ -36,7 +36,7 @@ class HomeViewModel(
     val intermediateSessionToken: StateFlow<String>
         get() = _intermediateSessionToken
 
-    var orgIdState by mutableStateOf(TextFieldValue(BuildConfig.STYTCH_B2B_ORG_ID))
+    var orgIdState by mutableStateOf(TextFieldValue(""))
     var emailState by mutableStateOf(TextFieldValue(""))
     var orgSlugState by mutableStateOf(TextFieldValue(""))
     var showEmailError by mutableStateOf(false)

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/OAuthViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/OAuthViewModel.kt
@@ -34,8 +34,8 @@ class OAuthViewModel : ViewModel() {
                     context = context,
                     oAuthRequestIdentifier = B2B_OAUTH_REQUEST,
                     organizationId = orgIdState.text,
-                    loginRedirectUrl = "app://b2bexampleapp.com/",
-                    signupRedirectUrl = "app://b2bexampleapp.com/",
+                    loginRedirectUrl = "app://b2bworkbench?type={}",
+                    signupRedirectUrl = "app://b2bworkbench?type={}",
                 ),
             )
         }
@@ -47,7 +47,7 @@ class OAuthViewModel : ViewModel() {
                 OAuth.ProviderDiscovery.DiscoveryStartParameters(
                     context = context,
                     oAuthRequestIdentifier = B2B_OAUTH_REQUEST,
-                    discoveryRedirectUrl = "app://b2bexampleapp.com/",
+                    discoveryRedirectUrl = "app://b2bworkbench?type={}",
                 ),
             )
         }

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/OAuthViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/OAuthViewModel.kt
@@ -1,6 +1,10 @@
 package com.stytch.exampleapp.b2b
 
 import android.app.Activity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.b2b.StytchB2BClient
@@ -21,13 +25,15 @@ class OAuthViewModel : ViewModel() {
     val loadingState: StateFlow<Boolean>
         get() = _loadingState
 
+    var orgIdState by mutableStateOf(TextFieldValue(""))
+
     fun startGoogleOAuthFlow(context: Activity) {
         viewModelScope.launchAndToggleLoadingState {
             StytchB2BClient.oauth.google.start(
                 OAuth.Provider.StartParameters(
                     context = context,
                     oAuthRequestIdentifier = B2B_OAUTH_REQUEST,
-                    organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
+                    organizationId = orgIdState.text,
                     loginRedirectUrl = "app://b2bexampleapp.com/",
                     signupRedirectUrl = "app://b2bexampleapp.com/",
                 ),
@@ -52,7 +58,7 @@ class OAuthViewModel : ViewModel() {
             val result =
                 StytchB2BClient.oauth.google.getTokenForProvider(
                     OAuth.Provider.GetTokenForProviderParams(
-                        organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
+                        organizationId = orgIdState.text,
                         loginRedirectUrl = "app://b2bOAuth",
                         signupRedirectUrl = "app://b2bOAuth",
                     ),

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/OTPViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/OTPViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class OTPViewModel : ViewModel() {
-    var orgIdState by mutableStateOf(TextFieldValue(BuildConfig.STYTCH_B2B_ORG_ID))
+    var orgIdState by mutableStateOf(TextFieldValue(""))
     var memberIdState by mutableStateOf(TextFieldValue(""))
     var phoneNumberState by mutableStateOf(TextFieldValue(""))
     var codeState by mutableStateOf(TextFieldValue(""))

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/PasswordsViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/PasswordsViewModel.kt
@@ -19,6 +19,7 @@ class PasswordsViewModel : ViewModel() {
     var existingPasswordState by mutableStateOf(TextFieldValue(""))
     var newPasswordState by mutableStateOf(TextFieldValue(""))
     var passwordResetTokenState by mutableStateOf(TextFieldValue(""))
+    var orgIdState by mutableStateOf(TextFieldValue(""))
 
     private val _currentResponse = MutableStateFlow("")
     val currentResponse: StateFlow<String>
@@ -34,7 +35,7 @@ class PasswordsViewModel : ViewModel() {
                 StytchB2BClient.passwords
                     .resetByEmailStart(
                         Passwords.ResetByEmailStartParameters(
-                            organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
+                            organizationId = orgIdState.text,
                             emailAddress = emailState.text,
                             loginRedirectUrl = "app://b2bexampleapp.com/",
                             resetPasswordRedirectUrl = "app://b2bexampleapp.com/",
@@ -49,7 +50,7 @@ class PasswordsViewModel : ViewModel() {
                 StytchB2BClient.passwords
                     .resetByExisting(
                         Passwords.ResetByExistingPasswordParameters(
-                            organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
+                            organizationId = orgIdState.text,
                             emailAddress = emailState.text,
                             existingPassword = existingPasswordState.text,
                             newPassword = newPasswordState.text,
@@ -64,7 +65,7 @@ class PasswordsViewModel : ViewModel() {
                 StytchB2BClient.passwords
                     .resetBySession(
                         Passwords.ResetBySessionParameters(
-                            organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
+                            organizationId = orgIdState.text,
                             password = newPasswordState.text,
                         ),
                     ).toFriendlyDisplay()
@@ -77,7 +78,7 @@ class PasswordsViewModel : ViewModel() {
                 StytchB2BClient.passwords
                     .authenticate(
                         Passwords.AuthParameters(
-                            organizationId = BuildConfig.STYTCH_B2B_ORG_ID,
+                            organizationId = orgIdState.text,
                             emailAddress = emailState.text,
                             password = existingPasswordState.text,
                         ),

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/RecoveryCodesViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/RecoveryCodesViewModel.kt
@@ -23,18 +23,17 @@ class RecoveryCodesViewModel : ViewModel() {
     val loadingState: StateFlow<Boolean>
         get() = _loadingState
 
-    var orgIdState by mutableStateOf(TextFieldValue(BuildConfig.STYTCH_B2B_ORG_ID))
+    var orgIdState by mutableStateOf(TextFieldValue(""))
     var memberIdState by mutableStateOf(TextFieldValue(""))
     var codeState by mutableStateOf(TextFieldValue(""))
 
-    private fun CoroutineScope.launchAndToggleLoadingState(block: suspend () -> Unit): DisposableHandle {
-        return launch {
+    private fun CoroutineScope.launchAndToggleLoadingState(block: suspend () -> Unit): DisposableHandle =
+        launch {
             _loadingState.value = true
             block()
         }.invokeOnCompletion {
             _loadingState.value = false
         }
-    }
 
     fun get() {
         viewModelScope.launchAndToggleLoadingState {
@@ -51,14 +50,15 @@ class RecoveryCodesViewModel : ViewModel() {
     fun recover() {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
-                StytchB2BClient.recoveryCodes.recover(
-                    RecoveryCodes.RecoverParameters(
-                        organizationId = orgIdState.text,
-                        memberId = memberIdState.text,
-                        sessionDurationMinutes = 30,
-                        recoveryCode = codeState.text,
-                    ),
-                ).toFriendlyDisplay()
+                StytchB2BClient.recoveryCodes
+                    .recover(
+                        RecoveryCodes.RecoverParameters(
+                            organizationId = orgIdState.text,
+                            memberId = memberIdState.text,
+                            sessionDurationMinutes = 30,
+                            recoveryCode = codeState.text,
+                        ),
+                    ).toFriendlyDisplay()
         }
     }
 }

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/TOTPViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/TOTPViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class TOTPViewModel : ViewModel() {
-    var orgIdState by mutableStateOf(TextFieldValue(BuildConfig.STYTCH_B2B_ORG_ID))
+    var orgIdState by mutableStateOf(TextFieldValue(""))
     var memberIdState by mutableStateOf(TextFieldValue(""))
     var codeState by mutableStateOf(TextFieldValue(""))
     private val _currentResponse = MutableStateFlow("")

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/OAuthScreen.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/OAuthScreen.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -31,6 +34,18 @@ fun OAuthScreen(viewModel: OAuthViewModel) {
             modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = viewModel.orgIdState,
+                singleLine = true,
+                label = {
+                    Text(text = stringResource(id = R.string.b2b_org_id))
+                },
+                onValueChange = {
+                    viewModel.orgIdState = it
+                },
+                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
+            )
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.oauth_start),

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/PasswordsScreen.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/ui/PasswordsScreen.kt
@@ -34,6 +34,18 @@ fun PasswordsScreen(viewModel: PasswordsViewModel) {
         ) {
             TextField(
                 modifier = Modifier.fillMaxWidth(),
+                value = viewModel.orgIdState,
+                singleLine = true,
+                label = {
+                    Text(text = stringResource(id = R.string.b2b_org_id))
+                },
+                onValueChange = {
+                    viewModel.orgIdState = it
+                },
+                shape = MaterialTheme.shapes.small.copy(all = ZeroCornerSize),
+            )
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
                 value = viewModel.emailState,
                 singleLine = true,
                 label = {

--- a/workbench-apps/consumer-workbench/build.gradle.kts
+++ b/workbench-apps/consumer-workbench/build.gradle.kts
@@ -15,11 +15,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        // Placeholders for OAuth redirect
-        manifestPlaceholders["stytchOAuthRedirectScheme"] = "app"
-        manifestPlaceholders["stytchOAuthRedirectHost"] = "oauth"
-        manifestPlaceholders["STYTCH_PUBLIC_TOKEN"] = rootProject.ext["STYTCH_PUBLIC_TOKEN"] as String
-        manifestPlaceholders["STYTCH_B2B_PUBLIC_TOKEN"] = ""
     }
 
     buildFeatures {
@@ -29,9 +24,6 @@ android {
 
     buildTypes {
         all {
-            val publicToken = rootProject.ext["STYTCH_PUBLIC_TOKEN"] as String
-            buildConfigField("String", "STYTCH_PUBLIC_TOKEN", "\"$publicToken\"")
-
             val googleOAuthClientId = rootProject.ext["GOOGLE_OAUTH_CLIENT_ID"] as String
             buildConfigField("String", "GOOGLE_OAUTH_CLIENT_ID", "\"$googleOAuthClientId\"")
 

--- a/workbench-apps/consumer-workbench/src/main/AndroidManifest.xml
+++ b/workbench-apps/consumer-workbench/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="app"
-                    android:host="@string/host"
+                    android:host="consumerworkbench"
                     android:pathPrefix="/" />
             </intent-filter>
         </activity>

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/App.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/App.kt
@@ -13,10 +13,7 @@ class App : Application() {
         super.onCreate()
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         Timber.plant(Timber.DebugTree())
-        StytchClient.configure(
-            context = this,
-            publicToken = BuildConfig.STYTCH_PUBLIC_TOKEN,
-        ) {
+        StytchClient.configure(this) {
             println("Stytch has been initialized and configured and is ready for use")
         }
         CoroutineScope(Dispatchers.Main).launch {

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/OAuthViewModel.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/OAuthViewModel.kt
@@ -68,8 +68,8 @@ class OAuthViewModel(
             OAuth.ThirdParty.StartParameters(
                 context = context,
                 oAuthRequestIdentifier = THIRD_PARTY_OAUTH_REQUEST,
-                loginRedirectUrl = "app://oauth",
-                signupRedirectUrl = "app://oauth",
+                loginRedirectUrl = "app://consumerworkbench/?type={}",
+                signupRedirectUrl = "app://consumerworkbench/?type={}",
             )
         when (provider) {
             OAuthProvider.APPLE -> StytchClient.oauth.apple.start(startParameters)
@@ -93,8 +93,8 @@ class OAuthViewModel(
     fun loginWithThirdPartyOAuthOneShot(provider: OAuthProvider) {
         val startParameters =
             OAuth.ThirdParty.GetTokenForProviderParams(
-                loginRedirectUrl = "app://oauth",
-                signupRedirectUrl = "app://oauth",
+                loginRedirectUrl = "app://consumerworkbench/?type={}",
+                signupRedirectUrl = "app://consumerworkbench/?type={}",
             )
         viewModelScope
             .launch {

--- a/workbench-apps/uiworkbench/build.gradle.kts
+++ b/workbench-apps/uiworkbench/build.gradle.kts
@@ -4,8 +4,7 @@ plugins {
     alias(libs.plugins.kotlinPluginCompose)
 }
 
-val publicToken = rootProject.extra["STYTCH_PUBLIC_TOKEN"] as String
-val googleOAuthClientId = rootProject.extra["UI_GOOGLE_CLIENT_ID"] as String
+val googleOAuthClientId = rootProject.extra["GOOGLE_OAUTH_CLIENT_ID"] as String
 
 android {
     namespace = "com.stytch.uiworkbench"
@@ -22,20 +21,10 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        // Placeholders for OAuth redirect
-        manifestPlaceholders.putAll(
-            mapOf(
-                "stytchOAuthRedirectScheme" to "uiworkbench",
-                "stytchOAuthRedirectHost" to "oauth",
-                "STYTCH_PUBLIC_TOKEN" to publicToken,
-                "STYTCH_B2B_PUBLIC_TOKEN" to "",
-            ),
-        )
     }
 
     buildTypes {
         all {
-            buildConfigField("String", "STYTCH_PUBLIC_TOKEN", "\"$publicToken\"")
             buildConfigField("String", "GOOGLE_OAUTH_CLIENT_ID", "\"$googleOAuthClientId\"")
         }
         release {

--- a/workbench-apps/uiworkbench/src/main/AndroidManifest.xml
+++ b/workbench-apps/uiworkbench/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="myuiapp" android:pathPrefix="/" />
+                <data android:scheme="app" android:host="uiworkbench" />
             </intent-filter>
         </activity>
     </application>

--- a/workbench-apps/uiworkbench/src/main/java/com/stytch/uiworkbench/UiWorkbenchActivity.kt
+++ b/workbench-apps/uiworkbench/src/main/java/com/stytch/uiworkbench/UiWorkbenchActivity.kt
@@ -51,8 +51,6 @@ class UiWorkbenchActivity : ComponentActivity() {
                             ),
                         oAuthOptions =
                             OAuthOptions(
-                                loginRedirectURL = "uiworkbench://oauth",
-                                signupRedirectURL = "uiworkbench://oauth",
                                 providers = listOf(OAuthProvider.GOOGLE, OAuthProvider.APPLE, OAuthProvider.GITHUB),
                             ),
                         otpOptions =

--- a/workbench-apps/uiworkbench/src/main/java/com/stytch/uiworkbench/UiWorkbenchApplication.kt
+++ b/workbench-apps/uiworkbench/src/main/java/com/stytch/uiworkbench/UiWorkbenchApplication.kt
@@ -6,6 +6,6 @@ import com.stytch.sdk.consumer.StytchClient
 class UiWorkbenchApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        StytchClient.configure(this, BuildConfig.STYTCH_PUBLIC_TOKEN)
+        StytchClient.configure(this)
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-2443](https://linear.app/stytch/issue/SDK-2443)

## Changes:

1. Eliminates the need for `manifestPlaceholders`, in place of an _optional_ string resource for enabling OAuth and UI deeplinks. Now, if a developer isn't using one of those pieces, they no longer need to set dummy placeholders. This also allows us to extract the pubic token in the configure call, instead of it being passed in, which removes the old question "Why am I adding a token to the placeholders _and_ a configure call". It also makes it easier, I think, to reason about how the deeplinks work.
2. Eliminates the need for most of the environment variables when working on the example/workbench apps (or running jobs on CI)

## Notes:

- Standardizing on a single string resource is the easiest/least frictiony way to get developers started, but necessitates setting _different_ default URLs in the dashboard than we previously advised. This is explained in the relevant tutorials. Hopefully in the near future we can automatically create these two URLs in the dashboard based on project configuration (like we do for `http://localhost:3000`)
- As mentioned, the string resource is OPTIONAL. It will not fail if it doesn't exist, and developers can continue to pass the token to the `configure` method, if they so choose. That said, the string resource method is now the _preferred_ way of using Stytch.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A