### PR TITLE
SDK-2372 Update B2B UI component ordering

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/ProductComponent.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/ProductComponent.kt
@@ -8,4 +8,11 @@ internal enum class ProductComponent {
     PasswordsEmailForm,
     PasswordEMLCombined,
     Divider,
+    ;
+
+    internal fun isInputComponent(): Boolean =
+        this == EmailForm ||
+            this == EmailDiscoveryForm ||
+            this == PasswordsEmailForm ||
+            this == PasswordEMLCombined
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/ProductComponent.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/ProductComponent.kt
@@ -15,4 +15,6 @@ internal enum class ProductComponent {
             this == EmailDiscoveryForm ||
             this == PasswordsEmailForm ||
             this == PasswordEMLCombined
+
+    internal fun isButtonComponent(): Boolean = this == OAuthButtons || this == SSOButtons
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
@@ -3,7 +3,6 @@ package com.stytch.sdk.ui.b2b.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
-import com.stytch.sdk.b2b.network.models.InternalOrganizationData
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.ui.shared.data.SessionOptions
@@ -38,82 +37,3 @@ public data class StytchB2BProductConfig
             ),
         val locale: Locale? = Locale.EN,
     ) : Parcelable
-
-/*
-  Here we are generating the ordering and which components will be displayed.
-  We use the Component enum this because there is some complex logic here, and
-  we want to be able to unit test.
-
-  Rules we want to follow when generating the components:
-  1. If we're displaying both an email-based method (email magic links and/or email OTPs) and passwords,
-  we need to display them together as a single wrapped component. The index of this wrapped component is
-  equivalent to the first index of either email-based method or passwords in the config products list.
-  2. If we have both buttons and input, we want to display a divider between the last 2 elements.
-  3. Some components have both a discovery and a non-discovery version. We want to display the correct version
-  based on the flow type (found in state).
-  4. We want to display the components in the order that they are listed in the config.
-
-  This function should be considered the source of truth for which components to render
-  and what order to render them in as of 6/21/23.
-*/
-internal fun List<StytchB2BProduct>.generateProductComponentsOrdering(
-    authFlowType: AuthFlowType,
-    organization: InternalOrganizationData?,
-): List<ProductComponent> {
-    val containsEmail = contains(StytchB2BProduct.EMAIL_MAGIC_LINKS) || contains(StytchB2BProduct.EMAIL_OTP)
-    val displayEmlAndPasswordsTogether = containsEmail && contains(StytchB2BProduct.PASSWORDS)
-    val components =
-        mapNotNull { product ->
-            when (product) {
-                StytchB2BProduct.EMAIL_MAGIC_LINKS,
-                StytchB2BProduct.EMAIL_OTP,
-                -> {
-                    if (displayEmlAndPasswordsTogether) {
-                        ProductComponent.PasswordEMLCombined
-                    } else {
-                        if (authFlowType == AuthFlowType.ORGANIZATION) {
-                            ProductComponent.EmailForm
-                        } else {
-                            ProductComponent.EmailDiscoveryForm
-                        }
-                    }
-                }
-
-                StytchB2BProduct.OAUTH -> {
-                    ProductComponent.OAuthButtons
-                }
-
-                StytchB2BProduct.SSO -> {
-                    // We only need to render a component if we have a valid SSO connection
-                    organization?.let { org ->
-                        val isSSOValid = !org.ssoActiveConnections.isNullOrEmpty()
-                        if (authFlowType == AuthFlowType.ORGANIZATION && isSSOValid) {
-                            ProductComponent.SSOButtons
-                        } else {
-                            null
-                        }
-                    }
-                }
-
-                StytchB2BProduct.PASSWORDS -> {
-                    if (displayEmlAndPasswordsTogether) {
-                        ProductComponent.PasswordEMLCombined
-                    } else {
-                        ProductComponent.PasswordsEmailForm
-                    }
-                }
-            }
-        }
-            // ensure we have only one of each component
-            .toSet()
-            // but we want a list we can modify
-            .toMutableList()
-
-    val hasButtons = components.any { it in setOf(ProductComponent.OAuthButtons, ProductComponent.SSOButtons) }
-    val hasInput = any { it in setOf(StytchB2BProduct.EMAIL_MAGIC_LINKS, StytchB2BProduct.PASSWORDS) }
-    val showDivider = hasButtons && hasInput
-    if (components.isNotEmpty() && showDivider) {
-        components.add(components.size - 1, ProductComponent.Divider)
-    }
-    return components.toList()
-}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrdering.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrdering.kt
@@ -14,16 +14,15 @@ import com.stytch.sdk.ui.b2b.data.StytchB2BProduct
     1. If we're displaying both email magic links or email otp and passwords, we need to display them together
        as a single wrapped component. The index of this wrapped component is equivalent to the first index of
        either email magic links, email otp, or passwords in the config products list.
