### PR TITLE
SDK-2597 Expose SSO Discover Connections on the Headless client

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -16,6 +16,7 @@ import com.stytch.sdk.b2b.network.models.B2BSCIMRotateCompleteResponseData
 import com.stytch.sdk.b2b.network.models.B2BSCIMRotateStartResponseData
 import com.stytch.sdk.b2b.network.models.B2BSCIMUpdateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSODeleteConnectionResponseData
+import com.stytch.sdk.b2b.network.models.B2BSSODiscoveryConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOGetConnectionsResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCCreateConnectionResponseData
 import com.stytch.sdk.b2b.network.models.B2BSSOOIDCUpdateConnectionResponseData
@@ -353,3 +354,8 @@ public typealias B2BPasswordDiscoveryResetByEmailResponse = StytchResult<B2BPass
  * Authenticate responses
  */
 public typealias B2BPasswordDiscoveryAuthenticateResponse = StytchResult<B2BPasswordDiscoveryAuthenticateResponseData>
+
+/**
+ * Type alias for StytchResult<B2BSSODiscoveryConnectionResponseData> used for SSO Discover Connections responses
+ */
+public typealias B2BSSODiscoveryConnectionResponse = StytchResult<B2BSSODiscoveryConnectionResponseData>

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -1428,6 +1428,6 @@ public data class B2BPasswordDiscoveryAuthenticateResponseData(
 @Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
-internal data class B2BSSODiscoveryConnectionResponseData(
+public data class B2BSSODiscoveryConnectionResponseData(
     val connections: List<SSOActiveConnection>,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import android.app.Activity
 import androidx.activity.ComponentActivity
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
+import com.stytch.sdk.b2b.B2BSSODiscoveryConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
@@ -190,6 +191,35 @@ public interface SSO {
      * @return [B2BSSODeleteConnectionResponse]
      */
     public fun deleteConnectionCompletable(connectionId: String): CompletableFuture<B2BSSODeleteConnectionResponse>
+
+    /** The SSO Discovery method surfaces SSO connections for the end user. It will return all active SSO connections
+     * for an end user or, if no active connections are found, it will return all SSO connections that the end user
+     * could JIT provision into based on the provided email address.
+     * @param emailAddress Email address to return SSO connection IDs for.
+     * @return [B2BSSODiscoveryConnectionResponse]
+     */
+    public suspend fun discoverConnections(emailAddress: String): B2BSSODiscoveryConnectionResponse
+
+    /** The SSO Discovery method surfaces SSO connections for the end user. It will return all active SSO connections
+     * for an end user or, if no active connections are found, it will return all SSO connections that the end user
+     * could JIT provision into based on the provided email address.
+     * @param emailAddress Email address to return SSO connection IDs for.
+     * @param callback A callback that receives a [B2BSSODiscoveryConnectionResponse]
+     */
+    public fun discoverConnections(
+        emailAddress: String,
+        callback: (B2BSSODiscoveryConnectionResponse) -> Unit,
+    )
+
+    /** The SSO Discovery method surfaces SSO connections for the end user. It will return all active SSO connections
+     * for an end user or, if no active connections are found, it will return all SSO connections that the end user
+     * could JIT provision into based on the provided email address.
+     * @param emailAddress Email address to return SSO connection IDs for.
+     * @return [B2BSSODiscoveryConnectionResponse]
+     */
+    public suspend fun discoverConnectionsCompletable(
+        emailAddress: String,
+    ): CompletableFuture<B2BSSODiscoveryConnectionResponse>
 
     /**
      * Exposes an instance of the [SAML] interface

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.b2b.sso
 import androidx.activity.ComponentActivity
 import com.stytch.sdk.b2b.B2BAuthMethod
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
+import com.stytch.sdk.b2b.B2BSSODiscoveryConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
@@ -180,6 +181,25 @@ internal class SSOImpl(
             .async {
                 deleteConnection(connectionId)
             }.asCompletableFuture()
+
+    override suspend fun discoverConnections(emailAddress: String): B2BSSODiscoveryConnectionResponse =
+        withContext(dispatchers.io) {
+            api.discoveryConnections(emailAddress = emailAddress)
+        }
+
+    override fun discoverConnections(
+        emailAddress: String,
+        callback: (B2BSSODiscoveryConnectionResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            callback(discoverConnections(emailAddress))
+        }
+    }
+
+    override suspend fun discoverConnectionsCompletable(
+        emailAddress: String,
+    ): CompletableFuture<B2BSSODiscoveryConnectionResponse> =
+        externalScope.async { discoverConnections(emailAddress) }.asCompletableFuture()
 
     override val saml: SSO.SAML = SAMLImpl()
 

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSSODiscoveryConnections.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSSODiscoveryConnections.kt
@@ -1,7 +1,7 @@
 package com.stytch.sdk.ui.b2b.usecases
 
 import androidx.core.text.htmlEncode
-import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.B2BSSODiscoveryConnectionResponseData
 import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
@@ -22,7 +22,7 @@ internal class UseSSODiscoveryConnections(
     operator fun invoke() {
         scope.launch(Dispatchers.IO) {
             request {
-                StytchB2BApi.SSO.discoveryConnections(
+                StytchB2BClient.sso.discoverConnections(
                     emailAddress =
                         state.value.emailState.emailAddress
                             .htmlEncode(),

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.sso
 
 import com.stytch.sdk.b2b.B2BSSODeleteConnectionResponse
+import com.stytch.sdk.b2b.B2BSSODiscoveryConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOGetConnectionsResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCCreateConnectionResponse
 import com.stytch.sdk.b2b.B2BSSOOIDCUpdateConnectionResponse
@@ -125,6 +126,22 @@ internal class SSOImplTest {
         coEvery { mockApi.getConnections() } returns mockk(relaxed = true)
         val mockCallback = spyk<(B2BSSOGetConnectionsResponse) -> Unit>()
         impl.getConnections(mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `SSO discoverConnections delegates to api`() =
+        runBlocking {
+            coEvery { mockApi.discoveryConnections(any()) } returns mockk(relaxed = true)
+            impl.discoverConnections("test@stytch.com")
+            coVerify { mockApi.discoveryConnections(eq("test@stytch.com")) }
+        }
+
+    @Test
+    fun `SSO discoverConnections with callback calls callback method`() {
+        coEvery { mockApi.discoveryConnections(any()) } returns mockk(relaxed = true)
+        val mockCallback = spyk<(B2BSSODiscoveryConnectionResponse) -> Unit>()
+        impl.discoverConnections("test@stytch.com", mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 


### PR DESCRIPTION
Linear Ticket: [SDK-2597](https://linear.app/stytch/issue/SDK-2597)

## Changes:

1. Expose SSO Discover Connections on the Headless client
2. Update the UI client to use that, instead of the internal endpoint

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A