### PR TITLE
Attempt to get code coverage reports in PRs

### DIFF
--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -28,3 +28,13 @@ jobs:
         env:
           GOOGLE_OAUTH_CLIENT_ID: 'abc123'
           PASSKEYS_DOMAIN: 'abc123'
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: |
+            ${{ github.workspace }}/source/sdk/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          token: ${{ secrets.CODE_COVERAGE_TOKEN }}
+          update-comment: true
+          title: Code Coverage

--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -24,7 +24,7 @@ jobs:
       # => https://github.com/marketplace/actions/gradle-command
       - uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: --info runOnGitHub
+          arguments: runOnGitHub
         env:
           GOOGLE_OAUTH_CLIENT_ID: 'abc123'
           PASSKEYS_DOMAIN: 'abc123'

--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -24,7 +24,7 @@ jobs:
       # => https://github.com/marketplace/actions/gradle-command
       - uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: runOnGitHub
+          arguments: --info runOnGitHub
         env:
           GOOGLE_OAUTH_CLIENT_ID: 'abc123'
           PASSKEYS_DOMAIN: 'abc123'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,6 @@ tasks.register("runOnGitHub") {
         ":source:sdk:lint",
         ":source:sdk:ktlintCheck",
         ":source:sdk:testDebugUnitTest",
-        ":source:sdk:jacocoTestReport",
     )
     group = "custom"
     description = "\$ ./gradlew runOnGitHub # runs on GitHub Action"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,7 @@ tasks.register("runOnGitHub") {
         ":source:sdk:lint",
         ":source:sdk:ktlintCheck",
         ":source:sdk:testDebugUnitTest",
+        ":source:sdk:jacocoTestReport",
     )
     group = "custom"
     description = "\$ ./gradlew runOnGitHub # runs on GitHub Action"

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -200,24 +200,29 @@ jacoco {
     toolVersion = "0.8.12"
 }
 
+tasks.register<JacocoReport>("jacocoTestReport")
+
 project.afterEvaluate {
-    tasks.register<JacocoReport>("jacocoTestReport") {
-        dependsOn(tasks.getByName("testDebugUnitTest"))
-        reports {
-            xml.required.set(true)
+    tasks.named<Test>("testDebugUnitTest").configure {
+        finalizedBy(tasks["jacocoTestReport"])
+        doLast {
+            tasks.named<JacocoReport>("jacocoTestReport") {
+                dependsOn(tasks.getByName("testDebugUnitTest"))
+                reports {
+                    xml.required.set(true)
+                }
+                executionData(file(layout.buildDirectory.dir("jacoco/testDebugUnitTest.exec")))
+                val kotlinTree =
+                    fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
+                        exclude(
+                            listOf(
+                                "**/network/models/**",
+                            ),
+                        )
+                    }.files
+                classDirectories.from(kotlinTree)
+                sourceDirectories.from(files(layout.projectDirectory.dir("src")))
+            }
         }
-        executionData(file(layout.buildDirectory.dir("jacoco/testDebugUnitTest.exec")))
-        println("JORDAN exec exists = ${file(layout.buildDirectory.dir("jacoco/testDebugUnitTest.exec")).exists()}")
-        val kotlinTree =
-            fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
-                exclude(
-                    listOf(
-                        "**/network/models/**",
-                    ),
-                )
-            }.files
-        println("JORDAN files length = ${kotlinTree.size}")
-        classDirectories.from(kotlinTree)
-        sourceDirectories.from(files(layout.projectDirectory.dir("src")))
     }
 }

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinPluginCompose)
     alias(libs.plugins.serialization)
+    id("jacoco")
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
@@ -41,8 +42,6 @@ android {
             isMinifyEnabled = false
             buildConfigField("Boolean", "DEBUG_MODE", "true")
             buildConfigField("String", "STYTCH_SDK_VERSION", "\"${project.extra["PUBLISH_VERSION"]}\"")
-            enableUnitTestCoverage = true
-            enableAndroidTestCoverage = true
         }
     }
     compileOptions {
@@ -119,15 +118,6 @@ tasks.named<DokkaTaskPartial>("dokkaHtmlPartial").configure {
             }
             reportUndocumented.set(true)
         }
-        /*
-        // TODO: Switch to KTS files to make this a lot easier/more idiomatic
-        pluginsMapConfiguration.set([
-            "org.jetbrains.dokka.versioning.VersioningPlugin" : """{
-                "version": "$PUBLISH_VERSION",
-                "olderVersionsDir": "$projectDir/../../docs/docs/olderVersions/sdk"
-            }"""
-        ])
-         */
     }
 }
 
@@ -203,5 +193,29 @@ tasks.register("printVersion") {
     description = "Prints the version of the SDK. Used for autoreleasing the SDK from GitHub"
     doLast {
         println(project.extra["PUBLISH_VERSION"])
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+project.afterEvaluate {
+    tasks.register<JacocoReport>("jacocoTestReport") {
+        dependsOn(tasks.getByName("testDebugUnitTest"))
+        reports {
+            xml.required.set(true)
+        }
+        executionData(file(layout.buildDirectory.dir("jacoco/testDebugUnitTest.exec")))
+        val kotlinTree =
+            fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
+                exclude(
+                    listOf(
+                        "**/network/models/**",
+                    ),
+                )
+            }.files
+        classDirectories.from(kotlinTree)
+        sourceDirectories.from(files(layout.projectDirectory.dir("src")))
     }
 }

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -207,6 +207,7 @@ project.afterEvaluate {
             xml.required.set(true)
         }
         executionData(file(layout.buildDirectory.dir("jacoco/testDebugUnitTest.exec")))
+        println("JORDAN exec exists = ${file(layout.buildDirectory.dir("jacoco/testDebugUnitTest.exec")).exists()}")
         val kotlinTree =
             fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
                 exclude(
@@ -215,6 +216,7 @@ project.afterEvaluate {
                     ),
                 )
             }.files
+        println("JORDAN files length = ${kotlinTree.size}")
         classDirectories.from(kotlinTree)
         sourceDirectories.from(files(layout.projectDirectory.dir("src")))
     }


### PR DESCRIPTION
Linear Ticket: [SDK-755](https://linear.app/stytch/issue/SDK-755)

## Changes:

1. Add and configure JaCoCo
2. Add new workflow step to our default PR workflow to comment with code coverage results

## Notes:

- Need to fine tune the exclusions. We don't need to have code coverage of every `data class`, for instance
- Need to fine tune the pass/fail metrics once we have a good (relevant) baseline

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A