-    2. If multiple "button types" are present, keep them together
-    3. If both buttons and inputs are present, display a divider above and below the input component.
+    2. If both buttons and inputs are present, display a divider above and below the input component.
        Do not add a divider above if the input is the first component or below if it is the last.
-    4. Overall, we want to display the components in the order that they are listed in the config, aside from the
+    3. Overall, we want to display the components in the order that they are listed in the config, aside from the
        operations described above
 */
 internal fun List<StytchB2BProduct>.generateProductComponentsOrdering(
     authFlowType: AuthFlowType,
     organization: InternalOrganizationData?,
-): List<ProductComponent> = mapProductsToComponents(authFlowType, organization).keepButtonsTogether().addDividers()
+): List<ProductComponent> = mapProductsToComponents(authFlowType, organization).addDividers()
 
 private fun List<StytchB2BProduct>.mapProductsToComponents(
     authFlowType: AuthFlowType,
@@ -76,19 +75,6 @@ private fun List<StytchB2BProduct>.mapProductsToComponents(
         .toSet()
         // make it a mutable list, for the next round of processing
         .toMutableList()
-}
-
-private fun MutableList<ProductComponent>.keepButtonsTogether(): MutableList<ProductComponent> {
-    val buttonTypes = filter { it.isButtonComponent() }
-    if (buttonTypes.isNotEmpty()) {
-        // get the index of the first button type
-        val firstButtonTypeIndex = indexOf(buttonTypes[0])
-        // remove all button types
-        removeAll(buttonTypes)
-        // re-add button types at the first button type index
-        addAll(firstButtonTypeIndex, buttonTypes)
-    }
-    return this
 }
 
 private fun MutableList<ProductComponent>.addDividers(): MutableList<ProductComponent> {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrdering.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrdering.kt
@@ -1,0 +1,88 @@
+package com.stytch.sdk.ui.b2b.extensions
+
+import com.stytch.sdk.b2b.network.models.InternalOrganizationData
+import com.stytch.sdk.ui.b2b.data.AuthFlowType
+import com.stytch.sdk.ui.b2b.data.ProductComponent
+import com.stytch.sdk.ui.b2b.data.StytchB2BProduct
+
+/*
+    Here we are generating the ordering and which components will be displayed.
+    We use the ProductComponent enum because there is some complex logic here, and
+    we want to be able to unit test.
+
+    Rules we want to follow when generating the components:
+    1. If we're displaying both email magic links or email otp and passwords, we need to display them together
+    as a single wrapped component. The index of this wrapped component is equivalent to the first index of
+    either email magic links, email otp, or passwords in the config products list.
+    2. If both buttons and input are present, display a divider above and below the input component.
+    Do not add a divider above if the input is the first component or below if it is the last.
+    3. We want to display the components in the order that they are listed in the config.
+*/
+internal fun List<StytchB2BProduct>.generateProductComponentsOrdering(
+    authFlowType: AuthFlowType,
+    organization: InternalOrganizationData?,
+): List<ProductComponent> {
+    val finalComponentOrdering = mutableListOf<ProductComponent>()
+    val containsEmail = contains(StytchB2BProduct.EMAIL_MAGIC_LINKS) || contains(StytchB2BProduct.EMAIL_OTP)
+    val displayEmlAndPasswordsTogether = containsEmail && contains(StytchB2BProduct.PASSWORDS)
+    // map StytchB2BProduct to appropriate ProductComponent
+    val productComponentList =
+        mapNotNull { product ->
+            when (product) {
+                StytchB2BProduct.EMAIL_MAGIC_LINKS,
+                StytchB2BProduct.EMAIL_OTP,
+                -> {
+                    if (displayEmlAndPasswordsTogether) {
+                        ProductComponent.PasswordEMLCombined
+                    } else {
+                        if (authFlowType == AuthFlowType.ORGANIZATION) {
+                            ProductComponent.EmailForm
+                        } else {
+                            ProductComponent.EmailDiscoveryForm
+                        }
+                    }
+                }
+
+                StytchB2BProduct.OAUTH -> {
+                    ProductComponent.OAuthButtons
+                }
+
+                StytchB2BProduct.SSO -> {
+                    // We only need to render a component if we have a valid SSO connection
+                    organization?.let { org ->
+                        val isSSOValid = !org.ssoActiveConnections.isNullOrEmpty()
+                        if (authFlowType == AuthFlowType.ORGANIZATION && isSSOValid) {
+                            ProductComponent.SSOButtons
+                        } else {
+                            null
+                        }
+                    }
+                }
+
+                StytchB2BProduct.PASSWORDS -> {
+                    if (displayEmlAndPasswordsTogether) {
+                        ProductComponent.PasswordEMLCombined
+                    } else {
+                        ProductComponent.PasswordsEmailForm
+                    }
+                }
+            }
+        }.toSet()
+    // add dividers as necessary
+    productComponentList
+        .forEachIndexed { index, component ->
+            val componentAndDividers = mutableListOf(component)
+            if (component.isInputComponent()) {
+                if (index > 0) {
+                    // add a divider before the component
+                    componentAndDividers.add(0, ProductComponent.Divider)
+                }
+                if (index < productComponentList.size - 1) {
+                    // add a divider after the component
+                    componentAndDividers.add(ProductComponent.Divider)
+                }
+            }
+            finalComponentOrdering.addAll(componentAndDividers)
+        }
+    return finalComponentOrdering
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrdering.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrdering.kt
@@ -12,11 +12,13 @@ import com.stytch.sdk.ui.b2b.data.StytchB2BProduct
 
     Rules we want to follow when generating the components:
     1. If we're displaying both email magic links or email otp and passwords, we need to display them together
-    as a single wrapped component. The index of this wrapped component is equivalent to the first index of
-    either email magic links, email otp, or passwords in the config products list.
-    2. If both buttons and input are present, display a divider above and below the input component.
-    Do not add a divider above if the input is the first component or below if it is the last.
-    3. We want to display the components in the order that they are listed in the config.
+       as a single wrapped component. The index of this wrapped component is equivalent to the first index of
+       either email magic links, email otp, or passwords in the config products list.
+    2. If multiple "button types" are present, keep them together
+    3. If both buttons and inputs are present, display a divider above and below the input component.
+       Do not add a divider above if the input is the first component or below if it is the last.
+    4. Overall, we want to display the components in the order that they are listed in the config, aside from the
+       operations described above
 */
 internal fun List<StytchB2BProduct>.generateProductComponentsOrdering(
     authFlowType: AuthFlowType,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/MainScreen.kt
@@ -40,7 +40,7 @@ import com.stytch.sdk.ui.b2b.data.SetLoading
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.data.StytchB2BProduct
 import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
-import com.stytch.sdk.ui.b2b.data.generateProductComponentsOrdering
+import com.stytch.sdk.ui.b2b.extensions.generateProductComponentsOrdering
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseEffectiveAuthConfig
 import com.stytch.sdk.ui.b2b.usecases.UseEmailOTPDiscoverySend

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrderingTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrderingTest.kt
@@ -21,8 +21,6 @@ internal class GenerateProductComponentsOrderingTest(
                 authFlowType = testCase.authFlowType,
                 organization = testCase.organization,
             )
-        println("EXPECTED: ${testCase.expected}")
-        println("ACTUAL: $actual")
         assert(actual == testCase.expected)
     }
 
@@ -135,10 +133,9 @@ internal val TEST_INPUTS_MIDDLE =
         expected =
             listOf(
                 ProductComponent.OAuthButtons,
+                ProductComponent.SSOButtons,
                 ProductComponent.Divider,
                 ProductComponent.EmailForm,
-                ProductComponent.Divider,
-                ProductComponent.SSOButtons,
             ),
     )
 internal val TEST_INPUTS_MIDDLE_MULTIPLE_INPUTS_ONE_COMPONENT =
@@ -159,10 +156,9 @@ internal val TEST_INPUTS_MIDDLE_MULTIPLE_INPUTS_ONE_COMPONENT =
         expected =
             listOf(
                 ProductComponent.OAuthButtons,
+                ProductComponent.SSOButtons,
                 ProductComponent.Divider,
                 ProductComponent.PasswordEMLCombined,
-                ProductComponent.Divider,
-                ProductComponent.SSOButtons,
             ),
     )
 

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrderingTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrderingTest.kt
@@ -133,9 +133,10 @@ internal val TEST_INPUTS_MIDDLE =
         expected =
             listOf(
                 ProductComponent.OAuthButtons,
-                ProductComponent.SSOButtons,
                 ProductComponent.Divider,
                 ProductComponent.EmailForm,
+                ProductComponent.Divider,
+                ProductComponent.SSOButtons,
             ),
     )
 internal val TEST_INPUTS_MIDDLE_MULTIPLE_INPUTS_ONE_COMPONENT =
