### PR TITLE
SDK-2588 - Fix JIT provisioning bug in B2B UI

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/main/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/main/MainScreenViewModel.kt
@@ -88,7 +88,7 @@ internal class MainScreenViewModel(
                     organizationId = organization.organizationId,
                 ).onSuccess { response ->
                     dispatch(SetLoading(false))
-                    if (!response.member?.memberPasswordId.isNullOrEmpty()) {
+                    if (response.member != null) {
                         usePasswordsAuthenticate()
                     } else {
                         useNonMemberPasswordReset()

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSendCorrectPasswordReset.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSendCorrectPasswordReset.kt
@@ -40,12 +40,13 @@ internal class UseSendCorrectPasswordReset(
                 organizationId = organizationId,
             ).onSuccess {
                 dispatch(SetLoading(false))
-                if (it.member?.memberPasswordId.isNullOrEmpty()) {
-                    // no memberPasswordId == no password, so drop them in the nonMemberReset flow
+                if (it.member != null) {
+                    // member exists, so send them a reset
+                    usePasswordResetByEmailStart()
+                } else {
+                    // no member, so drop them in the nonMemberReset flow
                     return@onSuccess useNonMemberPasswordReset()
                 }
-                // there IS a password for this user, so send them a reset
-                usePasswordResetByEmailStart()
             }.onFailure {
                 dispatch(SetLoading(false))
             }


### PR DESCRIPTION
We were deciding how to handle password reset flows (specifically, whether to use a "non member" flow) based not just on whether a member exists, but also on whether the member has a password. Instead, only consider whether the member exists, regardless of whether they have a password.

Linear Ticket: [SDK-2588](https://linear.app/stytch/issue/SDK-2588)

## Changes:

1. Only check the existence of a member, instead of the existence of a member password

## Notes:

- Same change as JS SDK made: https://github.com/stytchauth/js-sdk-turbo/pull/1635

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A