### PR TITLE
SDK-2592 support verify email template

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -538,6 +538,7 @@ internal object StytchB2BApi {
             resetPasswordTemplateId: String?,
             codeChallenge: String,
             locale: Locale?,
+            verifyEmailTemplateId: String?,
         ): StytchResult<BasicData> =
             safeB2BApiCall {
                 apiService.resetPasswordByEmailStart(
@@ -550,6 +551,7 @@ internal object StytchB2BApi {
                         resetPasswordTemplateId = resetPasswordTemplateId,
                         codeChallenge = codeChallenge,
                         locale = locale,
+                        verifyEmailTemplateId = verifyEmailTemplateId,
                     ),
                 )
             }
@@ -633,6 +635,7 @@ internal object StytchB2BApi {
                 resetPasswordTemplateId: String?,
                 codeChallenge: String,
                 locale: Locale?,
+                verifyEmailTemplateId: String?,
             ): StytchResult<BasicData> =
                 safeB2BApiCall {
                     apiService.passwordDiscoveryResetByEmailStart(
@@ -644,6 +647,7 @@ internal object StytchB2BApi {
                             resetPasswordTemplateId = resetPasswordTemplateId,
                             codeChallenge = codeChallenge,
                             locale = locale,
+                            verifyEmailTemplateId = verifyEmailTemplateId,
                         ),
                     )
                 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -120,6 +120,8 @@ internal object B2BRequests {
             @Json(name = "code_challenge")
             val codeChallenge: String,
             val locale: Locale? = null,
+            @Json(name = "verify_email_template_id")
+            val verifyEmailTemplateId: String?,
         )
 
         @Keep
@@ -187,6 +189,8 @@ internal object B2BRequests {
                 @Json(name = "pkce_code_challenge")
                 val codeChallenge: String,
                 val locale: Locale? = null,
+                @Json(name = "verify_email_template_id")
+                val verifyEmailTemplateId: String?,
             )
 
             @Keep

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/Passwords.kt
@@ -115,6 +115,9 @@ public interface Passwords {
      * @property resetPasswordTemplateId Use a custom template for password reset emails. By default, it will use your
      * default email template. The template must be a template using our built-in customizations or a custom HTML email
      * for Password Reset.
+     * @property verifyEmailTemplateId Use a custom template for password verify emails. By default, it will use your
+     * default email template. The template must be a template using our built-in customizations or a custom HTML email
+     * for Password Verification.
      */
     @JacocoExcludeGenerated
     public data class ResetByEmailStartParameters
@@ -126,6 +129,7 @@ public interface Passwords {
             val resetPasswordRedirectUrl: String? = null,
             val resetPasswordExpirationMinutes: Int? = null,
             val resetPasswordTemplateId: String? = null,
+            val verifyEmailTemplateId: String? = null,
             val locale: Locale? = null,
         )
 
@@ -381,6 +385,9 @@ public interface Passwords {
          * @property resetPasswordTemplateId - The email template ID to use for password reset. If not provided, your
          * default email template will be sent. If providing a template ID, it must be either a template using
          * Stytch's customizations, or a Passwords reset custom HTML template.
+         * @property verifyEmailTemplateId Use a custom template for password verify emails. By default, it will use
+         * your default email template. The template must be a template using our built-in customizations or a custom
+         * HTML email for Password Verification.
          */
         @JacocoExcludeGenerated
         public data class ResetByEmailStartParameters(
@@ -389,6 +396,7 @@ public interface Passwords {
             val resetPasswordRedirectUrl: String? = null,
             val resetPasswordExpirationMinutes: Int? = null,
             val resetPasswordTemplateId: String? = null,
+            val verifyEmailTemplateId: String? = null,
             val locale: Locale? = null,
         )
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/passwords/PasswordsImpl.kt
@@ -88,6 +88,7 @@ internal class PasswordsImpl internal constructor(
                     resetPasswordTemplateId = parameters.resetPasswordTemplateId,
                     codeChallenge = challengeCode,
                     locale = parameters.locale,
+                    verifyEmailTemplateId = parameters.verifyEmailTemplateId,
                 )
         }
         return result
@@ -257,6 +258,7 @@ internal class PasswordsImpl internal constructor(
                     resetPasswordTemplateId = parameters.resetPasswordTemplateId,
                     codeChallenge = challengeCode,
                     locale = parameters.locale,
+                    verifyEmailTemplateId = parameters.verifyEmailTemplateId,
                 )
             }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
@@ -12,4 +12,5 @@ import kotlinx.parcelize.Parcelize
 @JacocoExcludeGenerated
 public data class B2BPasswordOptions(
     val resetPasswordTemplateId: String? = null,
+    val verifyEmailTemplateId: String? = null,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordDiscoveryResetByEmailStart.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordDiscoveryResetByEmailStart.kt
@@ -30,6 +30,7 @@ internal class UsePasswordDiscoveryResetByEmailStart(
                         discoveryRedirectUrl = getRedirectUrl(),
                         resetPasswordRedirectUrl = getRedirectUrl(),
                         resetPasswordTemplateId = productConfig.passwordOptions.resetPasswordTemplateId,
+                        verifyEmailTemplateId = productConfig.passwordOptions.verifyEmailTemplateId,
                         locale = productConfig.locale,
                     ),
                 )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmailStart.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmailStart.kt
@@ -31,6 +31,7 @@ internal class UsePasswordResetByEmailStart(
                         loginRedirectUrl = getRedirectUrl(),
                         resetPasswordRedirectUrl = getRedirectUrl(),
                         resetPasswordTemplateId = productConfig.passwordOptions.resetPasswordTemplateId,
+                        verifyEmailTemplateId = productConfig.passwordOptions.verifyEmailTemplateId,
                         locale = productConfig.locale,
                     ),
                 )

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -581,6 +581,7 @@ internal class StytchB2BApiServiceTest {
                     resetPasswordTemplateId = "reset-password-template-id",
                     resetPasswordRedirectUrl = "reset://redirect",
                     locale = Locale.EN,
+                    verifyEmailTemplateId = "verify-email-template-id",
                 )
             requestIgnoringResponseException {
                 apiService.resetPasswordByEmailStart(parameters)
@@ -596,6 +597,7 @@ internal class StytchB2BApiServiceTest {
                         "reset_password_template_id" to parameters.resetPasswordTemplateId,
                         "reset_password_redirect_url" to parameters.resetPasswordRedirectUrl,
                         "locale" to parameters.locale?.jsonName,
+                        "verify_email_template_id" to parameters.verifyEmailTemplateId,
                     ),
             )
         }