@@ -156,9 +157,10 @@ internal val TEST_INPUTS_MIDDLE_MULTIPLE_INPUTS_ONE_COMPONENT =
         expected =
             listOf(
                 ProductComponent.OAuthButtons,
-                ProductComponent.SSOButtons,
                 ProductComponent.Divider,
                 ProductComponent.PasswordEMLCombined,
+                ProductComponent.Divider,
+                ProductComponent.SSOButtons,
             ),
     )
 

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrderingTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2b/extensions/GenerateProductComponentsOrderingTest.kt
@@ -1,0 +1,230 @@
+package com.stytch.sdk.ui.b2b.extensions
+
+import com.stytch.sdk.b2b.network.models.InternalOrganizationData
+import com.stytch.sdk.ui.b2b.data.AuthFlowType
+import com.stytch.sdk.ui.b2b.data.ProductComponent
+import com.stytch.sdk.ui.b2b.data.StytchB2BProduct
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class GenerateProductComponentsOrderingTest(
+    private val testCase: ProductComponentOrderingTestCase,
+) {
+    @Test
+    fun `Generates expected outputs`() {
+        val actual =
+            testCase.products.generateProductComponentsOrdering(
+                authFlowType = testCase.authFlowType,
+                organization = testCase.organization,
+            )
+        println("EXPECTED: ${testCase.expected}")
+        println("ACTUAL: $actual")
+        assert(actual == testCase.expected)
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun testCases(): Collection<ProductComponentOrderingTestCase> =
+            listOf(
+                TEST_NO_INPUTS,
+                TEST_NO_SSO_DISCOVERY,
+                TEST_NO_SSO_WITH_NO_CONNECTIONS,
+                TEST_SSO_WITH_VALID_CONNECTIONS,
+                TEST_INPUTS_FIRST,
+                TEST_INPUTS_MIDDLE,
+                TEST_INPUTS_MIDDLE_MULTIPLE_INPUTS_ONE_COMPONENT,
+                TEST_INPUTS_LAST,
+                TEST_MULTI_INPUTS_ONE_COMPONENT,
+                TEST_EML_DISCOVERY,
+                TEST_EOTP_DISCOVERY,
+                TEST_EMAIL_PASSWORD_COMBINED,
+                TEST_PASSWORD_ONLY,
+            )
+    }
+}
+
+internal data class ProductComponentOrderingTestCase(
+    val name: String,
+    val products: List<StytchB2BProduct>,
+    val authFlowType: AuthFlowType,
+    val organization: InternalOrganizationData?,
+    val expected: List<ProductComponent>,
+) {
+    override fun toString(): String = name
+}
+
+internal val TEST_NO_INPUTS =
+    ProductComponentOrderingTestCase(
+        name = "No Inputs",
+        products = listOf(StytchB2BProduct.OAUTH),
+        authFlowType = AuthFlowType.DISCOVERY,
+        organization = null,
+        expected = listOf(ProductComponent.OAuthButtons),
+    )
+
+internal val TEST_NO_SSO_DISCOVERY =
+    ProductComponentOrderingTestCase(
+        name = "No SSO in Discovery",
+        products = listOf(StytchB2BProduct.OAUTH, StytchB2BProduct.SSO),
+        authFlowType = AuthFlowType.DISCOVERY,
+        organization = null,
+        expected = listOf(ProductComponent.OAuthButtons),
+    )
+
+internal val TEST_NO_SSO_WITH_NO_CONNECTIONS =
+    ProductComponentOrderingTestCase(
+        name = "No SSO with no connections",
+        products = listOf(StytchB2BProduct.OAUTH, StytchB2BProduct.SSO),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization =
+            mockk {
+                every { ssoActiveConnections } returns emptyList()
+            },
+        expected = listOf(ProductComponent.OAuthButtons),
+    )
+
+internal val TEST_SSO_WITH_VALID_CONNECTIONS =
+    ProductComponentOrderingTestCase(
+        name = "SSO with valid connections",
+        products = listOf(StytchB2BProduct.OAUTH, StytchB2BProduct.SSO),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization =
+            mockk {
+                every { ssoActiveConnections } returns listOf(mockk(relaxed = true))
+            },
+        expected = listOf(ProductComponent.OAuthButtons, ProductComponent.SSOButtons),
+    )
+
+internal val TEST_INPUTS_FIRST =
+    ProductComponentOrderingTestCase(
+        name = "Inputs first",
+        products = listOf(StytchB2BProduct.EMAIL_MAGIC_LINKS, StytchB2BProduct.OAUTH, StytchB2BProduct.SSO),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization =
+            mockk {
+                every { ssoActiveConnections } returns listOf(mockk(relaxed = true))
+            },
+        expected =
+            listOf(
+                ProductComponent.EmailForm,
+                ProductComponent.Divider,
+                ProductComponent.OAuthButtons,
+                ProductComponent.SSOButtons,
+            ),
+    )
+
+internal val TEST_INPUTS_MIDDLE =
+    ProductComponentOrderingTestCase(
+        name = "Inputs in middle",
+        products =
+            listOf(
+                StytchB2BProduct.OAUTH,
+                StytchB2BProduct.EMAIL_MAGIC_LINKS,
+                StytchB2BProduct.SSO,
+            ),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization =
+            mockk {
+                every { ssoActiveConnections } returns listOf(mockk(relaxed = true))
+            },
+        expected =
+            listOf(
+                ProductComponent.OAuthButtons,
+                ProductComponent.Divider,
+                ProductComponent.EmailForm,
+                ProductComponent.Divider,
+                ProductComponent.SSOButtons,
+            ),
+    )
+internal val TEST_INPUTS_MIDDLE_MULTIPLE_INPUTS_ONE_COMPONENT =
+    ProductComponentOrderingTestCase(
+        name = "Inputs in middle with multiple input components",
+        products =
+            listOf(
+                StytchB2BProduct.OAUTH,
+                StytchB2BProduct.EMAIL_MAGIC_LINKS,
+                StytchB2BProduct.SSO,
+                StytchB2BProduct.PASSWORDS,
+            ),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization =
+            mockk {
+                every { ssoActiveConnections } returns listOf(mockk(relaxed = true))
+            },
+        expected =
+            listOf(
+                ProductComponent.OAuthButtons,
+                ProductComponent.Divider,
+                ProductComponent.PasswordEMLCombined,
+                ProductComponent.Divider,
+                ProductComponent.SSOButtons,
+            ),
+    )
+
+internal val TEST_INPUTS_LAST =
+    ProductComponentOrderingTestCase(
+        name = "Inputs last",
+        products = listOf(StytchB2BProduct.OAUTH, StytchB2BProduct.SSO, StytchB2BProduct.EMAIL_MAGIC_LINKS),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization =
+            mockk {
+                every { ssoActiveConnections } returns listOf(mockk(relaxed = true))
+            },
+        expected =
+            listOf(
+                ProductComponent.OAuthButtons,
+                ProductComponent.SSOButtons,
+                ProductComponent.Divider,
+                ProductComponent.EmailForm,
+            ),
+    )
+
+internal val TEST_MULTI_INPUTS_ONE_COMPONENT =
+    ProductComponentOrderingTestCase(
+        name = "Multiple inputs render one component",
+        products = listOf(StytchB2BProduct.EMAIL_MAGIC_LINKS, StytchB2BProduct.EMAIL_OTP, StytchB2BProduct.PASSWORDS),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization = null,
+        expected = listOf(ProductComponent.PasswordEMLCombined),
+    )
+
+internal val TEST_EML_DISCOVERY =
+    ProductComponentOrderingTestCase(
+        name = "EML Discovery",
+        products = listOf(StytchB2BProduct.EMAIL_MAGIC_LINKS),
+        authFlowType = AuthFlowType.DISCOVERY,
+        organization = null,
+        expected = listOf(ProductComponent.EmailDiscoveryForm),
+    )
+
+internal val TEST_EOTP_DISCOVERY =
+    ProductComponentOrderingTestCase(
+        name = "EOTP Discovery",
+        products = listOf(StytchB2BProduct.EMAIL_OTP),
+        authFlowType = AuthFlowType.DISCOVERY,
+        organization = null,
+        expected = listOf(ProductComponent.EmailDiscoveryForm),
+    )
+
+internal val TEST_EMAIL_PASSWORD_COMBINED =
+    ProductComponentOrderingTestCase(
+        name = "Email & Password Combined",
+        products = listOf(StytchB2BProduct.EMAIL_MAGIC_LINKS, StytchB2BProduct.PASSWORDS),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization = null,
+        expected = listOf(ProductComponent.PasswordEMLCombined),
+    )
+
+internal val TEST_PASSWORD_ONLY =
+    ProductComponentOrderingTestCase(
+        name = "Password Only",
+        products = listOf(StytchB2BProduct.PASSWORDS),
+        authFlowType = AuthFlowType.ORGANIZATION,
+        organization = null,
+        expected = listOf(ProductComponent.PasswordsEmailForm),
+    )


### PR DESCRIPTION
Linear Ticket: [SDK-2372](https://linear.app/stytch/issue/SDK-2372)

## Changes:

1. Updates product component ordering in pre-built B2B UI to match updated logic, specifically keeping OAuth and SSO buttons together, and adding dividers where appropriate
2. Adds tests to ensure the logic is correct

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A