### PR TITLE
Add a distinct value for Google OneTap/CredentialManager

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.40.1"
+extra["PUBLISH_VERSION"] = "0.40.2"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerAuthMethod.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerAuthMethod.kt
@@ -4,6 +4,7 @@ public enum class ConsumerAuthMethod {
     BIOMETRICS,
     CRYPTO,
     EMAIL_MAGIC_LINKS,
+    GOOGLE_ONE_TAP,
     OAUTH,
     OTP,
     PASSKEYS,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
@@ -105,7 +105,7 @@ internal class GoogleOneTapImpl(
                         nonce = nonce,
                         sessionDurationMinutes = parameters.sessionDurationMinutes,
                     ).apply {
-                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.OAUTH
+                        sessionStorage.lastAuthMethodUsed = ConsumerAuthMethod.GOOGLE_ONE_TAP
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
             }


### PR DESCRIPTION
Linear Ticket: [SDK-2487](https://linear.app/stytch/issue/SDK-2487/add-distinct-lastauthmethod-for-google-onetap)

## Changes:

1. Adds a distinct value for Google OneTap/CM, to distinguish between it and traditional OAuth, when persisting the last used auth method

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A