### PR TITLE
SDK-2473 EOTP expires in 10 minutes, not 2

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.40.0"
+extra["PUBLISH_VERSION"] = "0.40.1"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/components/ResendableOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/components/ResendableOTP.kt
@@ -30,7 +30,7 @@ import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-private const val OTP_EXPIRATION_SECONDS = (2 * 60).toLong()
+private const val DEFAULT_OTP_EXIPRATION_MINUTES = 2
 private const val ONE_SECOND = 1000L
 
 @Composable
@@ -42,12 +42,13 @@ internal fun ResendableOTP(
     onSubmit: (String) -> Unit,
     onResend: () -> Unit,
     errorMessage: String? = null,
+    otpExpirationMinutes: Int = DEFAULT_OTP_EXIPRATION_MINUTES,
 ) {
     val theme = LocalStytchTheme.current
     val type = LocalStytchTypography.current
     var showResendDialog by remember { mutableStateOf(false) }
-    var countdownSeconds by remember { mutableLongStateOf(OTP_EXPIRATION_SECONDS) }
-    var expirationTimeFormatted by remember { mutableStateOf("2:00") }
+    var countdownSeconds by remember { mutableLongStateOf(otpExpirationMinutes * 60L) }
+    var expirationTimeFormatted by remember { mutableStateOf("$otpExpirationMinutes:00") }
     val coroutineScope = rememberCoroutineScope()
     LaunchedEffect(Unit) {
         coroutineScope.launch {
@@ -96,7 +97,7 @@ internal fun ResendableOTP(
             acceptText = stringResource(id = R.string.send_code),
             onAcceptClick = {
                 onResend()
-                countdownSeconds = OTP_EXPIRATION_SECONDS
+                countdownSeconds = otpExpirationMinutes * 60L
                 showResendDialog = false
             },
         )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/EmailOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/EmailOTPEntryScreen.kt
@@ -100,5 +100,6 @@ internal fun EmailOTPEntryScreen(
         onBack = null,
         onSubmit = viewModel::handleSubmit,
         onResend = viewModel::handleResend,
+        otpExpirationMinutes = 10,
     )
 }


### PR DESCRIPTION
Linear Ticket: [SDK-2473](https://linear.app/stytch/issue/SDK-2473)

## Changes:

1. Fixes UI issue where email OTPs were incorrectly identified as expiring in 2 minutes, instead of 10
2. Bumps version

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A