@@ -709,6 +711,7 @@ internal class StytchB2BApiServiceTest {
                     resetPasswordTemplateId = "reset-password-template-id",
                     codeChallenge = "code-challenge",
                     locale = Locale.EN,
+                    verifyEmailTemplateId = "verify-email-template-id",
                 )
             requestIgnoringResponseException {
                 apiService.passwordDiscoveryResetByEmailStart(parameters)
@@ -723,6 +726,7 @@ internal class StytchB2BApiServiceTest {
                         "reset_password_template_id" to parameters.resetPasswordTemplateId,
                         "pkce_code_challenge" to parameters.codeChallenge,
                         "locale" to parameters.locale?.jsonName,
+                        "verify_email_template_id" to parameters.verifyEmailTemplateId,
                     ),
             )
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -383,6 +383,7 @@ internal class StytchB2BApiTest {
                 resetPasswordExpirationMinutes = null,
                 resetPasswordTemplateId = null,
                 locale = null,
+                verifyEmailTemplateId = null,
             )
             coVerify { StytchB2BApi.apiService.resetPasswordByEmailStart(any()) }
         }
@@ -433,7 +434,7 @@ internal class StytchB2BApiTest {
         runBlocking {
             every { StytchB2BApi.isInitialized } returns true
             coEvery { StytchB2BApi.apiService.passwordDiscoveryResetByEmailStart(any()) } returns mockk(relaxed = true)
-            StytchB2BApi.Passwords.Discovery.resetByEmailStart("", null, null, null, null, "", null)
+            StytchB2BApi.Passwords.Discovery.resetByEmailStart("", null, null, null, null, "", null, null)
             coVerify { StytchB2BApi.apiService.passwordDiscoveryResetByEmailStart(any()) }
         }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -127,7 +127,7 @@ internal class PasswordsImplTest {
         runBlocking {
             every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
             val mockkResponse = StytchResult.Success<BasicData>(mockk(relaxed = true))
-            coEvery { mockApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            coEvery { mockApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
                 mockkResponse
             val response =
                 impl.resetByEmailStart(
@@ -141,14 +141,14 @@ internal class PasswordsImplTest {
                     ),
                 )
             assert(response is StytchResult.Success)
-            coVerify { mockApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any()) }
+            coVerify { mockApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
     fun `PasswordsImpl resetByEmailStart with callback calls callback method`() {
         every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
         val mockkResponse = StytchResult.Success<BasicData>(mockk(relaxed = true))
-        coEvery { mockApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any()) } returns
+        coEvery { mockApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
             mockkResponse
         val mockCallback = spyk<(BaseResponse) -> Unit>()
         impl.resetByEmailStart(
@@ -261,18 +261,29 @@ internal class PasswordsImplTest {
         runBlocking {
             every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
             val mockkResponse = StytchResult.Success<BasicData>(mockk(relaxed = true))
-            coEvery { mockDiscoveryApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any()) } returns
+            coEvery {
+                mockDiscoveryApi.resetByEmailStart(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns
                 mockkResponse
             val response = impl.discovery.resetByEmailStart(mockk(relaxed = true))
             assert(response is StytchResult.Success)
-            coVerify { mockDiscoveryApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any()) }
+            coVerify { mockDiscoveryApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
     fun `PasswordsImpl DiscoveryImpl resetByEmailStart with callback calls callback method`() {
         every { mockPKCEPairManager.generateAndReturnPKCECodePair() } returns PKCECodePair("", "")
         val mockkResponse = StytchResult.Success<BasicData>(mockk(relaxed = true))
-        coEvery { mockDiscoveryApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any()) } returns
+        coEvery { mockDiscoveryApi.resetByEmailStart(any(), any(), any(), any(), any(), any(), any(), any()) } returns
             mockkResponse
         val mockCallback = spyk<(BaseResponse) -> Unit>()
         impl.discovery.resetByEmailStart(mockk(relaxed = true), mockCallback)


### PR DESCRIPTION
Linear Ticket: [SDK-2592](https://linear.app/stytch/issue/SDK-2592)

API recently added a new email template ID for password reset requests when triggering the verify email flow. This adds support in the Headless and UI clients

## Changes:

1. Add new parameter to headless client
2. Add it to UI config and pass as appropriate

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A