### PR TITLE
SDK-2447 Respect the order of components in B2C Prebuilt UI

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
@@ -34,9 +34,7 @@ import com.stytch.sdk.ui.b2c.AuthenticationActivity
 import com.stytch.sdk.ui.b2c.data.ApplicationUIState
 import com.stytch.sdk.ui.b2c.data.EventState
 import com.stytch.sdk.ui.b2c.data.OAuthProvider
-import com.stytch.sdk.ui.b2c.data.OTPMethods
 import com.stytch.sdk.ui.b2c.data.OTPOptions
-import com.stytch.sdk.ui.b2c.data.StytchProduct
 import com.stytch.sdk.ui.b2c.data.StytchProductConfig
 import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.DividerWithText
@@ -80,6 +78,8 @@ internal object MainScreen : AndroidScreen(), Parcelable {
             sendSmsOtp = { viewModel.sendSmsOTP(it, productConfig.locale) },
             sendWhatsAppOTP = { viewModel.sendWhatsAppOTP(it, productConfig.locale) },
             exitWithoutAuthenticating = context::exitWithoutAuthenticating,
+            productComponents = viewModel.getProductComponents(productConfig.products),
+            tabTypes = viewModel.getTabTitleOrdering(productConfig.products, productConfig.otpOptions.methods),
         )
     }
 }
