### PR TITLE
SDK-2583 Limit scope of automatic session revocation to sessions authenticate/revoke calls, and only for certain conditions

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -136,7 +136,6 @@ internal object StytchB2BApi {
                 sdkUrl,
                 authHeaderInterceptor,
                 StytchDFPInterceptor(dfpProvider, captchaProvider, dfpProtectedAuthEnabled, dfpProtectedAuthMode),
-                { StytchB2BClient.sessionStorage.revoke() },
                 StytchB2BApiService::class.java,
             )
     }
@@ -163,7 +162,6 @@ internal object StytchB2BApi {
             sdkUrl,
             authHeaderInterceptor,
             null,
-            { StytchB2BClient.sessionStorage.revoke() },
             StytchB2BApiService::class.java,
         )
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
@@ -1,5 +1,13 @@
 package com.stytch.sdk.common.errors
 
+private val UNRECOVERABLE_ERRORS =
+    setOf(
+        StytchAPIErrorType.UNAUTHORIZED_CREDENTIALS,
+        StytchAPIErrorType.USER_UNAUTHENTICATED,
+        StytchAPIErrorType.INVALID_SECRET_AUTHENTICATION,
+        StytchAPIErrorType.SESSION_NOT_FOUND,
+    )
+
 /**
  * An error class representing a non-schema error that occurs in the Stytch API
  * @property requestId the request id of the request that triggered this error
@@ -14,4 +22,6 @@ public data class StytchAPIError(
     public override val message: String,
     public val url: String? = null,
     public val statusCode: Int,
-) : StytchError(message = message)
+) : StytchError(message = message) {
+    internal fun isUnrecoverableError(): Boolean = UNRECOVERABLE_ERRORS.contains(this.errorType)
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -94,7 +94,6 @@ internal object StytchApi {
                 sdkUrl,
                 authHeaderInterceptor,
                 StytchDFPInterceptor(dfpProvider, captchaProvider, dfpProtectedAuthEnabled, dfpProtectedAuthMode),
-                { StytchClient.sessionStorage.revoke() },
                 StytchApiService::class.java,
             )
     }
@@ -121,7 +120,6 @@ internal object StytchApi {
             sdkUrl,
             authHeaderInterceptor,
             null,
-            { StytchClient.sessionStorage.revoke() },
             StytchApiService::class.java,
         )
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
@@ -4,8 +4,10 @@ import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchObjectInfo
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.StytchAPIError
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.common.errors.StytchInternalError
+import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.stytchObjectMapper
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
@@ -29,6 +31,21 @@ internal class SessionsImpl internal constructor(
     private val api: StytchApi.Sessions,
 ) : Sessions {
     private val callbacks = mutableListOf<(StytchObjectInfo<SessionData>) -> Unit>()
+
+    internal inline fun <reified T : Any> maybeForceClearSession(
+        result: StytchResult.Error,
+        forceClear: Boolean = false,
+    ): StytchResult<T> =
+        if (forceClear || result.exception is StytchAPIError && result.exception.isUnrecoverableError()) {
+            try {
+                sessionStorage.revoke()
+                result
+            } catch (ex: Exception) {
+                StytchResult.Error(StytchInternalError(ex))
+            }
+        } else {
+            result
+        }
 
     override val onChange: StateFlow<StytchObjectInfo<SessionData>> =
         combine(sessionStorage.sessionFlow, sessionStorage.lastValidatedAtFlow, ::stytchObjectMapper)
@@ -72,21 +89,20 @@ internal class SessionsImpl internal constructor(
 
     override fun getSync(): SessionData? = sessionStorage.session
 
-    override suspend fun authenticate(authParams: Sessions.AuthParams): AuthResponse {
-        val result: AuthResponse
+    override suspend fun authenticate(authParams: Sessions.AuthParams): AuthResponse =
         withContext(dispatchers.io) {
-            // do not revoke session here since we using stored data to authenticate
-            // call backend endpoint
-            result =
+            var result =
                 api
                     .authenticate(
                         authParams.sessionDurationMinutes,
                     ).apply {
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
+            if (result is StytchResult.Error) {
+                result = maybeForceClearSession(result, false)
+            }
+            result
         }
-        return result
-    }
 
     override fun authenticate(
         authParams: Sessions.AuthParams,
@@ -106,21 +122,21 @@ internal class SessionsImpl internal constructor(
                 authenticate(authParams)
             }.asCompletableFuture()
 
-    override suspend fun revoke(params: Sessions.RevokeParams): BaseResponse {
-        var result: BaseResponse
+    override suspend fun revoke(params: Sessions.RevokeParams): BaseResponse =
         withContext(dispatchers.io) {
-            result = api.revoke()
-        }
-        // remove stored session
-        try {
-            if (result is StytchResult.Success || params.forceClear) {
-                sessionStorage.revoke()
+            var result = api.revoke()
+            try {
+                when (result) {
+                    is StytchResult.Success -> sessionStorage.revoke()
+                    is StytchResult.Error -> {
+                        result = maybeForceClearSession<BasicData>(result, params.forceClear)
+                    }
+                }
+                result
+            } catch (e: Exception) {
+                StytchResult.Error(StytchInternalError(e))
             }
-        } catch (ex: Exception) {
-            result = StytchResult.Error(StytchInternalError(ex))
         }
-        return result
-    }
 
     override fun revoke(
         params: Sessions.RevokeParams,

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -48,7 +48,6 @@ internal class StytchB2BApiServiceTest {
                 mockWebServer.url("/").toString(),
                 null,
                 null,
-                {},
                 StytchB2BApiService::class.java,
             )
     }

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
@@ -11,6 +11,8 @@ import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchAPIErrorType
 import com.stytch.sdk.common.errors.StytchFailedToDecryptDataError
 import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
@@ -147,6 +149,21 @@ internal class B2BSessionsImplTest {
         }
 
     @Test
+    fun `SessionsImpl revoke does revoke a local session if a network error occurs and error is unrecoverable`() =
+        runBlocking {
+            coEvery { mockApi.revoke() } returns
+                StytchResult.Error(
+                    StytchAPIError(
+                        errorType = StytchAPIErrorType.SESSION_NOT_FOUND,
+                        message = "",
+                        statusCode = 401,
+                    ),
+                )
+            impl.revoke(B2BSessions.RevokeParams(false))
+            verify { mockSessionStorage.revoke() }
+        }
+
+    @Test
     fun `SessionsImpl revoke returns error if sessionStorage revoke fails`() =
         runBlocking {
             coEvery { mockApi.revoke() } returns StytchResult.Success(mockk(relaxed = true))
@@ -207,5 +224,31 @@ internal class B2BSessionsImplTest {
             callback = mockCallback,
         )
         verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SessionsImpl maybeForceClearSession behaves as expected`() {
+        val unrecoverableError =
+            StytchResult.Error(
+                StytchAPIError(
+                    errorType = StytchAPIErrorType.SESSION_NOT_FOUND,
+                    message = "",
+                    statusCode = 401,
+                ),
+            )
+        val recoverableError =
+            StytchResult.Error(
+                StytchAPIError(
+                    errorType = StytchAPIErrorType.UNKNOWN_ERROR,
+                    message = "",
+                    statusCode = 500,
+                ),
+            )
+        impl.maybeForceClearSession<Any>(recoverableError)
+        verify(exactly = 0) { mockSessionStorage.revoke() }
+        impl.maybeForceClearSession<Any>(unrecoverableError)
+        verify(exactly = 1) { mockSessionStorage.revoke() }
+        impl.maybeForceClearSession<Any>(recoverableError, true)
+        verify(exactly = 2) { mockSessionStorage.revoke() }
     }
 }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -37,7 +37,6 @@ internal class StytchApiServiceTests {
                 mockWebServer.url("/").toString(),
                 null,
                 null,
-                {},
                 StytchApiService::class.java,
             )
     }


### PR DESCRIPTION
Linear Ticket: [SDK-2583](https://linear.app/stytch/issue/SDK-2583)

## Changes:

1. Stop revoking sessions on all 401 errors. Instead, follow the JS model of only revoking if a revoke call succeeds OR a revoke call fails and `forceClear == true` OR an authenticate call fails with an unrecoverable error type
2. Add tests for new behavior

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A