### PR TITLE
SDK-2490 Finetune code coverage

### DIFF
--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -37,4 +37,6 @@ jobs:
             ${{ github.workspace }}/source/sdk/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
           token: ${{ secrets.CODE_COVERAGE_TOKEN }}
           update-comment: true
+          min-coverage-overall: 70
+          min-coverage-changed-files: 80
           title: Code Coverage

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -216,7 +216,31 @@ project.afterEvaluate {
                     fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
                         exclude(
                             listOf(
+                                // ignore internal network request/response models
                                 "**/network/models/**",
+                                // ignore common ui components
+                                "**/ui/**/components/**",
+                                "**/ui/**/data/**",
+                                "**/ui/**/theme/**",
+                                "**/ui/**/utils/**",
+                                "**/ui/**/screens/**",
+                                "**/ui/**/navigation/**",
+                                "**/ui/**/usecases/**",
+                                // ignore b2b specific UI components and helpers/utils/impls
+                                "**/ui/b2b/B2BAuthenticationActivity*",
+                                "**/ui/b2b/B2BAuthenticationViewModel*",
+                                "**/ui/b2b/BaseViewModel*",
+                                "**/ui/b2b/StytchB2BAuth*",
+                                "**/ui/b2b/StytchB2BAuthenticationApp*",
+                                "**/ui/b2b/StytchB2BAuthenticationContract*",
+                                "**/ui/b2b/domain/B2BUIStateMachine*",
+                                // ignore b2c specific UI components and helpers/utils/impls
+                                "**/ui/b2c/StytchAuthenticationApp*",
+                                "**/ui/b2c/AuthenticationActivity*",
+                                "**/ui/b2c/AuthenticationViewModel*",
+                                "**/ui/b2c/StytchAuth*",
+                                "**/ui/b2c/StytchAuthenticationApp*",
+                                "**/ui/b2c/StytchAuthenticationContract*",
                             ),
                         )
                     }.files

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.network.models.EmailInvites
 import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -54,6 +55,7 @@ public interface Discovery {
      * @property organizationId is the organization ID of the desired organization
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class SessionExchangeParameters
         @JvmOverloads
         constructor(
@@ -129,6 +131,7 @@ public interface Discovery {
      * @property allowedAuthMethods An array of allowed authentication methods. This list is enforced when auth_methods
      * is set to RESTRICTED. The list's accepted values are: sso , magic_link , and password .
      */
+    @JacocoExcludeGenerated
     public data class CreateOrganizationParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.EMLAuthenticateResponse
 import com.stytch.sdk.b2b.MemberResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -33,6 +34,7 @@ public interface B2BMagicLinks {
      * @property token is the unique sequence of characters used to log in
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthParameters
         @JvmOverloads
         constructor(
@@ -79,6 +81,7 @@ public interface B2BMagicLinks {
      * A data class used for wrapping parameters used for authenticating a discovery magic link
      * @property token the discovery magic links token
      */
+    @JacocoExcludeGenerated
     public data class DiscoveryAuthenticateParameters(
         val token: String,
     )
@@ -133,6 +136,7 @@ public interface B2BMagicLinks {
          * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
          * if no value is provided, the copy defaults to English.
          */
+        @JacocoExcludeGenerated
         public data class Parameters
             @JvmOverloads
             constructor(
@@ -184,6 +188,7 @@ public interface B2BMagicLinks {
          * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
          * if no value is provided, the copy defaults to English.
          */
+        @JacocoExcludeGenerated
         public data class DiscoverySendParameters
             @JvmOverloads
             constructor(
@@ -240,6 +245,7 @@ public interface B2BMagicLinks {
          * [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/role-assignment) for more information about role
          * assignment.
          */
+        @JacocoExcludeGenerated
         public data class InviteParameters
             @JvmOverloads
             constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/Member.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/Member.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.UpdateMemberResponse
 import com.stytch.sdk.b2b.network.models.MemberData
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.common.StytchObjectInfo
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.CompletableFuture
 
@@ -61,6 +62,7 @@ public interface Member {
      *  1. Which MFA method the Member is prompted to use when logging in
      *  2. Whether An SMS will be sent automatically after completing the first leg of authentication
      */
+    @JacocoExcludeGenerated
     public data class UpdateParams
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberAuthenticationFactor.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberAuthenticationFactor.kt
@@ -1,5 +1,7 @@
 package com.stytch.sdk.b2b.member
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * A [MemberAuthenticationFactor] represents a primary authentication factor associated with a Stytch Member
  * @param id The string representing the unique ID of this authentication factor
@@ -20,6 +22,7 @@ public sealed class MemberAuthenticationFactor(
     /**
      * Represents a Password associated with a Stytch Member
      */
+    @JacocoExcludeGenerated
     public data class Password(
         override val id: String,
     ) : MemberAuthenticationFactor(id)

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.b2b.OAuthAuthenticateResponse
 import com.stytch.sdk.b2b.OAuthDiscoveryAuthenticateResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -40,6 +41,7 @@ public interface OAuth {
          * @property providerParams An optional mapping of provider specific values to pass through to the OAuth
          * provider
          */
+        @JacocoExcludeGenerated
         public data class StartParameters
             @JvmOverloads
             constructor(
@@ -64,6 +66,7 @@ public interface OAuth {
          */
         public val discovery: ProviderDiscovery
 
+        @JacocoExcludeGenerated
         public data class GetTokenForProviderParams
             @JvmOverloads
             constructor(
@@ -105,6 +108,7 @@ public interface OAuth {
          * @property providerParams An optional mapping of provider specific values to pass through to the OAuth
          * provider
          */
+        @JacocoExcludeGenerated
         public data class DiscoveryStartParameters
             @JvmOverloads
             constructor(
@@ -135,6 +139,7 @@ public interface OAuth {
          * @property customScopes Any additional scopes to be requested from the identity provider
          * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
          */
+        @JacocoExcludeGenerated
         public data class GetTokenForProviderParams
             @JvmOverloads
             constructor(
@@ -163,6 +168,7 @@ public interface OAuth {
          * A data class wrapping the parameters necessary to authenticate an OAuth Discovery flow
          * @property discoveryOauthToken The oauth token used to finish the discovery flow
          */
+        @JacocoExcludeGenerated
         public data class DiscoveryAuthenticateParameters(
             val discoveryOauthToken: String,
         )
@@ -231,6 +237,7 @@ public interface OAuth {
      * secondary authentication requirement.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
@@ -22,6 +22,7 @@ import com.stytch.sdk.b2b.network.models.OrganizationData
 import com.stytch.sdk.b2b.network.models.SearchOperator
 import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.StytchObjectInfo
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.CompletableFuture
 
@@ -93,6 +94,7 @@ public interface Organization {
      * @property rbacEmailImplicitRoleAssignments An array of implicit role assignments granted to members in this
      * organization whose emails match the domain.
      */
+    @JacocoExcludeGenerated
     public data class UpdateOrganizationParameters
         @JvmOverloads
         constructor(
@@ -286,6 +288,7 @@ public interface Organization {
          * that Member authenticates and becomes active. If false, new Members will be created with status active.
          * @property roles Roles to explicitly assign to this Member.
          */
+        @JacocoExcludeGenerated
         public data class CreateMemberParameters
             @JvmOverloads
             constructor(
@@ -349,6 +352,7 @@ public interface Organization {
          * 1. Which MFA method the Member is prompted to use when logging in
          * 2. Whether An SMS will be sent automatically after completing the first leg of authentication
          */
+        @JacocoExcludeGenerated
         public data class UpdateMemberParameters
             @JvmOverloads
             constructor(
@@ -410,6 +414,7 @@ public interface Organization {
          * Only an operator is required. If you include no operands, no filtering will be applied.
          * If you include no query object, it will return all Members with no filtering applied.
          */
+        @JacocoExcludeGenerated
         public data class SearchParameters
             @JvmOverloads
             constructor(
@@ -426,6 +431,7 @@ public interface Organization {
          * @property operands An array of operand objects that contains all of the filters and values to apply to your
          * search query.
          */
+        @JacocoExcludeGenerated
         public data class SearchQuery(
             val operator: SearchOperator,
             val operands: List<SearchQueryOperand>,
@@ -446,6 +452,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_ids
              */
+            @JacocoExcludeGenerated
             public data class MemberIds(
                 val value: List<String>,
             ) : SearchQueryOperand(
@@ -456,6 +463,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_emails
              */
+            @JacocoExcludeGenerated
             public data class MemberEmails(
                 val value: List<String>,
             ) : SearchQueryOperand(
@@ -466,6 +474,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_email_fuzzy
              */
+            @JacocoExcludeGenerated
             public data class MemberEmailFuzzy(
                 val value: String,
             ) : SearchQueryOperand(
@@ -476,6 +485,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_is_breakglass
              */
+            @JacocoExcludeGenerated
             public data class MemberIsBreakingGlass(
                 val value: Boolean,
             ) : SearchQueryOperand(
@@ -486,6 +496,7 @@ public interface Organization {
             /**
              * An operand for searching based on statuses
              */
+            @JacocoExcludeGenerated
             public data class Statuses(
                 val value: List<String>,
             ) : SearchQueryOperand(
@@ -496,6 +507,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_mfa_phone_numbers
              */
+            @JacocoExcludeGenerated
             public data class MemberMFAPhoneNumbers(
                 val value: List<String>,
             ) : SearchQueryOperand(
@@ -506,6 +518,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_mfa_phone_number_fuzzy
              */
+            @JacocoExcludeGenerated
             public data class MemberMFAPhoneNumberFuzzy(
                 val value: String,
             ) : SearchQueryOperand(
@@ -516,6 +529,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_password_exists
              */
+            @JacocoExcludeGenerated
             public data class MemberPasswordExists(
                 val value: Boolean,
             ) : SearchQueryOperand(
@@ -526,6 +540,7 @@ public interface Organization {
             /**
              * An operand for searching based on member_roles
              */
+            @JacocoExcludeGenerated
             public data class MemberRoles(
                 val value: List<String>,
             ) : SearchQueryOperand(
@@ -536,6 +551,7 @@ public interface Organization {
             /**
              * An operand for searching based on custom filters
              */
+            @JacocoExcludeGenerated
             public data class Custom(
                 val name: String,
                 val value: Any,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
@@ -8,6 +8,7 @@ import com.stytch.sdk.b2b.EmailOTPLoginOrSignupResponse
 import com.stytch.sdk.b2b.SMSAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -43,6 +44,7 @@ public interface OTP {
          * @property enableAutofill indicates whether the SMS message should include autofill metadata
          * @property autofillSessionDurationMinutes indicates how long an autofilled session should last
          */
+        @JacocoExcludeGenerated
         public data class SendParameters
             @JvmOverloads
             constructor(
@@ -88,6 +90,7 @@ public interface OTP {
          * false. If not set, does not affect the member's MFA enrollment.
          * @property sessionDurationMinutes indicates how long the session should last before it expires
          */
+        @JacocoExcludeGenerated
         public data class AuthenticateParameters
             @JvmOverloads
             constructor(
@@ -146,6 +149,7 @@ public interface OTP {
          * Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no
          * value is provided, the copy defaults to English.
          */
+        @JacocoExcludeGenerated
         public data class LoginOrSignupParameters
             @JvmOverloads
             constructor(
@@ -193,6 +197,7 @@ public interface OTP {
          * value is provided, the copy defaults to English.
          * @property sessionDurationMinutes indicates how long the session should last before it expires
          */
+        @JacocoExcludeGenerated
         public data class AuthenticateParameters
             @JvmOverloads
             constructor(
@@ -244,6 +249,7 @@ public interface OTP {
              * Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br");
              * if no value is provided, the copy defaults to English.
              */
+            @JacocoExcludeGenerated
             public data class SendParameters
                 @JvmOverloads
                 constructor(
@@ -281,6 +287,7 @@ public interface OTP {
              * @property code The OTP to authenticate
              * @property emailAddress The email address of the member
              */
+            @JacocoExcludeGenerated
             public data class AuthenticateParameters(
                 val code: String,
                 val emailAddress: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.PasswordsAuthenticateResponse
 import com.stytch.sdk.b2b.SessionResetResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -36,6 +37,7 @@ public interface Passwords {
      * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
      * if no value is provided, the copy defaults to English.
      */
+    @JacocoExcludeGenerated
     public data class AuthParameters
         @JvmOverloads
         constructor(
@@ -114,6 +116,7 @@ public interface Passwords {
      * default email template. The template must be a template using our built-in customizations or a custom HTML email
      * for Password Reset.
      */
+    @JacocoExcludeGenerated
     public data class ResetByEmailStartParameters
         @JvmOverloads
         constructor(
@@ -162,6 +165,7 @@ public interface Passwords {
      * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
      * if no value is provided, the copy defaults to English.
      */
+    @JacocoExcludeGenerated
     public data class ResetByEmailParameters
         @JvmOverloads
         constructor(
@@ -215,6 +219,7 @@ public interface Passwords {
      * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
      * if no value is provided, the copy defaults to English.
      */
+    @JacocoExcludeGenerated
     public data class ResetByExistingPasswordParameters
         @JvmOverloads
         constructor(
@@ -268,6 +273,7 @@ public interface Passwords {
      * @property organizationId is the member's organization ID
      * @property password is the new password to set
      */
+    @JacocoExcludeGenerated
     public data class ResetBySessionParameters(
         val organizationId: String,
         val password: String,
@@ -313,6 +319,7 @@ public interface Passwords {
      * initiate a password strength check
      * @property password is the private sequence of characters you wish to check to get advice on improving it
      */
+    @JacocoExcludeGenerated
     public data class StrengthCheckParameters
         @JvmOverloads
         constructor(
@@ -375,6 +382,7 @@ public interface Passwords {
          * default email template will be sent. If providing a template ID, it must be either a template using
          * Stytch's customizations, or a Passwords reset custom HTML template.
          */
+        @JacocoExcludeGenerated
         public data class ResetByEmailStartParameters(
             val emailAddress: String,
             val discoveryRedirectUrl: String? = null,
@@ -421,6 +429,7 @@ public interface Passwords {
          * @property passwordResetToken - The token to authenticate.
          * @property password - The new password for the Member.
          */
+        @JacocoExcludeGenerated
         public data class ResetByEmailParameters(
             val passwordResetToken: String,
             val password: String,
@@ -461,6 +470,7 @@ public interface Passwords {
          * @property emailAddress - The email attempting to login.
          * @property password - The password for the email address.
          */
+        @JacocoExcludeGenerated
         public data class AuthenticateParameters(
             val emailAddress: String,
             val password: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodes.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodes.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.recoveryCodes
 import com.stytch.sdk.b2b.RecoveryCodesGetResponse
 import com.stytch.sdk.b2b.RecoveryCodesRecoverResponse
 import com.stytch.sdk.b2b.RecoveryCodesRotateResponse
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -52,6 +53,7 @@ public interface RecoveryCodes {
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      * @property recoveryCode The recovery code to authenticate.
      */
+    @JacocoExcludeGenerated
     public data class RecoverParameters(
         val organizationId: String,
         val memberId: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.b2b.SCIMRotateCompleteResponse
 import com.stytch.sdk.b2b.SCIMRotateStartResponse
 import com.stytch.sdk.b2b.SCIMUpdateConnectionResponse
 import com.stytch.sdk.b2b.network.models.SCIMGroupImplicitRoleAssignment
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -20,6 +21,7 @@ public interface SCIM {
      * @property displayName A human-readable display name for the connection.
      * @property identityProvider The identity provider of this connection.
      */
+    @JacocoExcludeGenerated
     public data class CreateConnectionParameters(
         val displayName: String? = null,
         val identityProvider: String? = null,
@@ -34,6 +36,7 @@ public interface SCIM {
      * organization who are created via this SCIM connection and belong to the specified group. Before adding any group
      * implicit role assignments, you must first provision groups from your IdP into Stytch
      */
+    @JacocoExcludeGenerated
     public data class UpdateConnectionParameters(
         val connectionId: String,
         val displayName: String? = null,
@@ -46,6 +49,7 @@ public interface SCIM {
      * @property limit The maximum number of groups that should be returned by the API.
      * @property cursor The cursor to use to indicate where to start group results.
      */
+    @JacocoExcludeGenerated
     public data class GetConnectionGroupsParameters(
         val limit: Int? = null,
         val cursor: String? = null,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.b2b.searchManager
 
 import com.stytch.sdk.b2b.B2BSearchMemberResponse
 import com.stytch.sdk.b2b.B2BSearchOrganizationResponse
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -12,6 +13,7 @@ public interface SearchManager {
      * A data class wrapping the parameters used for a Search Organizations call
      * @property organizationSlug the slug of the organization to search for
      */
+    @JacocoExcludeGenerated
     public data class SearchOrganizationParameters(
         val organizationSlug: String,
     )
@@ -47,6 +49,7 @@ public interface SearchManager {
      * @property emailAddress the email address of the member to search for
      * @property organizationId the id of the organization the member belongs to
      */
+    @JacocoExcludeGenerated
     public data class SearchMemberParameters(
         val emailAddress: String,
         val organizationId: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.b2b.SessionsAuthenticateResponse
 import com.stytch.sdk.b2b.network.models.B2BSessionData
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.StytchObjectInfo
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.common.network.models.Locale
 import kotlinx.coroutines.flow.StateFlow
@@ -40,6 +41,7 @@ public interface B2BSessions {
      * Data class used for wrapping parameters used with Sessions authentication
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthParams
         @JvmOverloads
         constructor(
@@ -50,6 +52,7 @@ public interface B2BSessions {
      * Data class used for wrapping parameters used with Sessions revocation
      * @property forceClear if true, we will clear the local session regardless of any network errors
      */
+    @JacocoExcludeGenerated
     public data class RevokeParams
         @JvmOverloads
         constructor(
@@ -130,6 +133,7 @@ public interface B2BSessions {
      * secondary authentication requirement.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class ExchangeParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -15,6 +15,7 @@ import com.stytch.sdk.b2b.network.models.ConnectionRoleAssignment
 import com.stytch.sdk.b2b.network.models.GroupRoleAssignment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import java.util.concurrent.CompletableFuture
 
@@ -44,6 +45,7 @@ public interface SSO {
      * finish the login. The URL must be configured as a Sign Up URL in the Redirect URL page. If the field is not
      * specified, the default Sign Up URL will be used.
      */
+    @JacocoExcludeGenerated
     public data class StartParams
         @JvmOverloads
         constructor(
@@ -74,6 +76,7 @@ public interface SSO {
      * @property customScopes Any additional scopes to be requested from the identity provider
      * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
      */
+    @JacocoExcludeGenerated
     public data class GetTokenForProviderParams
         @JvmOverloads
         constructor(
@@ -101,6 +104,7 @@ public interface SSO {
      * Currently supported languages are English (`"en"`), Spanish (`"es"`), and Brazilian Portuguese (`"pt-br"`);
      * if no value is provided, the copy defaults to English.
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParams
         @JvmOverloads
         constructor(
@@ -205,6 +209,7 @@ public interface SSO {
          * Data class used for wrapping the parameters for a SAML creation request
          * @property displayName A human-readable display name for the connection.
          */
+        @JacocoExcludeGenerated
         public data class CreateParameters
             @JvmOverloads
             constructor(
@@ -256,6 +261,7 @@ public interface SSO {
          * implicit role assignments, you must add a "groups" key to your SAML connection's attribute_mapping. Make sure
          * that your IdP is configured to correctly send the group information.
          */
+        @JacocoExcludeGenerated
         public data class UpdateParameters
             @JvmOverloads
             constructor(
@@ -300,6 +306,7 @@ public interface SSO {
          * @property connectionId Globally unique UUID that identifies a specific SAML Connection.
          * @property metadataUrl A URL that points to the IdP metadata. This will be provided by the IdP.
          */
+        @JacocoExcludeGenerated
         public data class UpdateByURLParameters(
             val connectionId: String,
             val metadataUrl: String,
@@ -338,6 +345,7 @@ public interface SSO {
          * @property connectionId Globally unique UUID that identifies a specific SAML Connection.
          * @property certificateId The ID of the certificate to be deleted.
          */
+        @JacocoExcludeGenerated
         public data class DeleteVerificationCertificateParameters(
             val connectionId: String,
             val certificateId: String,
@@ -386,6 +394,7 @@ public interface SSO {
          * Data class used for wrapping the parameters for an OIDC creation request
          * @property displayName A human-readable display name for the connection.
          */
+        @JacocoExcludeGenerated
         public data class CreateParameters
             @JvmOverloads
             constructor(
@@ -436,6 +445,7 @@ public interface SSO {
          * @property jwksUrl The location of the IdP's JSON Web Key Set, used to verify credentials issued by the IdP.
          * This will be provided by the IdP.
          */
+        @JacocoExcludeGenerated
         public data class UpdateParameters
             @JvmOverloads
             constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTP.kt
@@ -4,6 +4,7 @@ import com.stytch.sdk.b2b.TOTPAuthenticateResponse
 import com.stytch.sdk.b2b.TOTPCreateResponse
 import com.stytch.sdk.b2b.network.models.SetMFAEnrollment
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -18,6 +19,7 @@ public interface TOTP {
      * within this time frame the TOTP will be unusable. Defaults to 60 (1 hour) with a minimum of 5 and a maximum of
      * 1440.
      */
+    @JacocoExcludeGenerated
     public data class CreateParameters
         @JvmOverloads
         constructor(
@@ -61,6 +63,7 @@ public interface TOTP {
      * @property setDefaultMFAMethod If set to true, sets TOTP as the member's default MFA method.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.common
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.errors.StytchDeeplinkError
 
 /**
@@ -10,7 +11,10 @@ public sealed interface DeeplinkHandledStatus {
      * Indicates that a deeplink was successfully parsed from the deeplink.
      * @property response A [DeeplinkResponse] representing either the authenticated response or an error.
      */
-    public data class Handled(val response: DeeplinkResponse) : DeeplinkHandledStatus
+    @JacocoExcludeGenerated
+    public data class Handled(
+        val response: DeeplinkResponse,
+    ) : DeeplinkHandledStatus
 
     /**
      * Indicates that a deeplink was not handled by the Stytch client, either because a token could not be parsed from
@@ -21,7 +25,10 @@ public sealed interface DeeplinkHandledStatus {
      *
      * @property reason A StytchDeeplinkError explaining why the deeplink was not handled
      */
-    public data class NotHandled(val reason: StytchDeeplinkError) : DeeplinkHandledStatus
+    @JacocoExcludeGenerated
+    public data class NotHandled(
+        val reason: StytchDeeplinkError,
+    ) : DeeplinkHandledStatus
 
     /**
      * Indicates that this was a supported Stytch deeplink, but there is something more your application needs to do
@@ -33,5 +40,9 @@ public sealed interface DeeplinkHandledStatus {
      * @property type The [TokenType] that was extracted from the deeplink
      * @property token The token that was extracted from the deeplink
      */
-    public data class ManualHandlingRequired(val type: TokenType, val token: String) : DeeplinkHandledStatus
+    @JacocoExcludeGenerated
+    public data class ManualHandlingRequired(
+        val type: TokenType,
+        val token: String,
+    ) : DeeplinkHandledStatus
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkResponse.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkResponse.kt
@@ -1,17 +1,21 @@
 package com.stytch.sdk.common
 
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.CommonAuthenticationData
 
 /**
  * A class representing the types of Deeplink responses that the Stytch client has handled
  * @property result A [StytchResult] representing either the authenticated or discovery response, or an error.
  */
-public sealed class DeeplinkResponse(public open val result: StytchResult<Any>) {
+public sealed class DeeplinkResponse(
+    public open val result: StytchResult<Any>,
+) {
     /**
      * An authenticated user response
      * @property result A [StytchResult] representing either the authenticated response or an error.
      */
+    @JacocoExcludeGenerated
     public data class Auth(
         override val result: StytchResult<CommonAuthenticationData>,
     ) : DeeplinkResponse(result)
@@ -20,6 +24,7 @@ public sealed class DeeplinkResponse(public open val result: StytchResult<Any>) 
      * A B2B discovery response
      * @property result A [StytchResult] representing either the authenticated intermediate session or an error.
      */
+    @JacocoExcludeGenerated
     public data class Discovery(
         override val result: StytchResult<DiscoveryAuthenticateResponseData>,
     ) : DeeplinkResponse(result)

--- a/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkTokenPair.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkTokenPair.kt
@@ -2,13 +2,16 @@ package com.stytch.sdk.common
 
 import android.os.Parcelable
 import com.stytch.sdk.b2b.B2BRedirectType
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
 /**
  * A data class representing a concrete token type and corresponding token parsed from a deeplink
  */
-@Parcelize public data class DeeplinkTokenPair(
+@Parcelize
+@JacocoExcludeGenerated
+public data class DeeplinkTokenPair(
     val tokenType: @RawValue TokenType,
     val token: String?,
     val redirectType: B2BRedirectType? = null,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/EndpointOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/EndpointOptions.kt
@@ -1,9 +1,12 @@
 package com.stytch.sdk.common
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * Defines custom endpoints used by the SDK
  * @property dfppaDomain the domain that should be used for DFPPA
  */
+@JacocoExcludeGenerated
 public data class EndpointOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/PKCECodePair.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/PKCECodePair.kt
@@ -1,5 +1,7 @@
 package com.stytch.sdk.common
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * A data class representing the most recent PKCE code pair generated on this device. You may find this useful if you
  * use a hybrid (frontend and backend) authentication flow, where you need to complete a PKCE flow on the backend
@@ -7,6 +9,7 @@ package com.stytch.sdk.common
  * @property codeVerifier the verifier of the challenge
  * @property method a string identifying the encryption method used. This will always be "S256"
  */
+@JacocoExcludeGenerated
 public data class PKCECodePair(
     val codeChallenge: String,
     val codeVerifier: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
@@ -1,9 +1,12 @@
 package com.stytch.sdk.common
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * Options for configuring the StytchClient
  * @property endpointOptions Defines custom endpoints used by the SDK
  */
+@JacocoExcludeGenerated
 public data class StytchClientOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchObjectInfo.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchObjectInfo.kt
@@ -1,10 +1,12 @@
 package com.stytch.sdk.common
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.Date
 
 public sealed interface StytchObjectInfo<out T> {
     public data object Unavailable : StytchObjectInfo<Nothing>
 
+    @JacocoExcludeGenerated
     public data class Available<out T>(
         val lastValidatedAt: Date,
         val value: T,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchResult.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchResult.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.common
 
 import android.os.Parcelable
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.errors.StytchError
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
@@ -14,13 +15,19 @@ public sealed class StytchResult<out T> : Parcelable {
      * Data class that can hold a successful response from a Stytch endpoint
      * @property value is the value of the response
      */
-    public data class Success<out T>(val value: @RawValue T) : StytchResult<T>()
+    @JacocoExcludeGenerated
+    public data class Success<out T>(
+        val value: @RawValue T,
+    ) : StytchResult<T>()
 
     /**
      * Data class that can hold a StytchException
      * @property exception provides information about what went wrong during an API call
      */
-    public data class Error(val exception: StytchError) : StytchResult<Nothing>()
+    @JacocoExcludeGenerated
+    public data class Error(
+        val exception: StytchError,
+    ) : StytchResult<Nothing>()
 }
 
 internal fun <T> StytchResult<T>.getValueOrThrow(): T =

--- a/source/sdk/src/main/java/com/stytch/sdk/common/annotations/JacocoExcludeGenerated.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/annotations/JacocoExcludeGenerated.kt
@@ -1,0 +1,12 @@
+package com.stytch.sdk.common.annotations
+
+// https://stackoverflow.com/questions/73169311/exclude-kotlin-data-classes-from-jacoco-test-coverage
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.CONSTRUCTOR,
+)
+internal annotation class JacocoExcludeGenerated

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -2,6 +2,8 @@
 
 package com.stytch.sdk.common.errors
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * A base class representing SDK specific errors or exceptions that may occur. This class should not be used directly,
  * rather we should be creating implementations for each of the known/expected errors we return.
@@ -16,6 +18,7 @@ public sealed class StytchSDKError(
  * Thrown when you try to use the SDK before it has been configured
  * @property clientName the client type that must be configured (either `StytchClient` or `StytchB2BClient`)
  */
+@JacocoExcludeGenerated
 public data class StytchSDKNotConfiguredError(
     val clientName: String,
 ) : StytchSDKError(
@@ -27,6 +30,7 @@ public data class StytchSDKNotConfiguredError(
  * @property exception an optional [Throwable] that caused this error to occur
  * @property message a string describing what went wrong
  */
+@JacocoExcludeGenerated
 public data class StytchInternalError(
     public override val exception: Throwable? = null,
     public override val message: String = "An internal error has occurred. Please contact Stytch if this occurs.",
@@ -39,6 +43,7 @@ public data class StytchInternalError(
  * Thrown when we couldn't find a code verifier on device
  * @property exception an optional [Throwable] that caused this error to occur
  */
+@JacocoExcludeGenerated
 public data class StytchMissingPKCEError(
     public override val exception: Throwable?,
 ) : StytchSDKError(
@@ -50,6 +55,7 @@ public data class StytchMissingPKCEError(
  * Thrown when we couldn't create a code challenge on device
  * @property exception the [Throwable] that caused this error to occur
  */
+@JacocoExcludeGenerated
 public data class StytchFailedToCreateCodeChallengeError(
     public override val exception: Throwable,
 ) : StytchSDKError(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchUIError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchUIError.kt
@@ -1,5 +1,7 @@
 package com.stytch.sdk.common.errors
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * A base class representing SDK specific errors or exceptions that may occur. This class should not be used directly,
  * rather we should be creating implementations for each of the known/expected errors we return.
@@ -14,6 +16,7 @@ public sealed class StytchUIError(
  * Thrown when the UI Activity failed
  * @property code the Activity result code returned when the UI activity failed
  */
+@JacocoExcludeGenerated
 public data class StytchUIActivityFailed(
     val code: Int,
 ) : StytchUIError(message = "Activity failed with resultCode = $code")
@@ -29,6 +32,7 @@ public data object StytchUINoDataFromIntent : StytchUIError(
  * Thrown when your Stytch UI configuration is invalid
  * @property message a string describing what is incorrect about the UI configuration that was provided
  */
+@JacocoExcludeGenerated
 public data class StytchUIInvalidConfiguration(
     public override val message: String,
 ) : StytchUIError(message = message)

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/Biometrics.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/Biometrics.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer.biometrics
 
 import androidx.fragment.app.FragmentActivity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.consumer.BiometricsAuthResponse
 import java.util.concurrent.CompletableFuture
 
@@ -21,6 +22,7 @@ public interface Biometrics {
      * @property allowDeviceCredentials opts-in to allowing the use of non-biometric device credentials (PIN, Pattern)
      * as a fallback (on Android versions greater than Q)
      */
+    @JacocoExcludeGenerated
     public data class RegisterParameters
         @JvmOverloads
         constructor(
@@ -38,6 +40,7 @@ public interface Biometrics {
      * @property promptData is an optional biometric prompt configuration. If one is not provided a default will be
      * created
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParameters
         @JvmOverloads
         constructor(
@@ -52,6 +55,7 @@ public interface Biometrics {
      * @property subTitle The subtitle to be displayed in the Biometric Prompt
      * @property negativeButtonText "Cancel" button text to display, if device credentials are disallowed
      */
+    @JacocoExcludeGenerated
     public data class PromptData(
         val title: String,
         val subTitle: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.consumer.crypto
 
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
 import com.stytch.sdk.consumer.network.models.CryptoWalletType
@@ -16,6 +17,7 @@ public interface CryptoWallet {
      * @property cryptoWalletAddress The address to authenticate.
      * @property cryptoWalletType The type of wallet to authenticate. Currently `ethereum` and `solana` are supported.
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateStartParameters(
         val cryptoWalletAddress: String,
         val cryptoWalletType: CryptoWalletType,
@@ -28,6 +30,7 @@ public interface CryptoWallet {
      * @property signature The signature from the message.
      * @property sessionDurationMinutes the length of time in minutes that a session should be minted for
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.magicLinks
 import android.os.Parcelable
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.AuthResponse
 import kotlinx.parcelize.Parcelize
@@ -17,6 +18,7 @@ public interface MagicLinks {
      * @property token is the unique sequence of characters used to log in
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthParameters
         @JvmOverloads
         constructor(
@@ -79,6 +81,7 @@ public interface MagicLinks {
          * if no value is provided, the copy defaults to English.
          */
         @Parcelize
+        @JacocoExcludeGenerated
         public data class Parameters
             @JvmOverloads
             constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.activity.ComponentActivity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.consumer.NativeOAuthResponse
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 import java.util.concurrent.CompletableFuture
@@ -124,6 +125,7 @@ public interface OAuth {
          * @property autoSelectEnabled toggles whether or not to autoselect an account if only one Google account exists
          * @property sessionDurationMinutes indicates how long the session should last before it expires
          */
+        @JacocoExcludeGenerated
         public data class StartParameters
             @JvmOverloads
             constructor(
@@ -196,6 +198,7 @@ public interface OAuth {
          * @property customScopes Any additional scopes to be requested from the identity provider
          * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
          */
+        @JacocoExcludeGenerated
         public data class StartParameters
             @JvmOverloads
             constructor(
@@ -212,6 +215,7 @@ public interface OAuth {
          * @property token is the token returned from the provider
          * @property sessionDurationMinutes indicates how long the session should last before it expires
          */
+        @JacocoExcludeGenerated
         public data class AuthenticateParameters
             @JvmOverloads
             constructor(
@@ -239,6 +243,7 @@ public interface OAuth {
          * @property customScopes Any additional scopes to be requested from the identity provider
          * @property providerParams An optional mapping of provider specific values to pass through to the OAuth provider.
          */
+        @JacocoExcludeGenerated
         public data class GetTokenForProviderParams
             @JvmOverloads
             constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
@@ -22,6 +23,7 @@ public interface OTP {
      * @property methodId the identifier returned from the corresponding loginOrCreate or send method
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthParameters
         @JvmOverloads
         constructor(
@@ -93,6 +95,7 @@ public interface OTP {
          * if no value is provided, the copy defaults to English.
          */
         @Parcelize
+        @JacocoExcludeGenerated
         public data class Parameters
             @JvmOverloads
             constructor(
@@ -169,6 +172,7 @@ public interface OTP {
          * @property expirationMinutes indicates how long the OTP should last before it expires
          */
         @Parcelize
+        @JacocoExcludeGenerated
         public data class Parameters
             @JvmOverloads
             constructor(
@@ -248,6 +252,7 @@ public interface OTP {
          * Magic links - Sign-up.
          */
         @Parcelize
+        @JacocoExcludeGenerated
         public data class Parameters
             @JvmOverloads
             constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer.passkeys
 
 import android.app.Activity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
@@ -17,6 +18,7 @@ public interface Passkeys {
      * @property activity an activity context for launching the native Passkeys UI
      * @property domain the domain of the Passkey registration. Do not include the protocol
      */
+    @JacocoExcludeGenerated
     public data class RegisterParameters(
         val activity: Activity,
         val domain: String,
@@ -28,6 +30,7 @@ public interface Passkeys {
      * @property domain the domain of the Passkey registration. Do not include the protocol
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParameters
         @JvmOverloads
         constructor(
@@ -41,6 +44,7 @@ public interface Passkeys {
      * @property id the id of a Passkey registration
      * @property name the name for a Passkey
      */
+    @JacocoExcludeGenerated
     public data class UpdateParameters(
         val id: String,
         val name: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer.passwords
 import android.os.Parcelable
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.PasswordsCreateResponse
@@ -29,6 +30,7 @@ public interface Passwords {
      * @property password is your private sequence of characters to authenticate
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthParameters
         @JvmOverloads
         constructor(
@@ -45,6 +47,7 @@ public interface Passwords {
      * created account in the future
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class CreateParameters
         @JvmOverloads
         constructor(
@@ -66,6 +69,7 @@ public interface Passwords {
      * for Password Reset.
      */
     @Parcelize
+    @JacocoExcludeGenerated
     public data class ResetByEmailStartParameters
         @JvmOverloads
         constructor(
@@ -84,6 +88,7 @@ public interface Passwords {
      * @property password is the private sequence of characters you wish to use as a password
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class ResetByEmailParameters
         @JvmOverloads
         constructor(
@@ -98,6 +103,7 @@ public interface Passwords {
      * @property password is the new password to set
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class ResetBySessionParameters
         @JvmOverloads
         constructor(
@@ -114,6 +120,7 @@ public interface Passwords {
      * @property newPassword The new password for the user.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class ResetByExistingPasswordParameters
         @JvmOverloads
         constructor(
@@ -162,6 +169,7 @@ public interface Passwords {
      * initiate a password strength check
      * @property password is the private sequence of characters you wish to check to get advice on improving it
      */
+    @JacocoExcludeGenerated
     public data class StrengthCheckParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer.sessions
 
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.StytchObjectInfo
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.network.models.SessionData
@@ -43,6 +44,7 @@ public interface Sessions {
      * Data class used for wrapping parameters used with Sessions authentication
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthParams
         @JvmOverloads
         constructor(
@@ -53,6 +55,7 @@ public interface Sessions {
      * Data class used for wrapping parameters used with Sessions revocation
      * @property forceClear if true, we will clear the local session regardless of any network errors
      */
+    @JacocoExcludeGenerated
     public data class RevokeParams
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTP.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.consumer.totp
 
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.consumer.TOTPAuthenticateResponse
 import com.stytch.sdk.consumer.TOTPCreateResponse
 import com.stytch.sdk.consumer.TOTPRecoverResponse
@@ -18,6 +19,7 @@ public interface TOTP {
      * within this time frame the TOTP will be unusable. Defaults to 60 (1 hour) with a minimum of 5 and a maximum of
      * 1440.
      */
+    @JacocoExcludeGenerated
     public data class CreateParameters(
         val expirationMinutes: Int,
     )
@@ -27,6 +29,7 @@ public interface TOTP {
      * @property totpCode The TOTP code to authenticate. The TOTP code should consist of 6 digits.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class AuthenticateParameters
         @JvmOverloads
         constructor(
@@ -39,6 +42,7 @@ public interface TOTP {
      * @property recoveryCode The recovery code to authenticate.
      * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
+    @JacocoExcludeGenerated
     public data class RecoverParameters
         @JvmOverloads
         constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserAuthenticationFactor.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserAuthenticationFactor.kt
@@ -1,42 +1,67 @@
 package com.stytch.sdk.consumer.userManagement
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * A [UserAuthenticationFactor] represents a primary authentication factor associated with a Stytch User
  * @param id The string representing the unique ID of this authentication factor
  */
-public sealed class UserAuthenticationFactor(public open val id: String) {
+public sealed class UserAuthenticationFactor(
+    public open val id: String,
+) {
     /**
      * Represents an email address associated with a Stytch User
      */
-    public data class Email(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class Email(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 
     /**
      * Represents a phone number associated with a Stytch User
      */
-    public data class PhoneNumber(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class PhoneNumber(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 
     /**
      * Represents a biometric registration associated with a Stytch User
      */
-    public data class BiometricRegistration(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class BiometricRegistration(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 
     /**
      * Represents a Web3 login associated with a Stytch User
      */
-    public data class CryptoWallet(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class CryptoWallet(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 
     /**
      * Represents a WebAuthn registration associated with a Stytch User
      */
-    public data class WebAuthn(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class WebAuthn(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 
     /**
      * Represents a TOTP registration associated with a Stytch User
      */
-    public data class TOTP(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class TOTP(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 
     /**
      * Represents an OAuth registration associated with a Stytch User
      */
-    public data class OAuth(override val id: String) : UserAuthenticationFactor(id)
+    @JacocoExcludeGenerated
+    public data class OAuth(
+        override val id: String,
+    ) : UserAuthenticationFactor(id)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagement.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagement.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.consumer.userManagement
 
 import com.stytch.sdk.common.StytchObjectInfo
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.NameData
 import com.stytch.sdk.consumer.DeleteFactorResponse
 import com.stytch.sdk.consumer.SearchUserResponse
@@ -76,6 +77,7 @@ public interface UserManagement {
      * @property name the name of the user
      * @property untrustedMetadata a map of untrusted metadata to assign to the user
      */
+    @JacocoExcludeGenerated
     public data class UpdateParams
         @JvmOverloads
         constructor(
@@ -111,6 +113,7 @@ public interface UserManagement {
      * Data class used for wrapping parameters used for searching Users
      * @property email the email address to search for
      */
+    @JacocoExcludeGenerated
     public data class SearchParams(
         val email: String,
     )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/AuthenticationResult.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/AuthenticationResult.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
 import androidx.annotation.Keep
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.errors.StytchError
 import kotlinx.parcelize.Parcelize
 
@@ -10,6 +11,7 @@ import kotlinx.parcelize.Parcelize
 public sealed class AuthenticationResult : Parcelable {
     public data object Authenticated : AuthenticationResult()
 
+    @JacocoExcludeGenerated
     public data class Error(
         public val error: StytchError,
     ) : AuthenticationResult()

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BEmailMagicLinkOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BEmailMagicLinkOptions.kt
@@ -3,11 +3,13 @@ package com.stytch.sdk.ui.b2b.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class B2BEmailMagicLinkOptions(
     val loginTemplateId: String? = null,
     val signupTemplateId: String? = null,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthOptions.kt
@@ -3,11 +3,13 @@ package com.stytch.sdk.ui.b2b.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class B2BOAuthOptions(
     val providers: List<B2BOAuthProviderConfig> = emptyList(),
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthProviderConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthProviderConfig.kt
@@ -3,11 +3,13 @@ package com.stytch.sdk.ui.b2b.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class B2BOAuthProviderConfig(
     val type: B2BOAuthProviders,
     val customScopes: List<String> = emptyList(),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
@@ -3,11 +3,13 @@ package com.stytch.sdk.ui.b2b.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class B2BPasswordOptions(
     val resetPasswordTemplateId: String? = null,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/DirectLoginForSingleMembershipOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/DirectLoginForSingleMembershipOptions.kt
@@ -3,11 +3,13 @@ package com.stytch.sdk.ui.b2b.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class DirectLoginForSingleMembershipOptions(
     val status: Boolean,
     val ignoreInvites: Boolean,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.b2b.network.models.MfaMethod
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.ui.shared.data.SessionOptions
 import kotlinx.parcelize.Parcelize
@@ -11,6 +12,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class StytchB2BProductConfig
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptions.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.magicLinks.MagicLinks
 import kotlinx.parcelize.Parcelize
@@ -17,6 +18,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class EmailMagicLinksOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/GoogleOAuthOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/GoogleOAuthOptions.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -12,6 +13,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class GoogleOAuthOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OAuthOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OAuthOptions.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -14,6 +15,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class OAuthOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OTPOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OTPOptions.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.otp.OTP
 import kotlinx.parcelize.Parcelize
@@ -18,6 +19,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class OTPOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/PasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/PasswordOptions.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.consumer.passwords.Passwords
 import kotlinx.parcelize.Parcelize
@@ -16,6 +17,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class PasswordOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProductConfig.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.ui.shared.data.SessionOptions
 import kotlinx.parcelize.Parcelize
@@ -20,6 +21,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class StytchProductConfig
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/SessionOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/SessionOptions.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -13,6 +14,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Keep
 @JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
 public data class SessionOptions
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/StytchStyles.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/StytchStyles.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.shared.data
 
 import android.os.Parcelable
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -9,6 +10,7 @@ import kotlinx.parcelize.Parcelize
  * @param lightTheme a [StytchTheme] instance that defines the styles when in light mode
  */
 @Parcelize
+@JacocoExcludeGenerated
 public data class StytchStyles
     @JvmOverloads
     constructor(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/StytchTheme.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/StytchTheme.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.shared.data
 import android.os.Parcelable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 private val CHARCOAL: Int = Color(0xFF19303D).toArgb()
@@ -48,6 +49,7 @@ private val INK: Int = Color(0xFFFF354D5A).toArgb()
  * @param hideHeaderText a Boolean that determines whether or not to show the header text on the main UI screen.
  */
 @Parcelize
+@JacocoExcludeGenerated
 public data class StytchTheme
     @JvmOverloads
     constructor(


### PR DESCRIPTION
Linear Ticket: [SDK-2490](https://linear.app/stytch/issue/SDK-2490)

There's a bunch of stuff that really shouldn't be used to calculate our test coverage, like UI-specific composables and Kotlin-generated code (like all of the magic methods that get created for a `data class`)

## Changes:

1. Excludes some UI specific stuff from code coverage reports wholesale (the changes in the gradle file)
2. Adds a new `@JacocoExcludeGenerated` annotation to all of the relevant data classes to prevent them from being calculated (see: https://stackoverflow.com/questions/73169311/exclude-kotlin-data-classes-from-jacoco-test-coverage)
3. Explicitly configure the report step for what we consider pass/fail

## Notes:

- I don't think the pass/fail of the report is a hard blocker (ie: it won't actually prevent you from merging a PR); it's more of an honor system at this point.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A