### PR TITLE
SDK-2471 Reject attempted duplicate biometric registrations

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -54,7 +54,29 @@ jobs:
         name: Release build and publish
         needs: check
         if: needs.check.outputs.tag_exists == 'false'
-        uses: stytchauth/stytch-android/.github/workflows/publish.yml@main
+        runs-on: ubuntu-latest
+        env:
+          GOOGLE_OAUTH_CLIENT_ID: 'abc123'
+          PASSKEYS_DOMAIN: 'abc123'
+        steps:
+          - uses: actions/checkout@v3
+          - uses: actions/setup-java@v3
+            with:
+              distribution: zulu
+              java-version: 17
+          - name: Release build
+            run: ./gradlew :source:sdk:assembleRelease
+          - name: Source jar
+            run: ./gradlew :source:sdk:androidSourcesJar
+          - name: Publish to Maven Central
+            run: ./gradlew :source:sdk:publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+            env:
+              OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+              OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+              SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+              SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+              SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+              SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
     tag-and-release:
         name: Create tag and release
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish SDK
+name: Publish SDK (Manual)
 
 on:
   workflow_dispatch:

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.39.0"
+extra["PUBLISH_VERSION"] = "0.40.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -204,3 +204,7 @@ public data object UserCanceled : StytchSDKError("The user canceled the OAuth fl
 public data object NoActivityProvided : StytchSDKError("You must supply a receiver activity before calling this method")
 
 public data object UnknownOAuthOrSSOError : StytchSDKError("The OAuth or SSO flow completed unexpectedly")
+
+public data object BiometricsAlreadyEnrolledError : StytchSDKError(
+    "There is already a biometric factor enrolled on this device. Fully authenticate with all factors and remove the existing registration before attempting to register again.",
+)

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
@@ -10,6 +10,7 @@ import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.BiometricsAlreadyEnrolledError
 import com.stytch.sdk.common.errors.StytchError
 import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.errors.StytchKeystoreUnavailableError
@@ -134,7 +135,7 @@ internal class BiometricsImpl internal constructor(
                     throw StytchKeystoreUnavailableError()
                 }
                 if (isRegistrationAvailable(parameters.context)) {
-                    removeRegistration()
+                    throw BiometricsAlreadyEnrolledError
                 }
                 sessionStorage.ensureSessionIsValidOrThrow()
                 val allowedAuthenticators = getAllowedAuthenticators(parameters.allowDeviceCredentials)


### PR DESCRIPTION
Linear Ticket: [SDK-2471](https://linear.app/stytch/issue/SDK-2471)

## Changes:

1. To prevent issues with creating orphaned registrations or errors when attempting to delete a remote registration without being "fully" authenticated, instead prevent the creation of duplicate registrations on device.
2. Bump version
3. Update tests
4. Chore: copy the publishing steps from the "manual" publish workflow into the auto publish workflow, since just linking to it with the `uses` directive was never working

## Notes:

- This mimics whats now done in ReactNative and iOS SDKs

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A