### PR TITLE
SDK-2465 Add organization_slug to InternalOrganizationData response object

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -1001,6 +1001,8 @@ public data class InternalOrganizationData(
     val organizationName: String,
     @Json(name = "organization_logo_url")
     val organizationLogoUrl: String?,
+    @Json(name = "organization_slug")
+    val organizationSlug: String,
     @Json(name = "sso_active_connections")
     val ssoActiveConnections: List<SSOActiveConnection>?,
     @Json(name = "sso_default_connection_id")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/OrganizationDataExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/extensions/OrganizationDataExt.kt
@@ -5,14 +5,15 @@ import com.stytch.sdk.b2b.network.models.OrganizationData
 
 internal fun OrganizationData.toInternalOrganizationData(): InternalOrganizationData =
     InternalOrganizationData(
-        organizationId,
-        organizationName,
-        organizationLogoUrl,
-        ssoActiveConnections,
-        ssoDefaultConnectionId,
-        emailAllowedDomains,
-        emailJitProvisioning,
-        emailInvites,
-        authMethods,
-        allowedAuthMethods,
+        organizationId = organizationId,
+        organizationName = organizationName,
+        organizationLogoUrl = organizationLogoUrl,
+        organizationSlug = organizationSlug,
+        ssoActiveConnections = ssoActiveConnections,
+        ssoDefaultConnectionId = ssoDefaultConnectionId,
+        emailAllowedDomains = emailAllowedDomains,
+        emailJitProvisioning = emailJitProvisioning,
+        emailInvites = emailInvites,
+        authMethods = authMethods,
+        allowedAuthMethods = allowedAuthMethods,
     )


### PR DESCRIPTION
Linear Ticket: [SDK-2465](https://linear.app/stytch/issue/SDK-2465)

## Changes:

1. Mirrors changes made in: https://github.com/stytchauth/api/pull/6888.
2. Mirrors changes made in: https://github.com/stytchauth/stytch-ios/pull/404

## Notes:

- This is basically a no-op on Android, as we're not using it in UI, but will keep us in alignment with iOS

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A