### PR TITLE
Remove network check from bootstrapping calls to prevent startup race condition

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.38.0"
+extra["PUBLISH_VERSION"] = "0.38.1"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -321,34 +321,30 @@ public object StytchB2BClient {
     }
 
     private fun refreshBootstrapAndAPIClient() {
-        if (NetworkChangeListener.networkIsAvailable) {
-            applicationContext.get()?.let {
-                externalScope.launch(dispatchers.io) {
-                    refreshBootstrapData()
-                    StytchB2BApi.configureDFP(
-                        dfpProvider = dfpProvider,
-                        captchaProvider =
-                            CaptchaProviderImpl(
-                                it as Application,
-                                externalScope,
-                                bootstrapData.captchaSettings.siteKey,
-                            ),
-                        bootstrapData.dfpProtectedAuthEnabled,
-                        bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
-                    )
-                }
+        applicationContext.get()?.let {
+            externalScope.launch(dispatchers.io) {
+                refreshBootstrapData()
+                StytchB2BApi.configureDFP(
+                    dfpProvider = dfpProvider,
+                    captchaProvider =
+                        CaptchaProviderImpl(
+                            it as Application,
+                            externalScope,
+                            bootstrapData.captchaSettings.siteKey,
+                        ),
+                    bootstrapData.dfpProtectedAuthEnabled,
+                    bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+                )
             }
         }
     }
 
     internal suspend fun refreshBootstrapData() {
-        if (NetworkChangeListener.networkIsAvailable) {
-            bootstrapData =
-                when (val res = StytchB2BApi.getBootstrapData()) {
-                    is StytchResult.Success -> res.value
-                    else -> bootstrapData
-                }
-        }
+        bootstrapData =
+            when (val res = StytchB2BApi.getBootstrapData()) {
+                is StytchResult.Success -> res.value
+                else -> bootstrapData
+            }
     }
 
     internal fun assertInitialized() {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -313,34 +313,30 @@ public object StytchClient {
     }
 
     private fun refreshBootstrapAndAPIClient() {
-        if (NetworkChangeListener.networkIsAvailable) {
-            applicationContext.get()?.let {
-                externalScope.launch(dispatchers.io) {
-                    refreshBootstrapData()
-                    StytchApi.configureDFP(
-                        dfpProvider = dfpProvider,
-                        captchaProvider =
-                            CaptchaProviderImpl(
-                                it as Application,
-                                externalScope,
-                                bootstrapData.captchaSettings.siteKey,
-                            ),
-                        bootstrapData.dfpProtectedAuthEnabled,
-                        bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
-                    )
-                }
+        applicationContext.get()?.let {
+            externalScope.launch(dispatchers.io) {
+                refreshBootstrapData()
+                StytchApi.configureDFP(
+                    dfpProvider = dfpProvider,
+                    captchaProvider =
+                        CaptchaProviderImpl(
+                            it as Application,
+                            externalScope,
+                            bootstrapData.captchaSettings.siteKey,
+                        ),
+                    bootstrapData.dfpProtectedAuthEnabled,
+                    bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+                )
             }
         }
     }
 
     internal suspend fun refreshBootstrapData() {
-        if (NetworkChangeListener.networkIsAvailable) {
-            bootstrapData =
-                when (val res = StytchApi.getBootstrapData()) {
-                    is StytchResult.Success -> res.value
-                    else -> bootstrapData
-                }
-        }
+        bootstrapData =
+            when (val res = StytchApi.getBootstrapData()) {
+                is StytchResult.Success -> res.value
+                else -> bootstrapData
+            }
     }
 
     internal fun assertInitialized() {


### PR DESCRIPTION
Linear Ticket: None

## Changes:

1. Remove the network sanity check when refreshing bootstrap data. Since we standardized on an "off by default" value, it was possible that the network didn't report it's status before the initial bootstrap call, and thus calls _before_ it did so would use incorrect bootstrap data.

## Notes:

-

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A