@@ -95,33 +95,18 @@ private fun MainScreenComposable(
     sendSmsOtp: (OTPOptions) -> Unit,
     sendWhatsAppOTP: (OTPOptions) -> Unit,
     exitWithoutAuthenticating: () -> Unit,
+    productComponents: List<ProductComponent>,
+    tabTypes: List<TabTypes>,
 ) {
     val productConfig = LocalStytchProductConfig.current
     val theme = LocalStytchTheme.current
     val type = LocalStytchTypography.current
-    val hasButtons = productConfig.products.contains(StytchProduct.OAUTH)
-    val hasInput =
-        productConfig.products.any {
-            listOf(StytchProduct.OTP, StytchProduct.PASSWORDS, StytchProduct.EMAIL_MAGIC_LINKS).contains(it)
-        }
-    val hasEmail =
-        productConfig.products.any {
-            listOf(StytchProduct.EMAIL_MAGIC_LINKS, StytchProduct.PASSWORDS).contains(it)
-        } ||
-            productConfig.otpOptions.methods.contains(OTPMethods.EMAIL)
-    val hasDivider = hasButtons && hasInput
     val tabTitles =
-        mutableListOf<String>().apply {
-            if (hasEmail) {
-                add(stringResource(id = R.string.email))
-            }
-            if (productConfig.products.contains(StytchProduct.OTP)) {
-                if (productConfig.otpOptions.methods.contains(OTPMethods.SMS)) {
-                    add(stringResource(id = R.string.text))
-                }
-                if (productConfig.otpOptions.methods.contains(OTPMethods.WHATSAPP)) {
-                    add(stringResource(id = R.string.whatsapp))
-                }
+        tabTypes.map {
+            when (it) {
+                TabTypes.EMAIL -> stringResource(id = R.string.email)
+                TabTypes.SMS -> stringResource(id = R.string.text)
+                TabTypes.WHATSAPP -> stringResource(id = R.string.whatsapp)
             }
         }
     var selectedTabIndex by remember { mutableIntStateOf(0) }
@@ -134,86 +119,90 @@ private fun MainScreenComposable(
         if (!theme.hideHeaderText) {
             PageTitle(text = stringResource(id = R.string.sign_up_or_login))
         }
-        if (productConfig.products.contains(StytchProduct.OAUTH)) {
-            productConfig.oAuthOptions.providers.map {
-                SocialLoginButton(
-                    modifier =
-                        Modifier
-                            .padding(bottom = 12.dp)
-                            .semantics {
-                                contentDescription = semanticsOAuthButton
-                            },
-                    onClick = { onStartOAuthLogin(it, productConfig) },
-                    iconDrawable = painterResource(id = it.iconDrawable),
-                    iconDescription = stringResource(id = it.iconText),
-                    text = stringResource(id = it.text),
-                )
-            }
-        }
-        if (hasDivider) {
-            DividerWithText(
-                modifier = Modifier.padding(top = 12.dp, bottom = 24.dp),
-                text = stringResource(id = R.string.or),
-            )
-        }
-        if (hasInput && tabTitles.isNotEmpty()) { // sanity check
-            if (tabTitles.size > 1) {
-                val semanticTabs = stringResource(id = R.string.semantics_tabs)
-                TabRow(
-                    selectedTabIndex = selectedTabIndex,
-                    containerColor = Color(theme.backgroundColor),
-                    modifier = Modifier.padding(bottom = 12.dp).semantics { contentDescription = semanticTabs },
-                    indicator = { tabPositions ->
-                        SecondaryIndicator(
-                            modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
-                            color = Color(theme.primaryTextColor),
+        productComponents.map {
+            when (it) {
+                ProductComponent.BUTTONS -> {
+                    productConfig.oAuthOptions.providers.map {
+                        SocialLoginButton(
+                            modifier =
+                                Modifier
+                                    .padding(bottom = 12.dp)
+                                    .semantics {
+                                        contentDescription = semanticsOAuthButton
+                                    },
+                            onClick = { onStartOAuthLogin(it, productConfig) },
+                            iconDrawable = painterResource(id = it.iconDrawable),
+                            iconDescription = stringResource(id = it.iconText),
+                            text = stringResource(id = it.text),
                         )
-                    },
-                ) {
-                    tabTitles.forEachIndexed { index, title ->
-                        Tab(
-                            selected = index == selectedTabIndex,
-                            onClick = { selectedTabIndex = index },
-                            modifier = Modifier.height(48.dp),
-                        ) {
-                            Text(
-                                text = title,
-                                style =
-                                    type.body2.copy(
-                                        color = Color(theme.primaryTextColor),
-                                        lineHeight = 48.sp,
-                                    ),
-                            )
-                        }
                     }
                 }
-            }
-            when (tabTitles[selectedTabIndex]) {
-                stringResource(id = R.string.email) ->
-                    EmailEntry(
-                        emailState = emailState,
-                        onEmailAddressChanged = onEmailAddressChanged,
-                        onEmailAddressSubmit = { onEmailAddressSubmit(productConfig) },
+                ProductComponent.DIVIDER -> {
+                    DividerWithText(
+                        modifier = Modifier.padding(top = 12.dp, bottom = 24.dp),
+                        text = stringResource(id = R.string.or),
                     )
-                stringResource(id = R.string.text) ->
-                    PhoneEntry(
-                        countryCode = phoneState.countryCode,
-                        onCountryCodeChanged = onCountryCodeChanged,
-                        phoneNumber = phoneState.phoneNumber,
-                        onPhoneNumberChanged = onPhoneNumberChanged,
-                        onPhoneNumberSubmit = { sendSmsOtp(productConfig.otpOptions) },
-                        statusText = phoneState.error,
-                    )
-                stringResource(id = R.string.whatsapp) ->
-                    PhoneEntry(
-                        countryCode = phoneState.countryCode,
-                        onCountryCodeChanged = onCountryCodeChanged,
-                        phoneNumber = phoneState.phoneNumber,
-                        onPhoneNumberChanged = onPhoneNumberChanged,
-                        onPhoneNumberSubmit = { sendWhatsAppOTP(productConfig.otpOptions) },
-                        statusText = phoneState.error,
-                    )
-                else -> Text(stringResource(id = R.string.misconfigured_otp))
+                }
+                ProductComponent.INPUTS -> {
+                    if (tabTitles.size > 1) {
+                        val semanticTabs = stringResource(id = R.string.semantics_tabs)
+                        TabRow(
+                            selectedTabIndex = selectedTabIndex,
+                            containerColor = Color(theme.backgroundColor),
+                            modifier = Modifier.padding(bottom = 12.dp).semantics { contentDescription = semanticTabs },
+                            indicator = { tabPositions ->
+                                SecondaryIndicator(
+                                    modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                                    color = Color(theme.primaryTextColor),
+                                )
+                            },
+                        ) {
+                            tabTitles.forEachIndexed { index, title ->
+                                Tab(
+                                    selected = index == selectedTabIndex,
+                                    onClick = { selectedTabIndex = index },
+                                    modifier = Modifier.height(48.dp),
+                                ) {
+                                    Text(
+                                        text = title,
+                                        style =
+                                            type.body2.copy(
+                                                color = Color(theme.primaryTextColor),
+                                                lineHeight = 48.sp,
+                                            ),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    when (tabTitles[selectedTabIndex]) {
+                        stringResource(id = R.string.email) ->
+                            EmailEntry(
+                                emailState = emailState,
+                                onEmailAddressChanged = onEmailAddressChanged,
+                                onEmailAddressSubmit = { onEmailAddressSubmit(productConfig) },
+                            )
+                        stringResource(id = R.string.text) ->
+                            PhoneEntry(
+                                countryCode = phoneState.countryCode,
+                                onCountryCodeChanged = onCountryCodeChanged,
+                                phoneNumber = phoneState.phoneNumber,
+                                onPhoneNumberChanged = onPhoneNumberChanged,
+                                onPhoneNumberSubmit = { sendSmsOtp(productConfig.otpOptions) },
+                                statusText = phoneState.error,
+                            )
+                        stringResource(id = R.string.whatsapp) ->
+                            PhoneEntry(
+                                countryCode = phoneState.countryCode,
+                                onCountryCodeChanged = onCountryCodeChanged,
+                                phoneNumber = phoneState.phoneNumber,
+                                onPhoneNumberChanged = onPhoneNumberChanged,
+                                onPhoneNumberSubmit = { sendWhatsAppOTP(productConfig.otpOptions) },
+                                statusText = phoneState.error,
+                            )
+                        else -> Text(stringResource(id = R.string.misconfigured_otp))
+                    }
+                }
             }
         }
         uiState.genericErrorMessage?.let {

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
@@ -520,4 +520,58 @@ internal class MainScreenViewModelTest {
             assert(!viewModel.uiState.value.showLoadingDialog)
             assert(viewModel.uiState.value.phoneNumberState.error == "Something went wrong")
         }
+
+    @Test
+    fun `getProductComponents returns the expected order`() {
+        var given = listOf(StytchProduct.EMAIL_MAGIC_LINKS, StytchProduct.OAUTH)
+        var expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
+        assert(viewModel.getProductComponents(given) == expected)
+
+        given = listOf(StytchProduct.OTP, StytchProduct.OAUTH)
+        expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
+        assert(viewModel.getProductComponents(given) == expected)
+
+        given = listOf(StytchProduct.PASSWORDS, StytchProduct.OAUTH)
+        expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
+        assert(viewModel.getProductComponents(given) == expected)
+
+        given = listOf(StytchProduct.PASSWORDS, StytchProduct.EMAIL_MAGIC_LINKS, StytchProduct.OAUTH)
+        expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
+        assert(viewModel.getProductComponents(given) == expected)
+
+        given = listOf(StytchProduct.OAUTH, StytchProduct.EMAIL_MAGIC_LINKS)
+        expected = listOf(ProductComponent.BUTTONS, ProductComponent.DIVIDER, ProductComponent.INPUTS)
+        assert(viewModel.getProductComponents(given) == expected)
+
+        given = listOf(StytchProduct.OAUTH)
+        expected = listOf(ProductComponent.BUTTONS)
+        assert(viewModel.getProductComponents(given) == expected)
+
+        given = listOf(StytchProduct.EMAIL_MAGIC_LINKS)
+        expected = listOf(ProductComponent.INPUTS)
+        assert(viewModel.getProductComponents(given) == expected)
+    }
+
+    @Test
+    fun `getTabTitleOrdering returns the expected order`() {
+        var givenProducts = listOf(StytchProduct.EMAIL_MAGIC_LINKS, StytchProduct.PASSWORDS)
+        var givenOTPMethods = emptyList<OTPMethods>()
+        var expected = listOf(TabTypes.EMAIL)
+        assert(viewModel.getTabTitleOrdering(givenProducts, givenOTPMethods) == expected)
+
+        givenProducts = listOf(StytchProduct.OTP)
+        givenOTPMethods = listOf(OTPMethods.EMAIL)
+        expected = listOf(TabTypes.EMAIL)
+        assert(viewModel.getTabTitleOrdering(givenProducts, givenOTPMethods) == expected)
+
+        givenProducts = listOf(StytchProduct.OTP)
+        givenOTPMethods = listOf(OTPMethods.WHATSAPP, OTPMethods.EMAIL, OTPMethods.SMS)
+        expected = listOf(TabTypes.WHATSAPP, TabTypes.EMAIL, TabTypes.SMS)
+        assert(viewModel.getTabTitleOrdering(givenProducts, givenOTPMethods) == expected)
+
+        givenProducts = listOf(StytchProduct.PASSWORDS, StytchProduct.OTP)
+        givenOTPMethods = listOf(OTPMethods.WHATSAPP, OTPMethods.SMS)
+        expected = listOf(TabTypes.EMAIL, TabTypes.WHATSAPP, TabTypes.SMS)
+        assert(viewModel.getTabTitleOrdering(givenProducts, givenOTPMethods) == expected)
+    }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-2447](https://linear.app/stytch/issue/SDK-2447)

## Changes:

1. Respect the order of components that were passed in in both the products list and OTP methods list
2. Moves the ordering into the viewmodel for testability
3. Adds tests of the above

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A