### PR TITLE
SDK-2510 Make sessionJWT optional in updatesession methods

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -117,7 +117,7 @@ public interface B2BSessions {
      */
     public fun updateSession(
         sessionToken: String,
-        sessionJwt: String,
+        sessionJwt: String?,
     )
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
@@ -146,7 +146,7 @@ internal class B2BSessionsImpl internal constructor(
      */
     override fun updateSession(
         sessionToken: String,
-        sessionJwt: String,
+        sessionJwt: String?,
     ) {
         try {
             sessionStorage.updateSession(sessionToken = sessionToken, sessionJwt = sessionJwt)

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
@@ -120,6 +120,6 @@ public interface Sessions {
      */
     public fun updateSession(
         sessionToken: String,
-        sessionJwt: String,
+        sessionJwt: String?,
     )
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
@@ -145,7 +145,7 @@ internal class SessionsImpl internal constructor(
      */
     override fun updateSession(
         sessionToken: String,
-        sessionJwt: String,
+        sessionJwt: String?,
     ) {
         try {
             sessionStorage.updateSession(sessionToken, sessionJwt)


### PR DESCRIPTION
Linear Ticket: [SDK-2510](https://linear.app/stytch/issue/SDK-2510)

## Changes:

1. Make sessionJwt optional when calling updateSession

## Notes:

- Companion to https://github.com/stytchauth/stytch-ios/pull/423

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A