### PR TITLE
Assorted performance/maintenance improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
     // Optionally configure plugin
     ktlint {

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -132,12 +132,12 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.moshi)
     ksp(libs.moshi.kotlin.codegen)
-    implementation(libs.kotlinx.coroutines.android)
+    runtimeOnly(libs.kotlinx.coroutines.android)
     implementation(libs.tink.android)
     implementation(libs.bcprov.jdk18on)
     implementation(libs.recaptcha)
     implementation(libs.credentials)
-    implementation(libs.credentials.play.services.auth)
+    runtimeOnly(libs.credentials.play.services.auth)
     implementation(libs.googleid)
     implementation(libs.play.services.auth.api.phone)
     implementation(libs.lifecycle.common)
@@ -170,13 +170,13 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json)
-    androidTestImplementation(libs.runner)
-    androidTestImplementation(libs.rules)
+    androidTestRuntimeOnly(libs.runner)
+    // androidTestImplementation(libs.rules)
     androidTestImplementation(libs.core.testing)
     // Test rules and transitive dependencies:
     androidTestImplementation(libs.ui.test.junit4)
     // Needed for createAndroidComposeRule, but not createComposeRule:
-    debugImplementation(libs.ui.test.manifest)
+    debugRuntimeOnly(libs.ui.test.manifest)
 
     testImplementation(libs.mockwebserver)
 }

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.42.0"
+extra["PUBLISH_VERSION"] = "0.43.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/proguard-rules.pro
+++ b/source/sdk/proguard-rules.pro
@@ -12,13 +12,34 @@
 #   public *;
 #}
 
--keep public class com.stytch.sdk.** {
-    public protected *;
+-keep public interface com.stytch.sdk.** {
+    public *;
 }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
--keepattributes SourceFile,LineNumberTable
+-keep public class com.stytch.sdk.**$* {
+    *;
+}
+
+-keep public class com.stytch.sdk.b2b.* {
+    public *;
+}
+
+-keep public class com.stytch.sdk.common.* {
+    public *;
+}
+
+-keep public class com.stytch.sdk.consumer.* {
+    public *;
+}
+
+-keep public class com.stytch.sdk.ui.* {
+    public *;
+}
+
+-keep public class com.stytch.sdk.**.models.* {
+    public *;
+}
+
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.

--- a/source/sdk/proguard-rules.pro
+++ b/source/sdk/proguard-rules.pro
@@ -11,34 +11,43 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
--keep public interface com.stytch.sdk.** {
+-keep,allowoptimization public interface com.stytch.sdk.**, com.stytch.sdk.**.*$* {
     public *;
 }
 
--keep public class com.stytch.sdk.**$* {
-    *;
-}
 
--keep public class com.stytch.sdk.b2b.* {
+-keep,allowoptimization public enum com.stytch.sdk.** {
     public *;
 }
 
--keep public class com.stytch.sdk.common.* {
+-keep,allowoptimization public class
+    com.stytch.sdk.**.*Response*,
+    com.stytch.sdk.b2b.*,
+    com.stytch.sdk.common.*,
+    com.stytch.sdk.consumer.*,
+    com.stytch.sdk.ui.b2b.*,
+    com.stytch.sdk.ui.b2c.* {
     public *;
 }
 
--keep public class com.stytch.sdk.consumer.* {
+-keep,allowoptimization @com.stytch.sdk.common.annotations.JacocoExcludeGenerated public class com.stytch.sdk.** {
     public *;
 }
 
--keep public class com.stytch.sdk.ui.* {
+-keep,allowoptimization public class com.stytch.sdk.**.*$Companion* {
     public *;
 }
 
--keep public class com.stytch.sdk.**.models.* {
+-keep,allowoptimization,allowobfuscation,allowshrinking public class
+    !com.stytch.sdk.**.*Impl*,
+    !com.stytch.sdk.**.*Request*,
+    !com.stytch.sdk.**.*JsonAdapter* {
     public *;
 }
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
 
 
 # If you keep the line number information, uncomment this to

--- a/source/sdk/proguard-rules.pro
+++ b/source/sdk/proguard-rules.pro
@@ -11,37 +11,7 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
--keep,allowoptimization public interface com.stytch.sdk.**, com.stytch.sdk.**.*$* {
-    public *;
-}
-
-
--keep,allowoptimization public enum com.stytch.sdk.** {
-    public *;
-}
-
--keep,allowoptimization public class
-    com.stytch.sdk.**.*Response*,
-    com.stytch.sdk.b2b.*,
-    com.stytch.sdk.common.*,
-    com.stytch.sdk.consumer.*,
-    com.stytch.sdk.ui.b2b.*,
-    com.stytch.sdk.ui.b2c.* {
-    public *;
-}
-
--keep,allowoptimization @com.stytch.sdk.common.annotations.JacocoExcludeGenerated public class com.stytch.sdk.** {
-    public *;
-}
-
--keep,allowoptimization public class com.stytch.sdk.**.*$Companion* {
-    public *;
-}
-
--keep,allowoptimization,allowobfuscation,allowshrinking public class
-    !com.stytch.sdk.**.*Impl*,
-    !com.stytch.sdk.**.*Request*,
-    !com.stytch.sdk.**.*JsonAdapter* {
+-keep,allowoptimization public class com.stytch.sdk.** {
     public *;
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/B2BTokenType.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/B2BTokenType.kt
@@ -6,6 +6,7 @@ import java.util.Locale
 /**
  * An enum representing the supported (B2B) token types that we can extract from a deeplink
  */
+
 public enum class B2BTokenType : TokenType {
     /**
      * A B2B Email Magic Link deeplink

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -217,13 +217,14 @@ public object StytchB2BClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
+        StorageHelper.initialize(context)
+        sessionStorage = B2BSessionStorage(StorageHelper)
         configurationManager.configure(
             client = StytchB2BClientCommonConfiguration { callback(true) },
             context = context,
             publicToken = publicToken,
             options = options,
         )
-        sessionStorage = B2BSessionStorage(StorageHelper)
     }
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -69,6 +69,7 @@ import java.util.Date
  * The StytchB2BClient object is your entrypoint to the Stytch B2B SDK and is how you interact with all of our
  * supported authentication products.
  */
+
 public object StytchB2BClient {
     internal val configurationManager = ConfigurationManager()
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -225,12 +225,6 @@ public object StytchB2BClient {
         sessionStorage = B2BSessionStorage(StorageHelper)
     }
 
-    internal fun assertInitialized() {
-        if (!StytchB2BApi.isInitialized) {
-            throw StytchSDKNotConfiguredError("StytchB2BClient")
-        }
-    }
-
     /**
      * Exposes an instance of the [B2BMagicLinks] interface whicih provides methods for sending and authenticating
      * users with Email Magic Links.
@@ -239,7 +233,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val magicLinks: B2BMagicLinks by StytchLazyDelegate(::assertInitialized) {
+    public val magicLinks: B2BMagicLinks by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         B2BMagicLinksImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -258,7 +252,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val sessions: B2BSessions by StytchLazyDelegate(::assertInitialized) {
+    public val sessions: B2BSessions by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         B2BSessionsImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -275,7 +269,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val organization: Organization by StytchLazyDelegate(::assertInitialized) {
+    public val organization: Organization by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         OrganizationImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -292,7 +286,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val member: Member by StytchLazyDelegate(::assertInitialized) {
+    public val member: Member by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         MemberImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -309,7 +303,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val passwords: Passwords by StytchLazyDelegate(::assertInitialized) {
+    public val passwords: Passwords by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         PasswordsImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -328,7 +322,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val discovery: Discovery by StytchLazyDelegate(::assertInitialized) {
+    public val discovery: Discovery by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         DiscoveryImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -341,7 +335,7 @@ public object StytchB2BClient {
      * Exposes an instance of the [SSO] interface which provides methods for authenticating SSO sessions
      */
     @JvmStatic
-    public val sso: SSO by StytchLazyDelegate(::assertInitialized) {
+    public val sso: SSO by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         SSOImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -359,7 +353,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val dfp: DFP by StytchLazyDelegate(::assertInitialized) {
+    public val dfp: DFP by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         DFPImpl(
             configurationManager.dfpProvider,
             configurationManager.dispatchers,
@@ -367,7 +361,7 @@ public object StytchB2BClient {
         )
     }
 
-    internal val events: Events by StytchLazyDelegate(::assertInitialized) {
+    internal val events: Events by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         EventsImpl(
             configurationManager.deviceInfo,
             configurationManager.appSessionId,
@@ -384,7 +378,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val otp: OTP by StytchLazyDelegate(::assertInitialized) {
+    public val otp: OTP by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         OTPImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -400,7 +394,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val totp: TOTP by StytchLazyDelegate(::assertInitialized) {
+    public val totp: TOTP by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         TOTPImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -417,7 +411,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val recoveryCodes: RecoveryCodes by StytchLazyDelegate(::assertInitialized) {
+    public val recoveryCodes: RecoveryCodes by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         RecoveryCodesImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -434,7 +428,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val oauth: OAuth by StytchLazyDelegate(::assertInitialized) {
+    public val oauth: OAuth by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         OAuthImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -450,7 +444,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val rbac: RBAC by StytchLazyDelegate(::assertInitialized) {
+    public val rbac: RBAC by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         RBACImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -464,7 +458,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val searchManager: SearchManager by StytchLazyDelegate(::assertInitialized) {
+    public val searchManager: SearchManager by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         SearchManagerImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -479,7 +473,7 @@ public object StytchB2BClient {
      * StytchB2BClient.configure()
      */
     @JvmStatic
-    public val scim: SCIM by StytchLazyDelegate(::assertInitialized) {
+    public val scim: SCIM by StytchLazyDelegate(StytchB2BApi::assertInitialized) {
         SCIMImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -504,7 +498,7 @@ public object StytchB2BClient {
         uri: Uri,
         sessionDurationMinutes: Int,
     ): DeeplinkHandledStatus {
-        assertInitialized()
+        StytchB2BApi.assertInitialized()
         val (tokenType, token, redirectType) = parseDeeplink(uri)
         if (token.isNullOrEmpty()) {
             return DeeplinkHandledStatus.NotHandled(StytchDeeplinkMissingTokenError())
@@ -700,5 +694,7 @@ public object StytchB2BClient {
                 )
             }
         }
+
+        override fun getSessionToken(): String? = sessionStorage.sessionToken
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -217,14 +217,32 @@ public object StytchB2BClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
-        StorageHelper.initialize(context)
-        sessionStorage = B2BSessionStorage(StorageHelper)
+        // We must initialize the storagehelper/sessionstorage before configuration, because configuration kicks
+        // off a task that relies on the storage being available (session hydration). HOWEVER, we don't want to handle
+        // any exception in storage initialization immediately, because we want to log the error to the Events API,
+        // which requires the API to be configured (which happens in the configure call). So, catch and hold any error
+        // until _after_ configuration completes, at which point it is safe to log it.
+        val storageInitializationError =
+            try {
+                StorageHelper.initialize(context)
+                sessionStorage = B2BSessionStorage(StorageHelper)
+                null
+            } catch (ex: Exception) {
+                StytchInternalError(
+                    message = "Failed to initialize the SDK",
+                    exception = ex,
+                )
+            }
         configurationManager.configure(
             client = StytchB2BClientCommonConfiguration { callback(true) },
             context = context,
             publicToken = publicToken,
             options = options,
         )
+        storageInitializationError?.let {
+            events.logEvent("client_initialization_failure", null, it)
+            throw it
+        }
     }
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture
  *
  * Call the `StytchB2BClient.discovery.create()` method to create a new organization.
  */
+
 public interface Discovery {
     /**
      * Discover a member's available organizations

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture
  *
  * Call the `StytchB2BClient.magicLinks.discovery.authenticate()` method to authenticate a Member with a Magic Link.
  */
+
 public interface B2BMagicLinks {
     /**
      * Data class used for wrapping parameters used with MagicLinks authentication
@@ -118,6 +119,7 @@ public interface B2BMagicLinks {
     /**
      * Provides all possible ways to call EmailMagicLinks endpoints
      */
+
     public interface EmailMagicLinks {
         /**
          * Data class used for wrapping parameters used with requesting an email magic link

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberAuthenticationFactor.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberAuthenticationFactor.kt
@@ -6,17 +6,20 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
  * A [MemberAuthenticationFactor] represents a primary authentication factor associated with a Stytch Member
  * @param id The string representing the unique ID of this authentication factor
  */
+
 public sealed class MemberAuthenticationFactor(
     public open val id: String? = null,
 ) {
     /**
      * Represents an MFA Phone Number associated with a Stytch Member
      */
+
     public data object MfaPhoneNumber : MemberAuthenticationFactor()
 
     /**
      * Represents an MFA TOTP associated with a Stytch Member
      */
+
     public data object MfaTOTP : MemberAuthenticationFactor()
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberAuthenticationFactor.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberAuthenticationFactor.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
  * @param id The string representing the unique ID of this authentication factor
  */
 
+@JacocoExcludeGenerated
 public sealed class MemberAuthenticationFactor(
     public open val id: String? = null,
 ) {
@@ -14,13 +15,13 @@ public sealed class MemberAuthenticationFactor(
      * Represents an MFA Phone Number associated with a Stytch Member
      */
 
-    public data object MfaPhoneNumber : MemberAuthenticationFactor()
+    @JacocoExcludeGenerated public data object MfaPhoneNumber : MemberAuthenticationFactor()
 
     /**
      * Represents an MFA TOTP associated with a Stytch Member
      */
 
-    public data object MfaTOTP : MemberAuthenticationFactor()
+    @JacocoExcludeGenerated public data object MfaTOTP : MemberAuthenticationFactor()
 
     /**
      * Represents a Password associated with a Stytch Member

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -80,6 +80,7 @@ import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.events.EventsAPI
 import com.stytch.sdk.common.network.ApiService
+import com.stytch.sdk.common.network.CommonApi
 import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchAuthHeaderInterceptor
 import com.stytch.sdk.common.network.StytchDFPInterceptor
@@ -92,7 +93,7 @@ import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.safeApiCall
 
-internal object StytchB2BApi {
+internal object StytchB2BApi : CommonApi {
     internal lateinit var publicToken: String
     private lateinit var deviceInfo: DeviceInfo
 
@@ -110,7 +111,7 @@ internal object StytchB2BApi {
         ) { StytchB2BClient.sessionStorage.sessionToken }
     }
 
-    internal fun configure(
+    override fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
     ) {
@@ -118,7 +119,7 @@ internal object StytchB2BApi {
         this.deviceInfo = deviceInfo
     }
 
-    internal fun configureDFP(
+    override fun configureDFP(
         dfpProvider: DFPProvider,
         captchaProvider: CaptchaProvider,
         dfpProtectedAuthEnabled: Boolean,
@@ -945,7 +946,7 @@ internal object StytchB2BApi {
             }
     }
 
-    suspend fun getBootstrapData(): StytchResult<BootstrapData> =
+    override suspend fun getBootstrapData(): StytchResult<BootstrapData> =
         safeB2BApiCall {
             apiService.getBootstrapData(publicToken = publicToken)
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -9,7 +9,6 @@ import com.stytch.sdk.b2b.SCIMRotateCancelResponse
 import com.stytch.sdk.b2b.SCIMRotateCompleteResponse
 import com.stytch.sdk.b2b.SCIMRotateStartResponse
 import com.stytch.sdk.b2b.SCIMUpdateConnectionResponse
-import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
 import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BDiscoveryOTPEmailAuthenticateResponseData
@@ -96,27 +95,25 @@ import com.stytch.sdk.common.network.safeApiCall
 internal object StytchB2BApi : CommonApi {
     internal lateinit var publicToken: String
     private lateinit var deviceInfo: DeviceInfo
+    private lateinit var getSessionToken: () -> String?
 
     // save reference for changing auth header
     // make sure api is configured before accessing this variable
     @Suppress("MaxLineLength")
     @VisibleForTesting
     internal val authHeaderInterceptor: StytchAuthHeaderInterceptor by lazy {
-        if (!isInitialized) {
-            throw StytchSDKNotConfiguredError("StytchB2BClient")
-        }
-        StytchAuthHeaderInterceptor(
-            deviceInfo,
-            publicToken,
-        ) { StytchB2BClient.sessionStorage.sessionToken }
+        assertInitialized()
+        StytchAuthHeaderInterceptor(deviceInfo, publicToken, getSessionToken)
     }
 
     override fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
+        getSessionToken: () -> String?,
     ) {
         this.publicToken = publicToken
         this.deviceInfo = deviceInfo
+        this.getSessionToken = getSessionToken
     }
 
     override fun configureDFP(
@@ -125,7 +122,7 @@ internal object StytchB2BApi : CommonApi {
         dfpProtectedAuthEnabled: Boolean,
         dfpProtectedAuthMode: DFPProtectedAuthMode,
     ) {
-        StytchB2BClient.assertInitialized()
+        assertInitialized()
         val sdkUrl =
             if (isTestToken) {
                 TEST_SDK_URL
@@ -148,9 +145,15 @@ internal object StytchB2BApi : CommonApi {
 
     internal val isTestToken: Boolean
         get() {
-            StytchB2BClient.assertInitialized()
+            assertInitialized()
             return publicToken.contains("public-token-test")
         }
+
+    internal fun assertInitialized() {
+        if (!isInitialized) {
+            throw StytchSDKNotConfiguredError("StytchB2BClient")
+        }
+    }
 
     private val regularStytchApiService: StytchB2BApiService by lazy {
         val sdkUrl =
@@ -172,7 +175,7 @@ internal object StytchB2BApi : CommonApi {
     @VisibleForTesting
     internal val apiService: StytchB2BApiService
         get() {
-            StytchB2BClient.assertInitialized()
+            assertInitialized()
             return if (::dfpProtectedStytchApiService.isInitialized) {
                 dfpProtectedStytchApiService
             } else {
@@ -181,7 +184,7 @@ internal object StytchB2BApi : CommonApi {
         }
 
     internal suspend fun <T1, T : StytchDataResponse<T1>> safeB2BApiCall(apiCall: suspend () -> T): StytchResult<T1> =
-        safeApiCall({ StytchB2BClient.assertInitialized() }) {
+        safeApiCall({ assertInitialized() }) {
             apiCall()
         }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -15,7 +15,7 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
-internal interface StytchB2BApiService : ApiService {
+internal interface StytchB2BApiService : ApiService.ApiEndpoints {
     //region Magic Links
     @POST("b2b/magic_links/email/login_or_signup")
     suspend fun loginOrSignupByEmail(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.b2b.network.models
 
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.models.Locale
@@ -8,7 +7,6 @@ import com.stytch.sdk.common.network.models.Locale
 internal object B2BRequests {
     object MagicLinks {
         object Email {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class LoginOrSignupRequest(
                 @Json(name = "email_address")
@@ -30,7 +28,6 @@ internal object B2BRequests {
         }
 
         object Discovery {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class SendRequest(
                 @Json(name = "email_address")
@@ -44,7 +41,6 @@ internal object B2BRequests {
                 val locale: Locale? = null,
             )
 
-            @Keep
             @JsonClass(generateAdapter = true)
             data class AuthenticateRequest(
                 @Json(name = "discovery_magic_links_token")
@@ -55,7 +51,6 @@ internal object B2BRequests {
         }
 
         object Invite {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class InviteRequest(
                 @Json(name = "email_address")
@@ -72,7 +67,6 @@ internal object B2BRequests {
             )
         }
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "magic_links_token")
@@ -87,7 +81,6 @@ internal object B2BRequests {
     }
 
     object Passwords {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "organization_id")
@@ -102,7 +95,6 @@ internal object B2BRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetByEmailStartRequest(
             @Json(name = "organization_id")
@@ -124,7 +116,6 @@ internal object B2BRequests {
             val verifyEmailTemplateId: String?,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetByEmailRequest(
             @Json(name = "password_reset_token")
@@ -139,7 +130,6 @@ internal object B2BRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetByExistingPasswordRequest(
             @Json(name = "organization_id")
@@ -155,7 +145,6 @@ internal object B2BRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetBySessionRequest(
             @Json(name = "organization_id")
@@ -164,7 +153,6 @@ internal object B2BRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class StrengthCheckRequest(
             @Json(name = "email_address")
@@ -173,7 +161,6 @@ internal object B2BRequests {
         )
 
         object Discovery {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class ResetByEmailStartRequest(
                 @Json(name = "email_address")
@@ -193,7 +180,6 @@ internal object B2BRequests {
                 val verifyEmailTemplateId: String?,
             )
 
-            @Keep
             @JsonClass(generateAdapter = true)
             data class ResetByEmailRequest(
                 @Json(name = "password_reset_token")
@@ -206,7 +192,6 @@ internal object B2BRequests {
                 val locale: Locale? = null,
             )
 
-            @Keep
             @JsonClass(generateAdapter = true)
             data class AuthenticateRequest(
                 @Json(name = "email_address")
@@ -217,14 +202,12 @@ internal object B2BRequests {
     }
 
     object Discovery {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class MembershipsRequest(
             @Json(name = "intermediate_session_token")
             val intermediateSessionToken: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SessionExchangeRequest(
             @Json(name = "intermediate_session_token")
@@ -235,7 +218,6 @@ internal object B2BRequests {
             val sessionDurationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class CreateRequest(
             @Json(name = "intermediate_session_token")
@@ -264,7 +246,6 @@ internal object B2BRequests {
     }
 
     object SSO {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "sso_token")
@@ -278,14 +259,12 @@ internal object B2BRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SAMLCreateRequest(
             @Json(name = "display_name")
             val displayName: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SAMLUpdateRequest(
             @Json(name = "connection_id")
@@ -306,7 +285,6 @@ internal object B2BRequests {
             val samlGroupImplicitRoleAssignment: List<GroupRoleAssignment>? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class B2BSSOSAMLUpdateConnectionByURLRequest(
             @Json(name = "connection_id")
@@ -315,7 +293,6 @@ internal object B2BRequests {
             val metadataUrl: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class B2BSSOSAMLDeleteVerificationCertificateRequest(
             @Json(name = "connection_id")
@@ -324,14 +301,12 @@ internal object B2BRequests {
             val certificateId: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class OIDCCreateRequest(
             @Json(name = "display_name")
             val displayName: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class OIDCUpdateRequest(
             @Json(name = "connection_id")
@@ -355,7 +330,6 @@ internal object B2BRequests {
     }
 
     object Session {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ExchangeRequest(
             @Json(name = "organization_id")
@@ -367,7 +341,6 @@ internal object B2BRequests {
     }
 
     object Member {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class UpdateRequest(
             val name: String? = null,
@@ -383,7 +356,6 @@ internal object B2BRequests {
     }
 
     object Organization {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class UpdateRequest(
             @Json(name = "organization_name")
@@ -419,7 +391,6 @@ internal object B2BRequests {
             val defaultMfaMethod: MfaMethod? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class CreateMemberRequest(
             @Json(name = "email_address")
@@ -440,7 +411,6 @@ internal object B2BRequests {
             val roles: List<String>? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class UpdateMemberRequest(
             @Json(name = "email_address")
@@ -463,7 +433,6 @@ internal object B2BRequests {
             val defaultMfaMethod: MfaMethod? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SearchMembersRequest(
             val cursor: String? = null,
@@ -472,14 +441,12 @@ internal object B2BRequests {
         )
     }
 
-    @Keep
     @JsonClass(generateAdapter = true)
     data class SearchQuery(
         val operator: SearchOperator,
         val operands: List<SearchQueryOperand>,
     )
 
-    @Keep
     @JsonClass(generateAdapter = true)
     data class SearchQueryOperand(
         @Json(name = "filter_name")
@@ -490,7 +457,6 @@ internal object B2BRequests {
 
     object OTP {
         object SMS {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class SendRequest(
                 @Json(name = "organization_id")
@@ -506,7 +472,6 @@ internal object B2BRequests {
                 val enableAutofill: Boolean = false,
             )
 
-            @Keep
             @JsonClass(generateAdapter = true)
             data class AuthenticateRequest(
                 @Json(name = "organization_id")
@@ -524,7 +489,6 @@ internal object B2BRequests {
         }
 
         object Email {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class LoginOrSignupRequest(
                 @Json(name = "organization_id")
@@ -538,7 +502,6 @@ internal object B2BRequests {
                 val locale: Locale? = null,
             )
 
-            @Keep
             @JsonClass(generateAdapter = true)
             data class AuthenticateRequest(
                 val code: String,
@@ -552,7 +515,6 @@ internal object B2BRequests {
             )
 
             object Discovery {
-                @Keep
                 @JsonClass(generateAdapter = true)
                 data class SendRequest(
                     @Json(name = "email_address")
@@ -562,7 +524,6 @@ internal object B2BRequests {
                     val locale: Locale? = null,
                 )
 
-                @Keep
                 @JsonClass(generateAdapter = true)
                 data class AuthenticateRequest(
                     val code: String,
@@ -574,7 +535,6 @@ internal object B2BRequests {
     }
 
     object TOTP {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class CreateRequest(
             @Json(name = "organization_id")
@@ -587,7 +547,6 @@ internal object B2BRequests {
             val intermediateSessionToken: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "organization_id")
@@ -607,7 +566,6 @@ internal object B2BRequests {
     }
 
     object RecoveryCodes {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class RecoverRequest(
             @Json(name = "organization_id")
@@ -624,7 +582,6 @@ internal object B2BRequests {
     }
 
     object OAuth {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "oauth_token")
@@ -638,7 +595,6 @@ internal object B2BRequests {
             val intermediateSessionToken: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class DiscoveryAuthenticateRequest(
             @Json(name = "discovery_oauth_token")
@@ -649,14 +605,12 @@ internal object B2BRequests {
     }
 
     object SearchManager {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SearchOrganization(
             @Json(name = "organization_slug")
             val organizationSlug: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SearchMember(
             @Json(name = "email_address")
@@ -667,7 +621,6 @@ internal object B2BRequests {
     }
 
     object SCIM {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class B2BSCIMCreateConnection(
             @Json(name = "display_name")
@@ -676,7 +629,6 @@ internal object B2BRequests {
             val identityProvider: String?,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class B2BSCIMUpdateConnection(
             @Json(name = "connection_id")
@@ -689,14 +641,12 @@ internal object B2BRequests {
             val scimGroupImplicitRoleAssignments: List<SCIMGroupImplicitRoleAssignment>?,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class B2BSCIMGetConnectionGroups(
             val limit: Int?,
             val cursor: String?,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class B2BSCIMRotateConnectionRequest(
             @Json(name = "connection_id")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.b2b.network.models
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.models.CommonAuthenticationData
@@ -12,7 +11,6 @@ import com.stytch.sdk.common.network.models.StrengthPolicy
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
-@Keep
 public interface IB2BAuthData : CommonAuthenticationData {
     public val memberSession: B2BSessionData
     public override val sessionJwt: String
@@ -21,7 +19,6 @@ public interface IB2BAuthData : CommonAuthenticationData {
     public val organization: OrganizationData
 }
 
-@Keep
 public interface IB2BAuthDataWithMFA : CommonAuthenticationData {
     public val memberId: String
     public override val sessionToken: String
@@ -35,7 +32,6 @@ public interface IB2BAuthDataWithMFA : CommonAuthenticationData {
     public val primaryRequired: PrimaryRequired?
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class PrimaryRequired(
@@ -43,7 +39,6 @@ public data class PrimaryRequired(
     val allowedAuthMethods: List<AllowedAuthMethods>?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MFARequired(
@@ -53,7 +48,6 @@ public data class MFARequired(
     val secondaryAuthInitiated: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MemberOptions(
@@ -61,7 +55,6 @@ public data class MemberOptions(
     val mfaPhoneNumber: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SessionsAuthenticateResponseData(
@@ -80,7 +73,6 @@ public data class SessionsAuthenticateResponseData(
 ) : IB2BAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SMSAuthenticateResponseData(
@@ -99,7 +91,6 @@ public data class SMSAuthenticateResponseData(
 ) : IB2BAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BEMLAuthenticateData(
@@ -130,7 +121,6 @@ public data class B2BEMLAuthenticateData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSessionData(
@@ -153,7 +143,6 @@ public data class B2BSessionData(
     val roles: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MemberResponseData(
@@ -164,7 +153,6 @@ public data class MemberResponseData(
     val member: MemberData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MemberData(
@@ -203,7 +191,6 @@ public data class MemberData(
     // val roles: List<MemberRole>?, TODO: Add this
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RetiredEmailAddress(
@@ -213,7 +200,6 @@ public data class RetiredEmailAddress(
     val emailAddress: String?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SSORegistration(
@@ -227,7 +213,6 @@ public data class SSORegistration(
     val ssoAttributes: @RawValue Map<String, Any?>?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OrganizationResponseData(
@@ -238,7 +223,6 @@ public data class OrganizationResponseData(
     val organization: OrganizationData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OrganizationData(
@@ -284,7 +268,6 @@ public data class OrganizationData(
     val rbacEmailImplicitRoleAssignment: List<RBACEmailImplicitRoleAssignment>?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SSOActiveConnection(
@@ -296,7 +279,6 @@ public data class SSOActiveConnection(
     val identityProvider: String?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class PasswordsAuthenticateResponseData(
@@ -325,7 +307,6 @@ public data class PasswordsAuthenticateResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class EmailResetResponseData(
@@ -356,7 +337,6 @@ public data class EmailResetResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class PasswordResetByExistingPasswordResponseData(
@@ -387,7 +367,6 @@ public data class PasswordResetByExistingPasswordResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SessionResetResponseData(
@@ -403,7 +382,6 @@ public data class SessionResetResponseData(
     val organization: OrganizationData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class StrengthCheckResponseData(
@@ -422,7 +400,6 @@ public data class StrengthCheckResponseData(
     val ludsFeedback: LUDSRequirements,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class DiscoveredOrganizationsResponseData(
@@ -432,7 +409,6 @@ public data class DiscoveredOrganizationsResponseData(
     val discoveredOrganizations: List<DiscoveredOrganization>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class DiscoveredOrganization(
@@ -446,7 +422,6 @@ public data class DiscoveredOrganization(
     val mfaRequired: MFARequired?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class Membership(
@@ -455,14 +430,12 @@ public data class Membership(
     val member: MemberData?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MembershipDetails(
     val domain: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class IntermediateSessionExchangeResponseData(
@@ -491,7 +464,6 @@ public data class IntermediateSessionExchangeResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OrganizationCreateResponseData(
@@ -520,7 +492,6 @@ public data class OrganizationCreateResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class DiscoveryAuthenticateResponseData(
@@ -532,7 +503,6 @@ public data class DiscoveryAuthenticateResponseData(
     val discoveredOrganizations: List<DiscoveredOrganization>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SSOAuthenticateResponseData(
@@ -561,7 +531,6 @@ public data class SSOAuthenticateResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SessionExchangeResponseData(
@@ -590,7 +559,6 @@ public data class SessionExchangeResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class UpdateMemberResponseData(
@@ -601,7 +569,6 @@ public data class UpdateMemberResponseData(
     val member: MemberData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MemberDeleteAuthenticationFactorData(
@@ -612,7 +579,6 @@ public data class MemberDeleteAuthenticationFactorData(
     val member: MemberData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OrganizationUpdateResponseData(
@@ -623,7 +589,6 @@ public data class OrganizationUpdateResponseData(
     val organization: OrganizationData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OrganizationDeleteResponseData(
@@ -635,7 +600,6 @@ public data class OrganizationDeleteResponseData(
     val organizationId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OrganizationMemberDeleteResponseData(
@@ -647,7 +611,6 @@ public data class OrganizationMemberDeleteResponseData(
     val memberId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MemberResponseCommonData(
@@ -661,7 +624,6 @@ public data class MemberResponseCommonData(
     val organization: OrganizationData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class MemberSearchResponseData(
@@ -671,7 +633,6 @@ public data class MemberSearchResponseData(
     val resultsMetadata: ResultsMetadata,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class ResultsMetadata(
@@ -680,7 +641,6 @@ public data class ResultsMetadata(
     val nextCursor: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OTPAuthenticateResponse(
@@ -703,7 +663,6 @@ public data class OTPAuthenticateResponse(
 ) : IB2BAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPCreateResponseData(
@@ -718,7 +677,6 @@ public data class TOTPCreateResponseData(
     val recoveryCodes: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPAuthenticateResponseData(
@@ -739,7 +697,6 @@ public data class TOTPAuthenticateResponseData(
 ) : IB2BAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RecoveryCodeGetResponseData(
@@ -751,7 +708,6 @@ public data class RecoveryCodeGetResponseData(
     val recoveryCodes: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RecoveryCodeRotateResponseData(
@@ -763,7 +719,6 @@ public data class RecoveryCodeRotateResponseData(
     val recoveryCodes: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RecoveryCodeRecoverResponseData(
@@ -786,7 +741,6 @@ public data class RecoveryCodeRecoverResponseData(
 ) : IB2BAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OAuthAuthenticateResponseData(
@@ -817,7 +771,6 @@ public data class OAuthAuthenticateResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OAuthProviderValues(
@@ -830,7 +783,6 @@ public data class OAuthProviderValues(
     val scopes: List<String> = emptyList(),
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOGetConnectionsResponseData(
@@ -840,7 +792,6 @@ public data class B2BSSOGetConnectionsResponseData(
     val oidcConnections: List<OIDCConnection>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SAMLConnection(
@@ -871,7 +822,6 @@ public data class SAMLConnection(
     val samlGroupImplicitRoleAssignments: List<GroupRoleAssignment>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class X509Certificate(
@@ -887,7 +837,6 @@ public data class X509Certificate(
     val expiresAt: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class ConnectionRoleAssignment(
@@ -895,7 +844,6 @@ public data class ConnectionRoleAssignment(
     val roleId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class GroupRoleAssignment(
@@ -904,7 +852,6 @@ public data class GroupRoleAssignment(
     val group: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OIDCConnection(
@@ -932,7 +879,6 @@ public data class OIDCConnection(
     val jwksUrl: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSODeleteConnectionResponseData(
@@ -940,28 +886,24 @@ public data class B2BSSODeleteConnectionResponseData(
     val connectionId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOSAMLCreateConnectionResponseData(
     val connection: SAMLConnection,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOOIDCCreateConnectionResponseData(
     val connection: OIDCConnection,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOSAMLUpdateConnectionResponseData(
     val connection: SAMLConnection,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOOIDCUpdateConnectionResponseData(
@@ -969,14 +911,12 @@ public data class B2BSSOOIDCUpdateConnectionResponseData(
     val warning: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOSAMLUpdateConnectionByURLResponseData(
     val connection: SAMLConnection,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSOSAMLDeleteVerificationCertificateResponseData(
@@ -984,14 +924,12 @@ public data class B2BSSOSAMLDeleteVerificationCertificateResponseData(
     val certificateId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSearchOrganizationResponseData(
     val organization: InternalOrganizationData? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class InternalOrganizationData(
@@ -1019,14 +957,12 @@ public data class InternalOrganizationData(
     val allowedAuthMethods: List<AllowedAuthMethods>?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSearchMemberResponseData(
     val member: InternalMemberData? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class InternalMemberData(
@@ -1036,7 +972,6 @@ public data class InternalMemberData(
     val memberPasswordId: String,
 ) : Parcelable
 
-@Keep
 public interface BaseSCIMConnection {
     @Json(name = "organization_id")
     public val organizationId: String
@@ -1058,7 +993,6 @@ public interface BaseSCIMConnection {
     public val scimGroupImplicitRoleAssignments: List<SCIMGroupImplicitRoleAssignment>
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SCIMGroupImplicitRoleAssignment(
@@ -1068,7 +1002,6 @@ public data class SCIMGroupImplicitRoleAssignment(
     val groupId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RBACEmailImplicitRoleAssignment(
@@ -1077,7 +1010,6 @@ public data class RBACEmailImplicitRoleAssignment(
     val domain: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SCIMConnection(
@@ -1105,7 +1037,6 @@ public data class SCIMConnection(
 ) : BaseSCIMConnection,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SCIMConnectionWithBearerToken(
@@ -1129,7 +1060,6 @@ public data class SCIMConnectionWithBearerToken(
 ) : BaseSCIMConnection,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SCIMConnectionWithNextBearerToken(
@@ -1157,7 +1087,6 @@ public data class SCIMConnectionWithNextBearerToken(
 ) : BaseSCIMConnection,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SCIMGroup(
@@ -1171,7 +1100,6 @@ public data class SCIMGroup(
     val groupName: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMCreateConnectionResponseData(
@@ -1183,7 +1111,6 @@ public data class B2BSCIMCreateConnectionResponseData(
 ) : Parcelable,
     IBasicData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMUpdateConnectionResponseData(
@@ -1195,7 +1122,6 @@ public data class B2BSCIMUpdateConnectionResponseData(
 ) : Parcelable,
     IBasicData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMDeleteConnectionResponseData(
@@ -1208,7 +1134,6 @@ public data class B2BSCIMDeleteConnectionResponseData(
 ) : Parcelable,
     IBasicData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMGetConnectionResponseData(
@@ -1220,7 +1145,6 @@ public data class B2BSCIMGetConnectionResponseData(
 ) : IBasicData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMGetConnectionGroupsResponseData(
@@ -1230,7 +1154,6 @@ public data class B2BSCIMGetConnectionGroupsResponseData(
     val nextCursor: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMRotateStartResponseData(
@@ -1242,7 +1165,6 @@ public data class B2BSCIMRotateStartResponseData(
 ) : IBasicData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMRotateCompleteResponseData(
@@ -1254,7 +1176,6 @@ public data class B2BSCIMRotateCompleteResponseData(
 ) : IBasicData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSCIMRotateCancelResponseData(
@@ -1266,7 +1187,6 @@ public data class B2BSCIMRotateCancelResponseData(
 ) : IBasicData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BAuthenticationFactor(
@@ -1290,7 +1210,6 @@ public data class B2BAuthenticationFactor(
     @Json(name = "slack_oauth_factor")
     val slackOAuthFactor: OAuthFactor?,
 ) : Parcelable {
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class EmailFactor(
@@ -1300,7 +1219,6 @@ public data class B2BAuthenticationFactor(
         val emailAddress: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class PhoneFactor(
@@ -1310,7 +1228,6 @@ public data class B2BAuthenticationFactor(
         val phoneNumber: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class OAuthFactor(
@@ -1324,7 +1241,6 @@ public data class B2BAuthenticationFactor(
     ) : Parcelable
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BOTPsEmailLoginOrSignupResponseData(
@@ -1335,7 +1251,6 @@ public data class B2BOTPsEmailLoginOrSignupResponseData(
 ) : Parcelable,
     IBasicData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BOTPsEmailAuthenticateResponseData(
@@ -1366,7 +1281,6 @@ public data class B2BOTPsEmailAuthenticateResponseData(
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BDiscoveryOTPEmailSendResponseData(
@@ -1377,7 +1291,6 @@ public data class B2BDiscoveryOTPEmailSendResponseData(
 ) : Parcelable,
     IBasicData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BDiscoveryOTPEmailAuthenticateResponseData(
@@ -1393,7 +1306,6 @@ public data class B2BDiscoveryOTPEmailAuthenticateResponseData(
     val intermediateSessionToken: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BPasswordDiscoveryResetByEmailResponseData(
@@ -1409,7 +1321,6 @@ public data class B2BPasswordDiscoveryResetByEmailResponseData(
     val intermediateSessionToken: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BPasswordDiscoveryAuthenticateResponseData(
@@ -1425,7 +1336,6 @@ public data class B2BPasswordDiscoveryAuthenticateResponseData(
     val intermediateSessionToken: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class B2BSSODiscoveryConnectionResponseData(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.b2b.network.models
 
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.StytchDataResponse
 import com.stytch.sdk.common.network.models.BasicData
@@ -8,19 +7,16 @@ import com.stytch.sdk.common.network.models.OTPSendResponseData
 
 internal object B2BResponses {
     object MagicLinks {
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(
             data: B2BEMLAuthenticateData,
         ) : StytchDataResponse<B2BEMLAuthenticateData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class DiscoveryAuthenticateResponse(
             data: DiscoveryAuthenticateResponseData,
         ) : StytchDataResponse<DiscoveryAuthenticateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class InviteResponse(
             data: MemberResponseData,
@@ -28,13 +24,11 @@ internal object B2BResponses {
     }
 
     object Sessions {
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(
             data: SessionsAuthenticateResponseData,
         ) : StytchDataResponse<SessionsAuthenticateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class ExchangeResponse(
             data: SessionExchangeResponseData,
@@ -42,55 +36,46 @@ internal object B2BResponses {
     }
 
     object Organizations {
-        @Keep
         @JsonClass(generateAdapter = true)
         class GetOrganizationResponse(
             data: OrganizationResponseData,
         ) : StytchDataResponse<OrganizationResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class UpdateOrganizationResponse(
             data: OrganizationUpdateResponseData,
         ) : StytchDataResponse<OrganizationUpdateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class DeleteOrganizationResponse(
             data: OrganizationDeleteResponseData,
         ) : StytchDataResponse<OrganizationDeleteResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class DeleteMemberResponse(
             data: OrganizationMemberDeleteResponseData,
         ) : StytchDataResponse<OrganizationMemberDeleteResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class ReactivateMemberResponse(
             data: MemberResponseCommonData,
         ) : StytchDataResponse<MemberResponseCommonData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class DeleteOrganizationMemberAuthenticationFactorResponse(
             data: MemberResponseCommonData,
         ) : StytchDataResponse<MemberResponseCommonData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class GetMemberResponse(
             data: MemberResponseData,
         ) : StytchDataResponse<MemberResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class UpdateMemberResponse(
             data: UpdateMemberResponseData,
         ) : StytchDataResponse<UpdateMemberResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class DeleteMemberAuthenticationFactorResponse(
             data: MemberDeleteAuthenticationFactorData,
@@ -101,13 +86,11 @@ internal object B2BResponses {
             data: MemberResponseCommonData,
         ) : StytchDataResponse<MemberResponseCommonData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class UpdateOrganizationMemberResponse(
             data: MemberResponseCommonData,
         ) : StytchDataResponse<MemberResponseCommonData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class MemberSearchResponse(
             data: MemberSearchResponseData,
@@ -115,56 +98,47 @@ internal object B2BResponses {
     }
 
     object Passwords {
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(
             data: PasswordsAuthenticateResponseData,
         ) : StytchDataResponse<PasswordsAuthenticateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class ResetByEmailStartResponse(
             data: BasicData,
         ) : StytchDataResponse<BasicData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class ResetByEmailResponse(
             data: EmailResetResponseData,
         ) : StytchDataResponse<EmailResetResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class ResetByExistingPasswordResponse(
             data: PasswordResetByExistingPasswordResponseData,
         ) : StytchDataResponse<PasswordResetByExistingPasswordResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class ResetBySessionResponse(
             data: SessionResetResponseData,
         ) : StytchDataResponse<SessionResetResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class StrengthCheckResponse(
             data: StrengthCheckResponseData,
         ) : StytchDataResponse<StrengthCheckResponseData>(data)
 
         object Discovery {
-            @Keep
             @JsonClass(generateAdapter = true)
             class ResetByEmailStartResponse(
                 data: BasicData,
             ) : StytchDataResponse<BasicData>(data)
 
-            @Keep
             @JsonClass(generateAdapter = true)
             class ResetByEmailResponse(
                 data: B2BPasswordDiscoveryResetByEmailResponseData,
             ) : StytchDataResponse<B2BPasswordDiscoveryResetByEmailResponseData>(data)
 
-            @Keep
             @JsonClass(generateAdapter = true)
             class AuthenticateResponse(
                 data: B2BPasswordDiscoveryAuthenticateResponseData,
@@ -173,19 +147,16 @@ internal object B2BResponses {
     }
 
     object Discovery {
-        @Keep
         @JsonClass(generateAdapter = true)
         class DiscoverOrganizationsResponse(
             data: DiscoveredOrganizationsResponseData,
         ) : StytchDataResponse<DiscoveredOrganizationsResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class SessionExchangeResponse(
             data: IntermediateSessionExchangeResponseData,
         ) : StytchDataResponse<IntermediateSessionExchangeResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class CreateOrganizationResponse(
             data: OrganizationCreateResponseData,
@@ -193,61 +164,51 @@ internal object B2BResponses {
     }
 
     object SSO {
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(
             data: SSOAuthenticateResponseData,
         ) : StytchDataResponse<SSOAuthenticateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOGetConnectionsResponse(
             data: B2BSSOGetConnectionsResponseData,
         ) : StytchDataResponse<B2BSSOGetConnectionsResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSODeleteConnectionResponse(
             data: B2BSSODeleteConnectionResponseData,
         ) : StytchDataResponse<B2BSSODeleteConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOSAMLCreateConnectionResponse(
             data: B2BSSOSAMLCreateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOSAMLCreateConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOOIDCCreateConnectionResponse(
             data: B2BSSOOIDCCreateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOOIDCCreateConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOSAMLUpdateConnectionResponse(
             data: B2BSSOSAMLUpdateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOSAMLUpdateConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOOIDCUpdateConnectionResponse(
             data: B2BSSOOIDCUpdateConnectionResponseData,
         ) : StytchDataResponse<B2BSSOOIDCUpdateConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOSAMLUpdateConnectionByURLResponse(
             data: B2BSSOSAMLUpdateConnectionByURLResponseData,
         ) : StytchDataResponse<B2BSSOSAMLUpdateConnectionByURLResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSOSAMLDeleteVerificationCertificateResponse(
             data: B2BSSOSAMLDeleteVerificationCertificateResponseData,
         ) : StytchDataResponse<B2BSSOSAMLDeleteVerificationCertificateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSSODiscoveryConnectionResponse(
             data: B2BSSODiscoveryConnectionResponseData,
@@ -256,13 +217,11 @@ internal object B2BResponses {
 
     object OTP {
         object SMS {
-            @Keep
             @JsonClass(generateAdapter = true)
             class SendResponse(
                 data: OTPSendResponseData,
             ) : StytchDataResponse<OTPSendResponseData>(data)
 
-            @Keep
             @JsonClass(generateAdapter = true)
             class AuthenticateResponse(
                 data: SMSAuthenticateResponseData,
@@ -270,26 +229,22 @@ internal object B2BResponses {
         }
 
         object Email {
-            @Keep
             @JsonClass(generateAdapter = true)
             class LoginOrSignupResponse(
                 data: B2BOTPsEmailLoginOrSignupResponseData,
             ) : StytchDataResponse<B2BOTPsEmailLoginOrSignupResponseData>(data)
 
-            @Keep
             @JsonClass(generateAdapter = true)
             class AuthenticateResponse(
                 data: B2BOTPsEmailAuthenticateResponseData,
             ) : StytchDataResponse<B2BOTPsEmailAuthenticateResponseData>(data)
 
             object Discovery {
-                @Keep
                 @JsonClass(generateAdapter = true)
                 class SendResponse(
                     data: B2BDiscoveryOTPEmailSendResponseData,
                 ) : StytchDataResponse<B2BDiscoveryOTPEmailSendResponseData>(data)
 
-                @Keep
                 @JsonClass(generateAdapter = true)
                 class AuthenticateResponse(
                     data: B2BDiscoveryOTPEmailAuthenticateResponseData,
@@ -299,13 +254,11 @@ internal object B2BResponses {
     }
 
     object TOTP {
-        @Keep
         @JsonClass(generateAdapter = true)
         class CreateResponse(
             data: TOTPCreateResponseData,
         ) : StytchDataResponse<TOTPCreateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(
             data: TOTPAuthenticateResponseData,
@@ -313,19 +266,16 @@ internal object B2BResponses {
     }
 
     object RecoveryCodes {
-        @Keep
         @JsonClass(generateAdapter = true)
         class GetResponse(
             data: RecoveryCodeGetResponseData,
         ) : StytchDataResponse<RecoveryCodeGetResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class RotateResponse(
             data: RecoveryCodeRotateResponseData,
         ) : StytchDataResponse<RecoveryCodeRotateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class RecoverResponse(
             data: RecoveryCodeRecoverResponseData,
@@ -333,13 +283,11 @@ internal object B2BResponses {
     }
 
     object OAuth {
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(
             data: OAuthAuthenticateResponseData,
         ) : StytchDataResponse<OAuthAuthenticateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class DiscoveryAuthenticateResponse(
             data: DiscoveryAuthenticateResponseData,
@@ -347,13 +295,11 @@ internal object B2BResponses {
     }
 
     object SearchManager {
-        @Keep
         @JsonClass(generateAdapter = true)
         class SearchOrganizationResponse(
             data: B2BSearchOrganizationResponseData,
         ) : StytchDataResponse<B2BSearchOrganizationResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class SearchMemberResponse(
             data: B2BSearchMemberResponseData,
@@ -361,49 +307,41 @@ internal object B2BResponses {
     }
 
     object SCIM {
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMCreateConnectionResponse(
             data: B2BSCIMCreateConnectionResponseData,
         ) : StytchDataResponse<B2BSCIMCreateConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMUpdateConnectionResponse(
             data: B2BSCIMUpdateConnectionResponseData,
         ) : StytchDataResponse<B2BSCIMUpdateConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMDeleteConnectionResponse(
             data: B2BSCIMDeleteConnectionResponseData,
         ) : StytchDataResponse<B2BSCIMDeleteConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMGetConnectionResponse(
             data: B2BSCIMGetConnectionResponseData,
         ) : StytchDataResponse<B2BSCIMGetConnectionResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMGetConnectionGroupsResponse(
             data: B2BSCIMGetConnectionGroupsResponseData,
         ) : StytchDataResponse<B2BSCIMGetConnectionGroupsResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMRotateStartResponse(
             data: B2BSCIMRotateStartResponseData,
         ) : StytchDataResponse<B2BSCIMRotateStartResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMRotateCompleteResponse(
             data: B2BSCIMRotateCompleteResponseData,
         ) : StytchDataResponse<B2BSCIMRotateCompleteResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class B2BSCIMRotateCancelResponse(
             data: B2BSCIMRotateCancelResponseData,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuth.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture
  * The OAuth interface provides methods for authenticating a user, via the supported OAuth providers, provided you have
  * configured them within your Stytch Dashboard.
  */
+
 public interface OAuth {
     public fun setOAuthReceiverActivity(activity: ComponentActivity?)
 
@@ -21,6 +22,7 @@ public interface OAuth {
      * An interface describing the methods and parameters available for starting an OAuth or OAuth discovery flow
      * for a specific provider
      */
+
     public interface Provider {
         /**
          * A data class wrapping the parameters necessary to start an OAuth flow for a specific provider
@@ -94,6 +96,7 @@ public interface OAuth {
      * An interface describing the methods and parameters available for starting an OAuth discovery flow
      * for a specific provider
      */
+
     public interface ProviderDiscovery {
         /**
          * A data class wrapping the parameters necessary to start an OAuth flow for a specific provider
@@ -163,6 +166,7 @@ public interface OAuth {
     /**
      * An interface describing the parameters and methods available for authenticating an OAuth Discovery flow
      */
+
     public interface Discovery {
         /**
          * A data class wrapping the parameters necessary to authenticate an OAuth Discovery flow

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -108,7 +108,7 @@ internal class OAuthImpl(
         override fun start(parameters: OAuth.Provider.StartParameters) {
             val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
             val host =
-                StytchB2BClient.bootstrapData.cnameDomain?.let {
+                StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
                     "https://$it/"
                 } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
             val baseUrl = "${host}b2b/public/oauth/$providerName/start"
@@ -142,7 +142,7 @@ internal class OAuthImpl(
                     }
                     val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
                     val host =
-                        StytchB2BClient.bootstrapData.cnameDomain?.let {
+                        StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
                             "https://$it/"
                         } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
                     val baseUrl = "${host}b2b/public/oauth/$providerName/start"

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
@@ -445,6 +445,7 @@ public interface Organization {
          * @property filterName the field on which to filter
          * @property filterValue the value of the field to filter by
          */
+        @JacocoExcludeGenerated
         public sealed class SearchQueryOperand(
             @Json(name = "filter_name")
             public val filterName: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/Organization.kt
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture
  * The Organization interface provides methods for retrieving, updating, and deleting the current authenticated user's
  * organization and creating, updating, deleting, reactivating, and searching an organizations members
  */
+
 public interface Organization {
     /**
      * Exposes a flow of organization data
@@ -183,6 +184,7 @@ public interface Organization {
      * An interface that provides methods for performing create, update, delete, reactivate, and search operations on an
      * Organization's members
      */
+
     public interface OrganizationMembers {
         /**
          * Deletes a Member.

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/otp/OTP.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * The OTP interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS
  */
+
 public interface OTP {
     /**
      * Public variable that exposes an instance of SMS OTP
@@ -29,6 +30,7 @@ public interface OTP {
     /**
      * Provides all possible ways to call SMS OTP endpoints
      */
+
     public interface SMS {
         /**
          * A data class wrapping the parameters needed to send an SMS OTP
@@ -131,6 +133,7 @@ public interface OTP {
     /**
      * Provides all possible ways to call Email OTP endpoints
      */
+
     public interface Email {
         public val discovery: Discovery
 
@@ -237,6 +240,7 @@ public interface OTP {
         /**
          * Provides all possible ways to call Email OTP Discovery endpoints
          */
+
         public interface Discovery {
             /**
              * A data class wrapping the parameters needed to send an Email Discovery OTP

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/rbac/RBAC.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/rbac/RBAC.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture
  * The RBAC interface provides methods for checking a user's permissions according to the roles defined in the Stytch
  * Dashboard
  */
+
 public interface RBAC {
     /**
      * Determines whether the logged-in member is allowed to perform the specified action on the specified resource.

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/rbac/RBACImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/rbac/RBACImpl.kt
@@ -20,7 +20,7 @@ internal class RBACImpl(
         resourceId: String,
         action: String,
     ): Boolean =
-        StytchB2BClient.bootstrapData.rbacPolicy?.callerIsAuthorized(
+        StytchB2BClient.configurationManager.bootstrapData.rbacPolicy?.callerIsAuthorized(
             memberRoles = getRoleIds(),
             resourceId = resourceId,
             action = action,
@@ -30,7 +30,7 @@ internal class RBACImpl(
         resourceId: String,
         action: String,
     ): Boolean {
-        StytchB2BClient.refreshBootstrapData()
+        StytchB2BClient.configurationManager.refreshBootstrapData()
         return isAuthorizedSync(resourceId = resourceId, action = action)
     }
 
@@ -54,8 +54,10 @@ internal class RBACImpl(
             }.asCompletableFuture()
 
     override suspend fun allPermissions(): Map<String, Map<String, Boolean>> {
-        StytchB2BClient.refreshBootstrapData()
-        return StytchB2BClient.bootstrapData.rbacPolicy?.allPermissionsForCaller(getRoleIds()) ?: emptyMap()
+        StytchB2BClient.configurationManager.refreshBootstrapData()
+        return StytchB2BClient.configurationManager.bootstrapData.rbacPolicy
+            ?.allPermissionsForCaller(getRoleIds())
+            ?: emptyMap()
     }
 
     override fun allPermissions(callback: (Map<String, Map<String, Boolean>>) -> Unit) {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodes.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/recoveryCodes/RecoveryCodes.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * The RecoveryCodes interface provides methods for getting, rotating, and using recovery codes for a member
  */
+
 public interface RecoveryCodes {
     /**
      * Get the recovery codes for an authenticated member

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/scim/SCIM.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * The SCIM interface provides methods for creating, getting, updating, deleting, and rotating SCIM connections
  */
+
 public interface SCIM {
     /**
      * A data class wrapping the parameters needed to create a SCIM connection

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/searchManager/SearchManager.kt
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * The SearchManager interface provides methods for searching for organizations and members
  */
+
 public interface SearchManager {
     /**
      * A data class wrapping the parameters used for a Search Organizations call

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessions.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture
  * The B2BSessions interface provides methods for authenticating, updating, or revoking sessions, and properties to
  * retrieve the existing session token (opaque or JWT).
  */
+
 public interface B2BSessions {
     /**
      * Exposes a flow of session data

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSO.kt
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture
  * Stytch supports the following SSO protocols:
  * - SAML
  */
+
 public interface SSO {
     public fun setSSOReceiverActivity(activity: ComponentActivity?)
 
@@ -234,6 +235,7 @@ public interface SSO {
     /**
      * The SAML interface provides methods for creating, updating, and deleting a SAML connection
      */
+
     public interface SAML {
         /**
          * Data class used for wrapping the parameters for a SAML creation request
@@ -419,6 +421,7 @@ public interface SSO {
     /**
      * The OIDC interface provides methods for creating and updating an OIDC connection
      */
+
     public interface OIDC {
         /**
          * Data class used for wrapping the parameters for an OIDC creation request

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -48,7 +48,7 @@ internal class SSOImpl(
 
     override fun start(params: SSO.StartParams) {
         val host =
-            StytchB2BClient.bootstrapData.cnameDomain?.let {
+            StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
                 "https://$it/v1/"
             } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
         val potentialParameters =
@@ -75,7 +75,7 @@ internal class SSOImpl(
                     return@suspendCancellableCoroutine
                 }
                 val host =
-                    StytchB2BClient.bootstrapData.cnameDomain?.let {
+                    StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
                         "https://$it/v1/"
                     } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
                 val potentialParameters =

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/totp/TOTP.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * The TOTP interface provides methods for creating and authenticating TOTPs for a member
  */
+
 public interface TOTP {
     /**
      * A data class wrapping the parameters needed to create a TOTP

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -68,7 +68,6 @@ internal class ConfigurationManager {
                     smsRetriever.finish()
                     client.smsAutofillCallback(code, sessionDurationMinutes)
                 }
-            StorageHelper.initialize(context)
             client.commonApi.configure(publicToken, deviceInfo, client::getSessionToken)
             val bootstrapJob = refreshBootstrapAndApi(true)
             val sessionRehydrationJob = client.rehydrateSession()

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -1,0 +1,154 @@
+package com.stytch.sdk.common
+
+import android.app.Application
+import android.content.Context
+import com.stytch.sdk.common.dfp.ActivityProvider
+import com.stytch.sdk.common.dfp.CaptchaProviderImpl
+import com.stytch.sdk.common.dfp.DFPProvider
+import com.stytch.sdk.common.dfp.DFPProviderImpl
+import com.stytch.sdk.common.errors.StytchInternalError
+import com.stytch.sdk.common.extensions.getDeviceInfo
+import com.stytch.sdk.common.network.models.BootstrapData
+import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
+import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
+import com.stytch.sdk.common.pkcePairManager.PKCEPairManagerImpl
+import com.stytch.sdk.common.smsRetriever.StytchSMSRetriever
+import com.stytch.sdk.common.smsRetriever.StytchSMSRetrieverImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+import java.util.Date
+import java.util.UUID
+
+internal class ConfigurationManager {
+    internal lateinit var deviceInfo: DeviceInfo
+    internal lateinit var appSessionId: String
+    private var stytchClientOptions: StytchClientOptions? = null
+    internal var applicationContext = WeakReference<Context>(null)
+    internal var dispatchers: StytchDispatchers = StytchDispatchers()
+    internal var externalScope: CoroutineScope = CoroutineScope(SupervisorJob())
+    internal var pkcePairManager: PKCEPairManager = PKCEPairManagerImpl(StorageHelper, EncryptionManager)
+    internal lateinit var dfpProvider: DFPProvider
+    internal var bootstrapData: BootstrapData = BootstrapData()
+    internal lateinit var publicToken: String
+    internal lateinit var smsRetriever: StytchSMSRetriever
+    internal var isInitialized: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    private var configurationStartTime = 0L
+    private lateinit var client: StytchClientCommon
+
+    fun configure(
+        client: StytchClientCommon,
+        context: Context,
+        publicToken: String,
+        options: StytchClientOptions = StytchClientOptions(),
+    ) {
+        if (isAlreadyConfiguredFor(publicToken, options)) {
+            return
+        }
+        try {
+            configurationStartTime = Date().time
+            this.client = client
+            this.publicToken = publicToken
+            this.stytchClientOptions = options
+            this.applicationContext = WeakReference(context.applicationContext)
+            this.deviceInfo = context.getDeviceInfo()
+            this.appSessionId = "app-session-id-${UUID.randomUUID()}"
+            this.dfpProvider =
+                DFPProviderImpl(
+                    publicToken = publicToken,
+                    dfppaDomain = options.endpointOptions.dfppaDomain,
+                    activityProvider = ActivityProvider(context.applicationContext as Application),
+                )
+            this.smsRetriever =
+                StytchSMSRetrieverImpl(context) { code, sessionDurationMinutes ->
+                    smsRetriever.finish()
+                    client.smsAutofillCallback(code, sessionDurationMinutes)
+                }
+            StorageHelper.initialize(context)
+            client.commonApi.configure(publicToken, deviceInfo)
+            val bootstrapJob = refreshBootstrapAndApi(true)
+            val sessionRehydrationJob = client.rehydrateSession()
+            externalScope.launch(dispatchers.io) {
+                listOf(bootstrapJob, sessionRehydrationJob).joinAll()
+                client.logEvent("client_initialization_success", null, null)
+                isInitialized.value = true
+                emitAnalyticsEvent(
+                    ConfigurationAnalyticsEvent(
+                        step = ConfigurationStep.IS_INITIALIZED,
+                        duration = Date().time - configurationStartTime,
+                    ),
+                )
+                client.onFinishedInitialization()
+            }
+            NetworkChangeListener.configure(context.applicationContext, ::refreshBootstrapAndApi)
+            AppLifecycleListener.configure(::refreshBootstrapAndApi)
+        } catch (ex: Exception) {
+            client.logEvent("client_initialization_failure", null, ex)
+            throw StytchInternalError(
+                message = "Failed to initialize the SDK",
+                exception = ex,
+            )
+        }
+    }
+
+    private fun isAlreadyConfiguredFor(
+        publicToken: String,
+        options: StytchClientOptions,
+    ) = this::publicToken.isInitialized && this.publicToken == publicToken && this.stytchClientOptions == options
+
+    fun emitAnalyticsEvent(event: ConfigurationAnalyticsEvent) {
+        // TODO: Align on naming with Nidal
+        println("ConfigurationAnalyticEvent_${event.step} = ${event.duration}")
+        // client.logEvent("ConfigurationAnalyticEvent_${event.step}", mapOf("duration" to event.duration), null)
+    }
+
+    private fun refreshBootstrapAndApi(reportTiming: Boolean = false): Job =
+        externalScope.launch(dispatchers.io) {
+            val start = Date().time
+            applicationContext.get()?.let {
+                refreshBootstrapData()
+                client.commonApi.configureDFP(
+                    dfpProvider = dfpProvider,
+                    captchaProvider =
+                        CaptchaProviderImpl(
+                            it as Application,
+                            externalScope,
+                            bootstrapData.captchaSettings.siteKey,
+                        ),
+                    dfpProtectedAuthEnabled = bootstrapData.dfpProtectedAuthEnabled,
+                    dfpProtectedAuthMode = bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+                )
+                if (reportTiming) {
+                    emitAnalyticsEvent(
+                        ConfigurationAnalyticsEvent(
+                            step = ConfigurationStep.BOOTSTRAPPING,
+                            duration = Date().time - start,
+                        ),
+                    )
+                }
+            }
+        }
+
+    suspend fun refreshBootstrapData() {
+        bootstrapData =
+            when (val res = client.commonApi.getBootstrapData()) {
+                is StytchResult.Success -> res.value
+                else -> bootstrapData
+            }
+    }
+}
+
+internal data class ConfigurationAnalyticsEvent(
+    val step: ConfigurationStep,
+    val duration: Long,
+)
+
+internal enum class ConfigurationStep {
+    BOOTSTRAPPING,
+    SESSION_HYDRATION,
+    IS_INITIALIZED,
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 internal class ConfigurationManager {
     internal lateinit var deviceInfo: DeviceInfo
     internal lateinit var appSessionId: String
-    private var stytchClientOptions: StytchClientOptions? = null
+    private var options: StytchClientOptions = StytchClientOptions()
     internal var applicationContext = WeakReference<Context>(null)
     internal var dispatchers: StytchDispatchers = StytchDispatchers()
     internal var externalScope: CoroutineScope = CoroutineScope(SupervisorJob())
@@ -53,7 +53,7 @@ internal class ConfigurationManager {
             configurationStartTime = Date().time
             this.client = client
             this.publicToken = publicToken
-            this.stytchClientOptions = options
+            this.options = options
             this.applicationContext = WeakReference(context.applicationContext)
             this.deviceInfo = context.getDeviceInfo()
             this.appSessionId = "app-session-id-${UUID.randomUUID()}"
@@ -69,7 +69,7 @@ internal class ConfigurationManager {
                     client.smsAutofillCallback(code, sessionDurationMinutes)
                 }
             StorageHelper.initialize(context)
-            client.commonApi.configure(publicToken, deviceInfo)
+            client.commonApi.configure(publicToken, deviceInfo, client::getSessionToken)
             val bootstrapJob = refreshBootstrapAndApi(true)
             val sessionRehydrationJob = client.rehydrateSession()
             externalScope.launch(dispatchers.io) {
@@ -98,7 +98,7 @@ internal class ConfigurationManager {
     private fun isAlreadyConfiguredFor(
         publicToken: String,
         options: StytchClientOptions,
-    ) = this::publicToken.isInitialized && this.publicToken == publicToken && this.stytchClientOptions == options
+    ) = this::publicToken.isInitialized && this.publicToken == publicToken && this.options == options
 
     fun emitAnalyticsEvent(event: ConfigurationAnalyticsEvent) {
         // TODO: Align on naming with Nidal

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -123,12 +123,17 @@ internal class ConfigurationManager {
             }
         }
 
+    private var isRefreshingBootstrap = false
+
     suspend fun refreshBootstrapData() {
+        if (isRefreshingBootstrap) return
+        isRefreshingBootstrap = true
         bootstrapData =
             when (val res = client.commonApi.getBootstrapData()) {
                 is StytchResult.Success -> res.value
                 else -> bootstrapData
             }
+        isRefreshingBootstrap = false
     }
 }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
@@ -6,7 +6,7 @@ import com.stytch.sdk.common.errors.StytchDeeplinkError
 /**
  * A class representing the three states of a deeplink handled by StytchClient.handle() / StytchB2BClient.handle()
  */
-
+@JacocoExcludeGenerated
 public sealed interface DeeplinkHandledStatus {
     /**
      * Indicates that a deeplink was successfully parsed from the deeplink.

--- a/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.errors.StytchDeeplinkError
 /**
  * A class representing the three states of a deeplink handled by StytchClient.handle() / StytchB2BClient.handle()
  */
+
 public sealed interface DeeplinkHandledStatus {
     /**
      * Indicates that a deeplink was successfully parsed from the deeplink.

--- a/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkResponse.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/DeeplinkResponse.kt
@@ -8,6 +8,7 @@ import com.stytch.sdk.common.network.models.CommonAuthenticationData
  * A class representing the types of Deeplink responses that the Stytch client has handled
  * @property result A [StytchResult] representing either the authenticated or discovery response, or an error.
  */
+@JacocoExcludeGenerated
 public sealed class DeeplinkResponse(
     public open val result: StytchResult<Any>,
 ) {

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
@@ -1,0 +1,23 @@
+package com.stytch.sdk.common
+
+import com.stytch.sdk.common.network.CommonApi
+import kotlinx.coroutines.Job
+
+internal interface StytchClientCommon {
+    val commonApi: CommonApi
+
+    fun logEvent(
+        eventName: String,
+        details: Map<String, Any>?,
+        error: Exception?,
+    )
+
+    fun rehydrateSession(): Job
+
+    fun smsAutofillCallback(
+        code: String?,
+        sessionDurationMinutes: Int?,
+    )
+
+    var onFinishedInitialization: () -> Unit
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
@@ -20,4 +20,6 @@ internal interface StytchClientCommon {
     )
 
     var onFinishedInitialization: () -> Unit
+
+    fun getSessionToken(): String?
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchObjectInfo.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchObjectInfo.kt
@@ -3,8 +3,9 @@ package com.stytch.sdk.common
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import java.util.Date
 
+@JacocoExcludeGenerated
 public sealed interface StytchObjectInfo<out T> {
-    public data object Unavailable : StytchObjectInfo<Nothing>
+    @JacocoExcludeGenerated public data object Unavailable : StytchObjectInfo<Nothing>
 
     @JacocoExcludeGenerated
     public data class Available<out T>(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchResult.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchResult.kt
@@ -10,6 +10,7 @@ import kotlinx.parcelize.RawValue
  * Provides a wrapper for responses from the Stytch API
  */
 @Parcelize
+@JacocoExcludeGenerated
 public sealed class StytchResult<out T> : Parcelable {
     /**
      * Data class that can hold a successful response from a Stytch endpoint

--- a/source/sdk/src/main/java/com/stytch/sdk/common/TokenType.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/TokenType.kt
@@ -3,4 +3,5 @@ package com.stytch.sdk.common
 /**
  * An interface representing the supported token types that we can extract from a deeplink
  */
+
 public interface TokenType

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFP.kt
@@ -4,6 +4,7 @@ package com.stytch.sdk.common.dfp
  * The DFP interface provides methods for retrieving a DFP Telemetry ID, which you can look up from your backend.
  * For more information on DFP, see [here](https://stytch.com/docs/fraud/guides/device-fingerprinting)
  */
+
 public interface DFP {
     /**
      * Fetches a DFP Telemetry ID for use in backend lookup calls

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIError.kt
@@ -1,5 +1,7 @@
 package com.stytch.sdk.common.errors
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 private val UNRECOVERABLE_ERRORS =
     setOf(
         StytchAPIErrorType.UNAUTHORIZED_CREDENTIALS,
@@ -16,6 +18,7 @@ private val UNRECOVERABLE_ERRORS =
  * @property url a url linking to the Stytch documentation that describes this error
  * @property statusCode the HTTP status code that was returned for this request
  */
+@JacocoExcludeGenerated
 public data class StytchAPIError(
     public val requestId: String? = null,
     public val errorType: StytchAPIErrorType,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
@@ -1,10 +1,12 @@
 package com.stytch.sdk.common.errors
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * An error class representing a schema error that occurs in the Stytch API
  * @property message a string explaining what was wrong with the schema that was sent
  */
-
+@JacocoExcludeGenerated
 public data class StytchAPISchemaError(
     public override val message: String,
 ) : StytchError(message = message)

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPISchemaError.kt
@@ -4,6 +4,7 @@ package com.stytch.sdk.common.errors
  * An error class representing a schema error that occurs in the Stytch API
  * @property message a string explaining what was wrong with the schema that was sent
  */
+
 public data class StytchAPISchemaError(
     public override val message: String,
 ) : StytchError(message = message)

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
@@ -1,12 +1,14 @@
 package com.stytch.sdk.common.errors
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * An error that occurs when the Stytch SDK cannot reach the API. This may mean that there is a network error, or an
  * error occurred while creating the request
  * @property message a string explaining what went wrong
  * @property exception an optional [Throwable] that caused this error to occur
  */
-
+@JacocoExcludeGenerated
 public data class StytchAPIUnreachableError(
     public override val message: String,
     public val exception: Throwable? = null,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchAPIUnreachableError.kt
@@ -6,6 +6,7 @@ package com.stytch.sdk.common.errors
  * @property message a string explaining what went wrong
  * @property exception an optional [Throwable] that caused this error to occur
  */
+
 public data class StytchAPIUnreachableError(
     public override val message: String,
     public val exception: Throwable? = null,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchError.kt
@@ -1,9 +1,12 @@
 package com.stytch.sdk.common.errors
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * A base error class for all errors returned by the Stytch SDK
  * @property message a string explaining what went wrong
  */
+@JacocoExcludeGenerated
 public sealed class StytchError(
     public override val message: String,
 ) : Exception()

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
  * rather we should be creating implementations for each of the known/expected errors we return.
  * @property exception an optional [Throwable] that caused this error to occur
  */
+
 public sealed class StytchSDKError(
     message: String,
     public open val exception: Throwable? = null,
@@ -67,6 +68,7 @@ public data class StytchFailedToCreateCodeChallengeError(
  * A type of error that can occur during deeplink handling
  * @property message a string describing what went wrong when handling the deeplink
  */
+
 public interface StytchDeeplinkError {
     public val message: String
 }
@@ -74,6 +76,7 @@ public interface StytchDeeplinkError {
 /**
  * Thrown when we were passed an unknown deeplink token type
  */
+
 public class StytchDeeplinkUnkownTokenTypeError :
     StytchSDKError(
         message = "The deeplink received has an unknown token type.",
@@ -83,6 +86,7 @@ public class StytchDeeplinkUnkownTokenTypeError :
 /**
  * Thrown when we attempted to handle a deeplink, but no token was found
  */
+
 public class StytchDeeplinkMissingTokenError :
     StytchSDKError(
         message = "The deeplink received has a missing token value.",
@@ -92,6 +96,7 @@ public class StytchDeeplinkMissingTokenError :
 /**
  * Thrown when there is no current session persisted on device
  */
+
 public class StytchNoCurrentSessionError :
     StytchSDKError(
         message = "There is no session currently available.",
@@ -100,6 +105,7 @@ public class StytchNoCurrentSessionError :
 /**
  * Thrown when there are no biometric registrations present on the device
  */
+
 public class StytchNoBiometricsRegistrationError :
     StytchSDKError(
         message = "There is no biometric registration available. Authenticate with another method and add a new biometric registration first.",
@@ -108,6 +114,7 @@ public class StytchNoBiometricsRegistrationError :
 /**
  * Thrown when the keystore is unavailable, but the developer did not pass allowFallbackToCleartext=true
  */
+
 public class StytchKeystoreUnavailableError :
     StytchSDKError(
         message = "The Android keystore is unavailable on the device. Consider setting allowFallbackToCleartext to true.",
@@ -117,6 +124,7 @@ public class StytchKeystoreUnavailableError :
  * Thrown when we are unable to retrieve a biometric key
  * @property exception an optional [Throwable] that caused this error to occur
  */
+
 public data class StytchMissingPublicKeyError(
     override val exception: Throwable?,
 ) : StytchSDKError(
@@ -128,6 +136,7 @@ public data class StytchMissingPublicKeyError(
  * Thrown when a challenge signing (biometrics, passkeys) has failed
  * @property exception an optional [Throwable] that caused this error to occur
  */
+
 public data class StytchChallengeSigningFailed(
     public override val exception: Throwable?,
 ) : StytchSDKError(
@@ -138,6 +147,7 @@ public data class StytchChallengeSigningFailed(
 /**
  * Thrown when the Google OneTap authorization credential was missing an id_token
  */
+
 public class StytchMissingAuthorizationCredentialIdTokenError :
     StytchSDKError(
         message = "The authorization credential is missing an ID token.",
@@ -146,6 +156,7 @@ public class StytchMissingAuthorizationCredentialIdTokenError :
 /**
  * Thrown when the Google OneTap client or nonce is missing
  */
+
 public class StytchInvalidAuthorizationCredentialError :
     StytchSDKError(
         message = "The authorization credential is invalid.",
@@ -154,6 +165,7 @@ public class StytchInvalidAuthorizationCredentialError :
 /**
  * Thrown when you attempt to perform a passkey flow on a device that does not support passkeys
  */
+
 public class StytchPasskeysNotSupportedError :
     StytchSDKError(
         message = "Passkeys are not supported on this device.",

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchSDKError.kt
@@ -9,7 +9,7 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
  * rather we should be creating implementations for each of the known/expected errors we return.
  * @property exception an optional [Throwable] that caused this error to occur
  */
-
+@JacocoExcludeGenerated
 public sealed class StytchSDKError(
     message: String,
     public open val exception: Throwable? = null,
@@ -124,7 +124,7 @@ public class StytchKeystoreUnavailableError :
  * Thrown when we are unable to retrieve a biometric key
  * @property exception an optional [Throwable] that caused this error to occur
  */
-
+@JacocoExcludeGenerated
 public data class StytchMissingPublicKeyError(
     override val exception: Throwable?,
 ) : StytchSDKError(
@@ -213,16 +213,22 @@ public data class UnexpectedCredentialType(
         message = "Unexpected type of credential: $credentialType",
     )
 
-public data object NoBrowserFound : StytchSDKError("No supported browser was found on this device")
+@JacocoExcludeGenerated public data object NoBrowserFound : StytchSDKError(
+    "No supported browser was found on this device",
+)
 
-public data object NoURIFound : StytchSDKError("No OAuth URI could be found in the bundle")
+@JacocoExcludeGenerated public data object NoURIFound : StytchSDKError("No OAuth URI could be found in the bundle")
 
-public data object UserCanceled : StytchSDKError("The user canceled the OAuth flow")
+@JacocoExcludeGenerated public data object UserCanceled : StytchSDKError("The user canceled the OAuth flow")
 
-public data object NoActivityProvided : StytchSDKError("You must supply a receiver activity before calling this method")
+@JacocoExcludeGenerated public data object NoActivityProvided : StytchSDKError(
+    "You must supply a receiver activity before calling this method",
+)
 
-public data object UnknownOAuthOrSSOError : StytchSDKError("The OAuth or SSO flow completed unexpectedly")
+@JacocoExcludeGenerated public data object UnknownOAuthOrSSOError : StytchSDKError(
+    "The OAuth or SSO flow completed unexpectedly",
+)
 
-public data object BiometricsAlreadyEnrolledError : StytchSDKError(
+@JacocoExcludeGenerated public data object BiometricsAlreadyEnrolledError : StytchSDKError(
     "There is already a biometric factor enrolled on this device. Fully authenticate with all factors and remove the existing registration before attempting to register again.",
 )

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchUIError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchUIError.kt
@@ -24,6 +24,7 @@ public data class StytchUIActivityFailed(
 /**
  * Thrown when there was an error parsing the activity intent
  */
+
 public data object StytchUINoDataFromIntent : StytchUIError(
     message = "Failed to retrieve data from intent",
 )

--- a/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchUIError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/errors/StytchUIError.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
  * rather we should be creating implementations for each of the known/expected errors we return.
  * @property exception an optional [Throwable] that caused this error to occur
  */
+@JacocoExcludeGenerated
 public sealed class StytchUIError(
     message: String,
     public open val exception: Throwable? = null,
@@ -25,7 +26,7 @@ public data class StytchUIActivityFailed(
  * Thrown when there was an error parsing the activity intent
  */
 
-public data object StytchUINoDataFromIntent : StytchUIError(
+@JacocoExcludeGenerated public data object StytchUINoDataFromIntent : StytchUIError(
     message = "Failed to retrieve data from intent",
 )
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
@@ -14,66 +14,66 @@ import java.util.concurrent.TimeUnit
 
 private const val ONE_HUNDRED_TWENTY = 120L
 
-internal interface ApiService {
-    companion object {
-        private var client: OkHttpClient =
-            OkHttpClient
-                .Builder()
-                .readTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
-                .writeTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
-                .connectTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
-                .addNetworkInterceptor {
-                    // OkHttp is adding a charset to the content-type which is rejected by the API
-                    // see: https://github.com/square/okhttp/issues/3081
-                    it.proceed(
-                        it
-                            .request()
-                            .newBuilder()
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    )
-                }.build()
+internal open class ApiService(
+    hostUrl: String,
+) {
+    private var client: OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .readTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
+            .writeTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
+            .connectTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
+            .addNetworkInterceptor {
+                // OkHttp is adding a charset to the content-type which is rejected by the API
+                // see: https://github.com/square/okhttp/issues/3081
+                it.proceed(
+                    it
+                        .request()
+                        .newBuilder()
+                        .header("Content-Type", "application/json")
+                        .build(),
+                )
+            }.build()
 
-        fun getInitialRetrofitInstance(
-            hostUrl: String,
-            authHeaderInterceptor: StytchAuthHeaderInterceptor?,
-        ): Retrofit {
-            val newBuilder = client.newBuilder()
-            authHeaderInterceptor?.let {
-                newBuilder.addInterceptor(it)
-            }
-            client = newBuilder.build()
-            val moshi =
-                Moshi
-                    .Builder()
-                    .add(createEnumJsonAdapter<AllowedAuthMethods>())
-                    .add(createEnumJsonAdapter<MfaMethod>())
-                    .add(createEnumJsonAdapter<SetMFAEnrollment>())
-                    .add(createEnumJsonAdapter<CryptoWalletType>())
-                    .add(createEnumJsonAdapter<Locale>())
-                    .build()
-            return Retrofit
-                .Builder()
-                .baseUrl(hostUrl)
-                .addConverterFactory(MoshiConverterFactory.create(moshi))
-                .client(client)
-                .build()
-        }
+    private val moshi =
+        Moshi
+            .Builder()
+            .add(createEnumJsonAdapter<AllowedAuthMethods>())
+            .add(createEnumJsonAdapter<MfaMethod>())
+            .add(createEnumJsonAdapter<SetMFAEnrollment>())
+            .add(createEnumJsonAdapter<CryptoWalletType>())
+            .add(createEnumJsonAdapter<Locale>())
+            .build()
 
-        fun addDfpInterceptor(
-            retrofit: Retrofit,
-            dfpInterceptor: StytchDFPInterceptor,
-        ): Retrofit {
-            val newClientBuilder = client.newBuilder()
-            newClientBuilder
-                .interceptors()
-                .find {
-                    it::class.java == StytchDFPInterceptor::class.java
-                }?.let { existingInterceptor ->
-                    newClientBuilder.interceptors().remove(existingInterceptor)
-                }
-            client = newClientBuilder.addInterceptor(dfpInterceptor).build()
-            return retrofit.newBuilder().client(client).build()
+    internal var retrofit =
+        Retrofit
+            .Builder()
+            .baseUrl(hostUrl)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(client)
+            .build()
+
+    fun addAuthHeaderInterceptor(authHeaderInterceptor: StytchAuthHeaderInterceptor?): Retrofit {
+        val newBuilder = client.newBuilder()
+        authHeaderInterceptor?.let {
+            newBuilder.addInterceptor(it)
         }
+        client = newBuilder.build()
+        return retrofit.newBuilder().client(client).build()
     }
+
+    fun addDfpInterceptor(dfpInterceptor: StytchDFPInterceptor): Retrofit {
+        val newClientBuilder = client.newBuilder()
+        newClientBuilder
+            .interceptors()
+            .find {
+                it::class.java == StytchDFPInterceptor::class.java
+            }?.let { existingInterceptor ->
+                newClientBuilder.interceptors().remove(existingInterceptor)
+            }
+        client = newClientBuilder.addInterceptor(dfpInterceptor).build()
+        return retrofit.newBuilder().client(client).build()
+    }
+
+    interface ApiEndpoints
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
@@ -16,19 +16,12 @@ private const val ONE_HUNDRED_TWENTY = 120L
 
 internal interface ApiService {
     companion object {
-        private fun clientBuilder(
-            authHeaderInterceptor: StytchAuthHeaderInterceptor?,
-            dfpInterceptor: StytchDFPInterceptor?,
-        ): OkHttpClient {
-            val builder =
-                OkHttpClient
-                    .Builder()
-                    .readTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
-                    .writeTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
-                    .connectTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
-            authHeaderInterceptor?.let { builder.addInterceptor(it) }
-            dfpInterceptor?.let { builder.addInterceptor(it) }
-            builder
+        private var client: OkHttpClient =
+            OkHttpClient
+                .Builder()
+                .readTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
+                .writeTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
+                .connectTimeout(ONE_HUNDRED_TWENTY, TimeUnit.SECONDS)
                 .addNetworkInterceptor {
                     // OkHttp is adding a charset to the content-type which is rejected by the API
                     // see: https://github.com/square/okhttp/issues/3081
@@ -39,16 +32,13 @@ internal interface ApiService {
                             .header("Content-Type", "application/json")
                             .build(),
                     )
-                }
-            return builder.build()
-        }
+                }.build()
 
-        fun <T : ApiService> createApiService(
+        fun getInitialRetrofitInstance(
             hostUrl: String,
-            authHeaderInterceptor: StytchAuthHeaderInterceptor?,
-            dfpInterceptor: StytchDFPInterceptor?,
-            apiService: Class<T>,
-        ): T {
+            authHeaderInterceptor: StytchAuthHeaderInterceptor,
+        ): Retrofit {
+            client = client.newBuilder().addInterceptor(authHeaderInterceptor).build()
             val moshi =
                 Moshi
                     .Builder()
@@ -62,9 +52,24 @@ internal interface ApiService {
                 .Builder()
                 .baseUrl(hostUrl)
                 .addConverterFactory(MoshiConverterFactory.create(moshi))
-                .client(clientBuilder(authHeaderInterceptor, dfpInterceptor))
+                .client(client)
                 .build()
-                .create(apiService)
+        }
+
+        fun addDfpInterceptor(
+            retrofit: Retrofit,
+            dfpInterceptor: StytchDFPInterceptor,
+        ): Retrofit {
+            val newClientBuilder = client.newBuilder()
+            newClientBuilder
+                .interceptors()
+                .find {
+                    it::class.java == StytchDFPInterceptor::class.java
+                }?.let { existingInterceptor ->
+                    newClientBuilder.interceptors().remove(existingInterceptor)
+                }
+            client = newClientBuilder.addInterceptor(dfpInterceptor).build()
+            return retrofit.newBuilder().client(client).build()
         }
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
@@ -36,9 +36,13 @@ internal interface ApiService {
 
         fun getInitialRetrofitInstance(
             hostUrl: String,
-            authHeaderInterceptor: StytchAuthHeaderInterceptor,
+            authHeaderInterceptor: StytchAuthHeaderInterceptor?,
         ): Retrofit {
-            client = client.newBuilder().addInterceptor(authHeaderInterceptor).build()
+            val newBuilder = client.newBuilder()
+            authHeaderInterceptor?.let {
+                newBuilder.addInterceptor(it)
+            }
+            client = newBuilder.build()
             val moshi =
                 Moshi
                     .Builder()

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/CommonApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/CommonApi.kt
@@ -1,0 +1,24 @@
+package com.stytch.sdk.common.network
+
+import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.dfp.CaptchaProvider
+import com.stytch.sdk.common.dfp.DFPProvider
+import com.stytch.sdk.common.network.models.BootstrapData
+import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
+
+internal interface CommonApi {
+    fun configure(
+        publicToken: String,
+        deviceInfo: DeviceInfo,
+    )
+
+    fun configureDFP(
+        dfpProvider: DFPProvider,
+        captchaProvider: CaptchaProvider,
+        dfpProtectedAuthEnabled: Boolean,
+        dfpProtectedAuthMode: DFPProtectedAuthMode,
+    )
+
+    suspend fun getBootstrapData(): StytchResult<BootstrapData>
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/CommonApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/CommonApi.kt
@@ -11,6 +11,7 @@ internal interface CommonApi {
     fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
+        getSessionToken: () -> String?,
     )
 
     fun configureDFP(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/StytchDataResponse.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/StytchDataResponse.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.common.network
 
-import androidx.annotation.Keep
-
-@Keep
-internal open class StytchDataResponse<T>(internal val data: T)
+internal open class StytchDataResponse<T>(
+    internal val data: T,
+)

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonRequests.kt
@@ -1,13 +1,11 @@
 package com.stytch.sdk.common.network.models
 
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.utils.IEnumValue
 
 internal object CommonRequests {
     object Sessions {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "session_duration_minutes")
@@ -16,14 +14,12 @@ internal object CommonRequests {
     }
 
     object Events {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class Event(
             val telemetry: EventTelemetry,
             val event: EventEvent,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class EventTelemetry(
             @Json(name = "event_id")
@@ -41,14 +37,12 @@ internal object CommonRequests {
             val device: DeviceIdentifier,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class VersionIdentifier(
             val identifier: String,
             val version: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class DeviceIdentifier(
             val model: String? = null,
@@ -56,7 +50,6 @@ internal object CommonRequests {
             val screenSize: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class EventEvent(
             @Json(name = "public_token")
@@ -70,7 +63,6 @@ internal object CommonRequests {
     }
 }
 
-@Keep
 @JsonClass(generateAdapter = false)
 public enum class Locale(
     override val jsonName: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -1,19 +1,16 @@
 package com.stytch.sdk.common.network.models
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
-@Keep
 public interface IBasicData {
     public val statusCode: Int
     public val requestId: String
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class BasicData(
@@ -24,7 +21,6 @@ public data class BasicData(
 ) : Parcelable,
     IBasicData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class StytchErrorResponse(
@@ -40,7 +36,6 @@ public data class StytchErrorResponse(
     val errorUrl: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class StytchSchemaError(
@@ -49,7 +44,6 @@ public data class StytchSchemaError(
     val query: @RawValue Any?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class CryptoWalletData(
@@ -65,7 +59,6 @@ public data class CryptoWalletData(
     val verified: Boolean,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class EmailData(
@@ -75,7 +68,6 @@ public data class EmailData(
     public val verified: Boolean,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class NameData(
@@ -87,7 +79,6 @@ public data class NameData(
     val middleName: String?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class WebAuthNRegistrations(
@@ -104,7 +95,6 @@ public data class WebAuthNRegistrations(
     val name: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class PhoneNumber(
@@ -118,7 +108,6 @@ public data class PhoneNumber(
     val verified: Boolean,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class Provider(
@@ -133,7 +122,6 @@ public data class Provider(
     val profilePictureUrl: String? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTP(
@@ -144,7 +132,6 @@ public data class TOTP(
     val verified: Boolean,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class BiometricRegistrations(
@@ -155,7 +142,6 @@ public data class BiometricRegistrations(
     val verified: Boolean,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class Password(
@@ -165,7 +151,6 @@ public data class Password(
     val requiresReset: Boolean,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class BiometricsStartResponse(
@@ -178,7 +163,6 @@ public data class BiometricsStartResponse(
     val challenge: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class LoginOrCreateOTPData(
@@ -190,7 +174,6 @@ public data class LoginOrCreateOTPData(
     val methodId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OTPSendResponseData(
@@ -202,7 +185,6 @@ public data class OTPSendResponseData(
     val methodId: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class AuthenticationFactor(
@@ -264,7 +246,6 @@ public data class AuthenticationFactor(
     @Json(name = "crypto_wallet_factor")
     val cryptoWalletFactor: CryptoWalletFactor?,
 ) : Parcelable {
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class EmailFactor(
@@ -274,7 +255,6 @@ public data class AuthenticationFactor(
         val emailAddress: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class PhoneFactor(
@@ -284,7 +264,6 @@ public data class AuthenticationFactor(
         val phoneNumber: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class OAuthFactor(
@@ -295,7 +274,6 @@ public data class AuthenticationFactor(
         val providerSubject: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class WebAuthnFactor(
@@ -306,7 +284,6 @@ public data class AuthenticationFactor(
         val userAgent: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class BiometricFactor(
@@ -314,7 +291,6 @@ public data class AuthenticationFactor(
         val biometricRegistrationId: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class AuthenticatorAppFactor(
@@ -322,7 +298,6 @@ public data class AuthenticationFactor(
         val totpId: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class RecoveryCodeFactor(
@@ -330,7 +305,6 @@ public data class AuthenticationFactor(
         val totpRecoveryCodeId: String,
     ) : Parcelable
 
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class CryptoWalletFactor(
@@ -343,13 +317,11 @@ public data class AuthenticationFactor(
     ) : Parcelable
 }
 
-@Keep
 public interface CommonAuthenticationData {
     public val sessionJwt: String
     public val sessionToken: String
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class BootstrapData(
@@ -383,7 +355,6 @@ public data class BootstrapData(
     val rbacPolicy: RBACPolicy? = null,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RBACPolicy(
@@ -428,7 +399,6 @@ public data class RBACPolicy(
     }
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RBACPolicyRole(
@@ -438,7 +408,6 @@ public data class RBACPolicyRole(
     val permissions: List<RBACPermission>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RBACPermission(
@@ -447,7 +416,6 @@ public data class RBACPermission(
     val actions: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class RBACPolicyResource(
@@ -457,7 +425,6 @@ public data class RBACPolicyResource(
     val actions: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class PasswordConfig(
@@ -467,14 +434,12 @@ public data class PasswordConfig(
     val ludsMinimumCount: Int,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = false)
 public enum class DFPProtectedAuthMode {
     OBSERVATION,
     DECISIONING,
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class CaptchaSettings(
@@ -482,12 +447,10 @@ public data class CaptchaSettings(
     val siteKey: String? = "",
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public class NoResponseData : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class LUDSRequirements(
@@ -505,7 +468,6 @@ public data class LUDSRequirements(
     val missingCharacters: Int,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = false)
 public enum class StrengthPolicy {
     @Json(name = "zxcvbn")
@@ -516,7 +478,7 @@ public enum class StrengthPolicy {
 }
 
 // The feedback response types are different for B2B/B2C. B2C combines both in one object, B2B separates them
-@Keep
+
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class Feedback(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponses.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponses.kt
@@ -1,43 +1,47 @@
 package com.stytch.sdk.common.network.models
 
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.StytchDataResponse
 
 internal object CommonResponses {
     object Biometrics {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class RegisterStartResponse(data: BiometricsStartResponse) :
-            StytchDataResponse<BiometricsStartResponse>(data)
+        class RegisterStartResponse(
+            data: BiometricsStartResponse,
+        ) : StytchDataResponse<BiometricsStartResponse>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class AuthenticateStartResponse(data: BiometricsStartResponse) :
-            StytchDataResponse<BiometricsStartResponse>(data)
+        class AuthenticateStartResponse(
+            data: BiometricsStartResponse,
+        ) : StytchDataResponse<BiometricsStartResponse>(data)
     }
 
     object Sessions {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class RevokeResponse(data: BasicData) : StytchDataResponse<BasicData>(data)
+        class RevokeResponse(
+            data: BasicData,
+        ) : StytchDataResponse<BasicData>(data)
     }
 
     object Bootstrap {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class BootstrapResponse(data: BootstrapData) : StytchDataResponse<BootstrapData>(data)
+        class BootstrapResponse(
+            data: BootstrapData,
+        ) : StytchDataResponse<BootstrapData>(data)
     }
 
-    @Keep
     @JsonClass(generateAdapter = true)
-    class BasicResponse(data: BasicData) : StytchDataResponse<BasicData>(data)
+    class BasicResponse(
+        data: BasicData,
+    ) : StytchDataResponse<BasicData>(data)
 
-    @Keep
     @JsonClass(generateAdapter = true)
-    class SendResponse(data: BasicData) : StytchDataResponse<BasicData>(data)
+    class SendResponse(
+        data: BasicData,
+    ) : StytchDataResponse<BasicData>(data)
 
-    @Keep
     @JsonClass(generateAdapter = true)
-    class NoResponse(data: NoResponseData) : StytchDataResponse<NoResponseData>(data)
+    class NoResponse(
+        data: NoResponseData,
+    ) : StytchDataResponse<NoResponseData>(data)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sso/SSOError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sso/SSOError.kt
@@ -1,9 +1,12 @@
 package com.stytch.sdk.common.sso
 
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+
 /**
  * Represents one of three potential errors encountered during the Third party OAuth or SSO authentication flow.
  * @property message A friendly string indicating what went wrong during the OAuth or SSO authentication flow.
  */
+@JacocoExcludeGenerated
 public sealed class SSOError(
     override val message: String,
 ) : Exception(message) {
@@ -11,19 +14,21 @@ public sealed class SSOError(
      * Indicates that no suitable browser was found on this device, and OAuth authentication cannot proceed.
      */
 
-    public data object NoBrowserFound : SSOError("No supported browser was found on this device")
+    @JacocoExcludeGenerated public data object NoBrowserFound : SSOError(
+        "No supported browser was found on this device",
+    )
 
     /**
      * Indicates that no URI was found in the activity state, and OAuth authentication cannot proceed.
      */
 
-    public data object NoURIFound : SSOError("No OAuth URI could be found in the bundle")
+    @JacocoExcludeGenerated public data object NoURIFound : SSOError("No OAuth URI could be found in the bundle")
 
     /**
      * Indicates that the user canceled the OAuth flow. This is safe to ignore.
      */
 
-    public data object UserCanceled : SSOError("The user canceled the OAuth flow")
+    @JacocoExcludeGenerated public data object UserCanceled : SSOError("The user canceled the OAuth flow")
 
     /**
      * A helper object with properties that can help you interact with errors of this type

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sso/SSOError.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sso/SSOError.kt
@@ -10,16 +10,19 @@ public sealed class SSOError(
     /**
      * Indicates that no suitable browser was found on this device, and OAuth authentication cannot proceed.
      */
+
     public data object NoBrowserFound : SSOError("No supported browser was found on this device")
 
     /**
      * Indicates that no URI was found in the activity state, and OAuth authentication cannot proceed.
      */
+
     public data object NoURIFound : SSOError("No OAuth URI could be found in the bundle")
 
     /**
      * Indicates that the user canceled the OAuth flow. This is safe to ignore.
      */
+
     public data object UserCanceled : SSOError("The user canceled the OAuth flow")
 
     /**
@@ -29,6 +32,7 @@ public sealed class SSOError(
         /**
          * A string identifying the class of this Exception for serializing/deserializing the error within an Intent
          */
+
         public const val SSO_EXCEPTION: String = "com.stytch.sdk.common.sso.SSOError"
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerTokenType.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerTokenType.kt
@@ -6,6 +6,7 @@ import java.util.Locale
 /**
  * An enum representing the supported (consumer) token types that we can extract from a deeplink
  */
+
 public enum class ConsumerTokenType : TokenType {
     /**
      * A Consumer Email Magic Link deeplink
@@ -30,12 +31,11 @@ public enum class ConsumerTokenType : TokenType {
     ;
 
     internal companion object {
-        fun fromString(typeString: String?): ConsumerTokenType {
-            return try {
+        fun fromString(typeString: String?): ConsumerTokenType =
+            try {
                 valueOf(typeString?.uppercase(Locale.ENGLISH)!!)
             } catch (_: Exception) {
                 UNKNOWN
             }
-        }
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -210,13 +210,14 @@ public object StytchClient {
         options: StytchClientOptions = StytchClientOptions(),
         callback: ((Boolean) -> Unit) = {},
     ) {
+        StorageHelper.initialize(context)
+        sessionStorage = ConsumerSessionStorage(StorageHelper)
         configurationManager.configure(
             client = StytchClientCommonConfiguration { callback(true) },
             context = context,
             publicToken = publicToken,
             options = options,
         )
-        sessionStorage = ConsumerSessionStorage(StorageHelper)
     }
 
     /**
@@ -560,7 +561,6 @@ public object StytchClient {
             configurationManager.externalScope.launch(configurationManager.dispatchers.io) {
                 val start = Date().time
                 sessionStorage.session?.let {
-                    println("THIS IS MY SESSION DATA: $it")
                     // if we have a session, it's expiration date has already been validated, now attempt
                     // to validate it with the Stytch servers
                     StytchApi.Sessions.authenticate(null).apply {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -62,6 +62,7 @@ import java.util.Date
  * The StytchClient object is your entrypoint to the Stytch Consumer SDK and is how you interact with all of our
  * supported authentication products.
  */
+
 public object StytchClient {
     internal val configurationManager = ConfigurationManager()
 

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -218,12 +218,6 @@ public object StytchClient {
         sessionStorage = ConsumerSessionStorage(StorageHelper)
     }
 
-    internal fun assertInitialized() {
-        if (!StytchApi.isInitialized) {
-            throw StytchSDKNotConfiguredError("StytchClient")
-        }
-    }
-
     /**
      * Exposes an instance of the [MagicLinks] interface whicih provides methods for sending and authenticating users
      * with Email Magic Links.
@@ -232,7 +226,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val magicLinks: MagicLinks by StytchLazyDelegate(::assertInitialized) {
+    public val magicLinks: MagicLinks by StytchLazyDelegate(StytchApi::assertInitialized) {
         MagicLinksImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -250,7 +244,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val otps: OTP by StytchLazyDelegate(::assertInitialized) {
+    public val otps: OTP by StytchLazyDelegate(StytchApi::assertInitialized) {
         OTPImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -267,7 +261,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val passwords: Passwords by StytchLazyDelegate(::assertInitialized) {
+    public val passwords: Passwords by StytchLazyDelegate(StytchApi::assertInitialized) {
         PasswordsImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -285,7 +279,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val sessions: Sessions by StytchLazyDelegate(::assertInitialized) {
+    public val sessions: Sessions by StytchLazyDelegate(StytchApi::assertInitialized) {
         SessionsImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -302,7 +296,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val biometrics: Biometrics by StytchLazyDelegate(::assertInitialized) {
+    public val biometrics: Biometrics by StytchLazyDelegate(StytchApi::assertInitialized) {
         BiometricsImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -323,7 +317,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val user: UserManagement by StytchLazyDelegate(::assertInitialized) {
+    public val user: UserManagement by StytchLazyDelegate(StytchApi::assertInitialized) {
         UserManagementImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -340,7 +334,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val oauth: OAuth by StytchLazyDelegate(::assertInitialized) {
+    public val oauth: OAuth by StytchLazyDelegate(StytchApi::assertInitialized) {
         OAuthImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -358,7 +352,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val passkeys: Passkeys by StytchLazyDelegate(::assertInitialized) {
+    public val passkeys: Passkeys by StytchLazyDelegate(StytchApi::assertInitialized) {
         PasskeysImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -375,7 +369,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val dfp: DFP by StytchLazyDelegate(::assertInitialized) {
+    public val dfp: DFP by StytchLazyDelegate(StytchApi::assertInitialized) {
         DFPImpl(
             configurationManager.dfpProvider,
             configurationManager.dispatchers,
@@ -391,7 +385,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val crypto: CryptoWallet by StytchLazyDelegate(::assertInitialized) {
+    public val crypto: CryptoWallet by StytchLazyDelegate(StytchApi::assertInitialized) {
         CryptoWalletImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -408,7 +402,7 @@ public object StytchClient {
      * StytchClient.configure()
      */
     @JvmStatic
-    public val totp: TOTP by StytchLazyDelegate(::assertInitialized) {
+    public val totp: TOTP by StytchLazyDelegate(StytchApi::assertInitialized) {
         TOTPImpl(
             configurationManager.externalScope,
             configurationManager.dispatchers,
@@ -417,7 +411,7 @@ public object StytchClient {
         )
     }
 
-    internal val events: Events by StytchLazyDelegate(::assertInitialized) {
+    internal val events: Events by StytchLazyDelegate(StytchApi::assertInitialized) {
         EventsImpl(
             configurationManager.deviceInfo,
             configurationManager.appSessionId,
@@ -448,7 +442,7 @@ public object StytchClient {
         uri: Uri,
         sessionDurationMinutes: Int,
     ): DeeplinkHandledStatus {
-        assertInitialized()
+        StytchApi.assertInitialized()
         return withContext(configurationManager.dispatchers.io) {
             val token = uri.getQueryParameter(QUERY_TOKEN)
             if (token.isNullOrEmpty()) {
@@ -565,6 +559,7 @@ public object StytchClient {
             configurationManager.externalScope.launch(configurationManager.dispatchers.io) {
                 val start = Date().time
                 sessionStorage.session?.let {
+                    println("THIS IS MY SESSION DATA: $it")
                     // if we have a session, it's expiration date has already been validated, now attempt
                     // to validate it with the Stytch servers
                     StytchApi.Sessions.authenticate(null).apply {
@@ -600,5 +595,7 @@ public object StytchClient {
                 )
             }
         }
+
+        override fun getSessionToken(): String? = sessionStorage.sessionToken
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
@@ -17,6 +17,7 @@ public sealed class BiometricAvailability {
          * An enum describing why biometrics are unavailable on this device
          * @property message a string representation of why biometrics are unavailable
          */
+
         public enum class Reason(
             public val message: String,
         ) {
@@ -87,15 +88,18 @@ public sealed class BiometricAvailability {
      * Status indicating that the biometric key has been revoked. Usually this means the user has added a new
      * biometric or deleted all existing biometrics.
      */
+
     public data object RegistrationRevoked : BiometricAvailability()
 
     /**
      * Status indicating that biometrics are available, but no registrations have been made yet
      */
+
     public data object AvailableNoRegistrations : BiometricAvailability()
 
     /**
      * Status indicating that biometrics are available and there is already a biometric registration on device
      */
+
     public data object AvailableRegistered : BiometricAvailability()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
@@ -1,10 +1,12 @@
 package com.stytch.sdk.consumer.biometrics
 
 import androidx.biometric.BiometricManager
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 
 /**
  * Wrapper around BiometricManager results to provide friendly messaging for developers
  */
+@JacocoExcludeGenerated
 public sealed class BiometricAvailability {
     /**
      * Status indicating that biometrics are not available on this device for some reason
@@ -89,17 +91,17 @@ public sealed class BiometricAvailability {
      * biometric or deleted all existing biometrics.
      */
 
-    public data object RegistrationRevoked : BiometricAvailability()
+    @JacocoExcludeGenerated public data object RegistrationRevoked : BiometricAvailability()
 
     /**
      * Status indicating that biometrics are available, but no registrations have been made yet
      */
 
-    public data object AvailableNoRegistrations : BiometricAvailability()
+    @JacocoExcludeGenerated public data object AvailableNoRegistrations : BiometricAvailability()
 
     /**
      * Status indicating that biometrics are available and there is already a biometric registration on device
      */
 
-    public data object AvailableRegistered : BiometricAvailability()
+    @JacocoExcludeGenerated public data object AvailableRegistered : BiometricAvailability()
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/Biometrics.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/Biometrics.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture
  * The Biometrics interface provides methods for detecting biometric availability, registering, authenticating, and
  * removing biometrics identifiers.
  */
+
 public interface Biometrics {
     /**
      * Data class used for wrapping parameters used with Biometrics registration flow

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture
  * The CryptoWallet interface provides methods for authenticating a user using one of the supported Crypto Wallets
  * (Ethereum or Solana)
  */
+
 public interface CryptoWallet {
     /**
      * A data class wrapping the parameters needed to begin a crypto wallet authentication flow

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/MagicLinks.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * MagicLinks interface that encompasses authentication functions as well as other related functionality
  */
+
 public interface MagicLinks {
     /**
      * Data class used for wrapping parameters used with MagicLinks authentication
@@ -61,6 +62,7 @@ public interface MagicLinks {
     /**
      * Provides all possible ways to call EmailMagicLinks endpoints
      */
+
     public interface EmailMagicLinks {
         /**
          * Data class used for wrapping parameters used with MagicLinks.EmailMagicLinks.loginOrCreate

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -12,6 +12,7 @@ import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.events.EventsAPI
 import com.stytch.sdk.common.network.ApiService
+import com.stytch.sdk.common.network.CommonApi
 import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchAuthHeaderInterceptor
 import com.stytch.sdk.common.network.StytchDFPInterceptor
@@ -51,7 +52,7 @@ import com.stytch.sdk.consumer.network.models.UpdateUserResponseData
 import com.stytch.sdk.consumer.network.models.UserData
 import com.stytch.sdk.consumer.network.models.UserSearchResponseData
 
-internal object StytchApi {
+internal object StytchApi : CommonApi {
     internal lateinit var publicToken: String
     private lateinit var deviceInfo: DeviceInfo
 
@@ -69,7 +70,7 @@ internal object StytchApi {
         ) { StytchClient.sessionStorage.sessionToken }
     }
 
-    internal fun configure(
+    override fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
     ) {
@@ -77,7 +78,7 @@ internal object StytchApi {
         this.deviceInfo = deviceInfo
     }
 
-    internal fun configureDFP(
+    override fun configureDFP(
         dfpProvider: DFPProvider,
         captchaProvider: CaptchaProvider,
         dfpProtectedAuthEnabled: Boolean,
@@ -854,7 +855,7 @@ internal object StytchApi {
             }
     }
 
-    suspend fun getBootstrapData(): StytchResult<BootstrapData> =
+    override suspend fun getBootstrapData(): StytchResult<BootstrapData> =
         safeConsumerApiCall {
             apiService.getBootstrapData(publicToken = publicToken)
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -15,7 +15,7 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 
 @Suppress("TooManyFunctions")
-internal interface StytchApiService : ApiService {
+internal interface StytchApiService : ApiService.ApiEndpoints {
     //region Magic Links
     @POST("magic_links/email/login_or_create")
     @DFPPAEnabled

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerRequests.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.consumer.network.models
 
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.models.Locale
@@ -9,7 +8,6 @@ import com.stytch.sdk.common.network.models.NameData
 internal object ConsumerRequests {
     object MagicLinks {
         object Email {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class LoginOrCreateUserRequest(
                 val email: String,
@@ -27,7 +25,6 @@ internal object ConsumerRequests {
             )
         }
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             val token: String,
@@ -37,7 +34,6 @@ internal object ConsumerRequests {
             val sessionDurationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SendRequest(
             val email: String,
@@ -60,7 +56,6 @@ internal object ConsumerRequests {
     }
 
     object Passwords {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class CreateRequest(
             val email: String,
@@ -69,7 +64,6 @@ internal object ConsumerRequests {
             val sessionDurationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             val email: String,
@@ -78,7 +72,6 @@ internal object ConsumerRequests {
             val sessionDurationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetByEmailStartRequest(
             val email: String,
@@ -97,7 +90,6 @@ internal object ConsumerRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetByEmailRequest(
             val token: String,
@@ -109,7 +101,6 @@ internal object ConsumerRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class ResetBySessionRequest(
             val password: String,
@@ -118,14 +109,12 @@ internal object ConsumerRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class StrengthCheckRequest(
             val email: String?,
             val password: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class PasswordResetByExistingPasswordRequest(
             val email: String,
@@ -139,7 +128,6 @@ internal object ConsumerRequests {
     }
 
     object OTP {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SMS(
             @Json(name = "phone_number")
@@ -151,7 +139,6 @@ internal object ConsumerRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class WhatsApp(
             @Json(name = "phone_number")
@@ -161,7 +148,6 @@ internal object ConsumerRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class Email(
             val email: String,
@@ -174,7 +160,6 @@ internal object ConsumerRequests {
             val locale: Locale? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class Authenticate(
             val token: String,
@@ -186,14 +171,12 @@ internal object ConsumerRequests {
     }
 
     object Biometrics {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class RegisterStartRequest(
             @Json(name = "public_key")
             val publicKey: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class RegisterRequest(
             val signature: String,
@@ -203,14 +186,12 @@ internal object ConsumerRequests {
             val sessionDurationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateStartRequest(
             @Json(name = "public_key")
             val publicKey: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             val signature: String,
@@ -223,7 +204,6 @@ internal object ConsumerRequests {
 
     object OAuth {
         object Google {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class AuthenticateRequest(
                 @Json(name = "id_token")
@@ -235,7 +215,6 @@ internal object ConsumerRequests {
         }
 
         object ThirdParty {
-            @Keep
             @JsonClass(generateAdapter = true)
             data class AuthenticateRequest(
                 val token: String,
@@ -254,7 +233,6 @@ internal object ConsumerRequests {
     }
 
     object User {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class UpdateRequest(
             val name: NameData? = null,
@@ -262,7 +240,6 @@ internal object ConsumerRequests {
             val untrustedMetadata: Map<String, Any?>? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class SearchRequest(
             val email: String,
@@ -270,7 +247,6 @@ internal object ConsumerRequests {
     }
 
     object WebAuthn {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class RegisterStartRequest(
             val domain: String,
@@ -282,14 +258,12 @@ internal object ConsumerRequests {
             val isPasskey: Boolean? = false,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class RegisterRequest(
             @Json(name = "public_key_credential")
             val publicKeyCredential: String,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateStartRequest(
             @Json(name = "user_id")
@@ -299,7 +273,6 @@ internal object ConsumerRequests {
             val isPasskey: Boolean? = false,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "public_key_credential")
@@ -314,7 +287,6 @@ internal object ConsumerRequests {
             val sessionToken: String? = null,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class UpdateRequest(
             val name: String,
@@ -322,7 +294,6 @@ internal object ConsumerRequests {
     }
 
     object Crypto {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class CryptoWalletAuthenticateStartRequest(
             @Json(name = "crypto_wallet_address")
@@ -331,7 +302,6 @@ internal object ConsumerRequests {
             val cryptoWalletType: CryptoWalletType,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class CryptoWalletAuthenticateRequest(
             @Json(name = "crypto_wallet_address")
@@ -345,14 +315,12 @@ internal object ConsumerRequests {
     }
 
     object TOTP {
-        @Keep
         @JsonClass(generateAdapter = true)
         data class TOTPCreateRequest(
             @Json(name = "expiration_minutes")
             val expirationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class TOTPAuthenticateRequest(
             @Json(name = "totp_code")
@@ -361,7 +329,6 @@ internal object ConsumerRequests {
             val sessionDurationMinutes: Int,
         )
 
-        @Keep
         @JsonClass(generateAdapter = true)
         data class TOTPRecoverRequest(
             @Json(name = "recovery_code")

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk.consumer.network.models
 
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.StytchDataResponse
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
@@ -8,79 +7,86 @@ import com.stytch.sdk.common.network.models.OTPSendResponseData
 
 internal object ConsumerResponses {
     object Passwords {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class PasswordsCreateResponse(data: CreateResponse) : StytchDataResponse<CreateResponse>(data)
+        class PasswordsCreateResponse(
+            data: CreateResponse,
+        ) : StytchDataResponse<CreateResponse>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class PasswordsStrengthCheckResponse(data: StrengthCheckResponse) :
-            StytchDataResponse<StrengthCheckResponse>(data)
+        class PasswordsStrengthCheckResponse(
+            data: StrengthCheckResponse,
+        ) : StytchDataResponse<StrengthCheckResponse>(data)
     }
 
     object Biometrics {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class RegisterResponse(data: BiometricsAuthData) :
-            StytchDataResponse<BiometricsAuthData>(data)
+        class RegisterResponse(
+            data: BiometricsAuthData,
+        ) : StytchDataResponse<BiometricsAuthData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class AuthenticateResponse(data: BiometricsAuthData) :
-            StytchDataResponse<BiometricsAuthData>(data)
+        class AuthenticateResponse(
+            data: BiometricsAuthData,
+        ) : StytchDataResponse<BiometricsAuthData>(data)
     }
 
     object User {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class UserResponse(data: UserData) : StytchDataResponse<UserData>(data)
+        class UserResponse(
+            data: UserData,
+        ) : StytchDataResponse<UserData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class DeleteFactorResponse(data: DeleteAuthenticationFactorData) :
-            StytchDataResponse<DeleteAuthenticationFactorData>(data)
+        class DeleteFactorResponse(
+            data: DeleteAuthenticationFactorData,
+        ) : StytchDataResponse<DeleteAuthenticationFactorData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class UpdateUserResponse(data: UpdateUserResponseData) : StytchDataResponse<UpdateUserResponseData>(data)
+        class UpdateUserResponse(
+            data: UpdateUserResponseData,
+        ) : StytchDataResponse<UpdateUserResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class UserSearchResponse(data: UserSearchResponseData) : StytchDataResponse<UserSearchResponseData>(data)
+        class UserSearchResponse(
+            data: UserSearchResponseData,
+        ) : StytchDataResponse<UserSearchResponseData>(data)
     }
 
     object OAuth {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class OAuthAuthenticateResponse(data: OAuthData) : StytchDataResponse<OAuthData>(data)
+        class OAuthAuthenticateResponse(
+            data: OAuthData,
+        ) : StytchDataResponse<OAuthData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class NativeOAuthAuthenticateResponse(data: NativeOAuthData) : StytchDataResponse<NativeOAuthData>(data)
+        class NativeOAuthAuthenticateResponse(
+            data: NativeOAuthData,
+        ) : StytchDataResponse<NativeOAuthData>(data)
     }
 
     object WebAuthn {
-        @Keep
         @JsonClass(generateAdapter = true)
-        class RegisterStartResponse(data: WebAuthnRegisterStartData) :
-            StytchDataResponse<WebAuthnRegisterStartData>(data)
+        class RegisterStartResponse(
+            data: WebAuthnRegisterStartData,
+        ) : StytchDataResponse<WebAuthnRegisterStartData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class RegisterResponse(data: WebAuthnRegisterData) : StytchDataResponse<WebAuthnRegisterData>(data)
+        class RegisterResponse(
+            data: WebAuthnRegisterData,
+        ) : StytchDataResponse<WebAuthnRegisterData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class AuthenticateResponse(data: WebAuthnAuthenticateStartData) :
-            StytchDataResponse<WebAuthnAuthenticateStartData>(data)
+        class AuthenticateResponse(
+            data: WebAuthnAuthenticateStartData,
+        ) : StytchDataResponse<WebAuthnAuthenticateStartData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
-        class UpdateResponse(data: WebAuthnUpdateResponseData) : StytchDataResponse<WebAuthnUpdateResponseData>(data)
+        class UpdateResponse(
+            data: WebAuthnUpdateResponseData,
+        ) : StytchDataResponse<WebAuthnUpdateResponseData>(data)
     }
 
     object Crypto {
-        @Keep
         @JsonClass(generateAdapter = true)
         class AuthenticateStartResponse(
             data: CryptoWalletAuthenticateStartResponseData,
@@ -88,40 +94,39 @@ internal object ConsumerResponses {
     }
 
     object TOTP {
-        @Keep
         @JsonClass(generateAdapter = true)
         class TOTPCreateResponse(
             data: TOTPCreateResponseData,
         ) : StytchDataResponse<TOTPCreateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class TOTPAuthenticateResponse(
             data: TOTPAuthenticateResponseData,
         ) : StytchDataResponse<TOTPAuthenticateResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class TOTPRecoveryCodesResponse(
             data: TOTPRecoveryCodesResponseData,
         ) : StytchDataResponse<TOTPRecoveryCodesResponseData>(data)
 
-        @Keep
         @JsonClass(generateAdapter = true)
         class TOTPRecoverResponse(
             data: TOTPRecoverResponseData,
         ) : StytchDataResponse<TOTPRecoverResponseData>(data)
     }
 
-    @Keep
     @JsonClass(generateAdapter = true)
-    class AuthenticateResponse(data: AuthData) : StytchDataResponse<AuthData>(data)
+    class AuthenticateResponse(
+        data: AuthData,
+    ) : StytchDataResponse<AuthData>(data)
 
-    @Keep
     @JsonClass(generateAdapter = true)
-    class LoginOrCreateOTPResponse(data: LoginOrCreateOTPData) : StytchDataResponse<LoginOrCreateOTPData>(data)
+    class LoginOrCreateOTPResponse(
+        data: LoginOrCreateOTPData,
+    ) : StytchDataResponse<LoginOrCreateOTPData>(data)
 
-    @Keep
     @JsonClass(generateAdapter = true)
-    class OTPSendResponse(data: OTPSendResponseData) : StytchDataResponse<OTPSendResponseData>(data)
+    class OTPSendResponse(
+        data: OTPSendResponseData,
+    ) : StytchDataResponse<OTPSendResponseData>(data)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.consumer.network.models
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.models.AuthenticationFactor
@@ -21,7 +20,6 @@ import com.stytch.sdk.common.utils.IEnumValue
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
-@Keep
 public interface IAuthData : CommonAuthenticationData {
     public val session: SessionData
     public override val sessionJwt: String
@@ -29,12 +27,10 @@ public interface IAuthData : CommonAuthenticationData {
     public val user: UserData
 }
 
-@Keep
 public interface INativeOAuthData : IAuthData {
     public val userCreated: Boolean
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class AuthData(
@@ -51,7 +47,6 @@ public data class AuthData(
 ) : IAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class SessionData(
@@ -71,7 +66,6 @@ public data class SessionData(
     @Json(name = "authentication_factors")
     val authenticationFactors: List<AuthenticationFactor>,
 ) : Parcelable {
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class AttributesData(
@@ -82,7 +76,6 @@ public data class SessionData(
     ) : Parcelable
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class UserData(
@@ -114,7 +107,6 @@ public data class UserData(
     val untrustedMetadata: @RawValue Map<String, Any?>?,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class CreateResponse(
@@ -139,7 +131,6 @@ public data class CreateResponse(
 ) : IAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class BiometricsAuthData(
@@ -158,7 +149,6 @@ public data class BiometricsAuthData(
 ) : IAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class DeleteAuthenticationFactorData(
@@ -169,7 +159,6 @@ public data class DeleteAuthenticationFactorData(
     val user: UserData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class OAuthData(
@@ -193,7 +182,6 @@ public data class OAuthData(
     val providerValues: OAuthProviderValues,
 ) : IAuthData,
     Parcelable {
-    @Keep
     @JsonClass(generateAdapter = true)
     @Parcelize
     public data class OAuthProviderValues(
@@ -207,7 +195,6 @@ public data class OAuthData(
     ) : Parcelable
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class NativeOAuthData(
@@ -222,7 +209,6 @@ public data class NativeOAuthData(
 ) : INativeOAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class StrengthCheckResponse(
@@ -240,7 +226,6 @@ public data class StrengthCheckResponse(
     val strengthPolicy: StrengthPolicy,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class UpdateUserResponseData(
@@ -251,14 +236,12 @@ public data class UpdateUserResponseData(
     val user: UserData,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class UserSearchResponseData(
     val userType: UserType,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = false)
 @Parcelize
 public enum class UserType : Parcelable {
@@ -272,7 +255,6 @@ public enum class UserType : Parcelable {
     PASSWORDLESS,
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class WebAuthnRegisterStartData(
@@ -282,7 +264,6 @@ public data class WebAuthnRegisterStartData(
     val publicKeyCredentialCreationOptions: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class WebAuthnRegisterData(
@@ -301,7 +282,6 @@ public data class WebAuthnRegisterData(
 ) : Parcelable,
     IAuthData
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class WebAuthnAuthenticateStartData(
@@ -309,7 +289,6 @@ public data class WebAuthnAuthenticateStartData(
     val publicKeyCredentialRequestOptions: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class WebAuthnUpdateResponseData(
@@ -321,7 +300,6 @@ public data class WebAuthnUpdateResponseData(
     val webauthnRegistration: WebAuthNRegistrations,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = false)
 @Parcelize
 public enum class CryptoWalletType(
@@ -332,14 +310,12 @@ public enum class CryptoWalletType(
     SOLANA("solana"),
 }
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class CryptoWalletAuthenticateStartResponseData(
     val challenge: String,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPCreateResponseData(
@@ -352,7 +328,6 @@ public data class TOTPCreateResponseData(
     val recoveryCodes: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPAuthenticateResponseData(
@@ -367,7 +342,6 @@ public data class TOTPAuthenticateResponseData(
 ) : IAuthData,
     Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPRecoveryCodesResponseData(
@@ -376,7 +350,6 @@ public data class TOTPRecoveryCodesResponseData(
     val totps: List<TOTPRecovery>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPRecovery(
@@ -387,7 +360,6 @@ public data class TOTPRecovery(
     val recoveryCodes: List<String>,
 ) : Parcelable
 
-@Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
 public data class TOTPRecoverResponseData(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture
  * The OAuth interface provides methods for authenticating a user via a native Google OneTap prompt or any of the
  * supported third-party OAuth providers, provided you have configured them within your Stytch Dashboard.
  */
+
 public interface OAuth {
     /**
      * The interface for authenticating a user with Google OneTap
@@ -117,6 +118,7 @@ public interface OAuth {
     /**
      * Provides start, authenticate, and signOut methods for native Google One Tap authentication
      */
+
     public interface GoogleOneTap {
         /**
          * Data class used for wrapping parameters to start a Google OneTap flow
@@ -176,6 +178,7 @@ public interface OAuth {
     /**
      * Provides a method for starting Third Party OAuth authentications
      */
+
     public interface ThirdParty {
         /**
          * The Third Party OAuth provider name

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
@@ -35,7 +35,7 @@ internal class ThirdPartyOAuthImpl(
         val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
         val token = StytchApi.publicToken
         val host =
-            StytchClient.bootstrapData.cnameDomain?.let {
+            StytchClient.configurationManager.bootstrapData.cnameDomain?.let {
                 "https://$it/v1/"
             } ?: if (StytchApi.isTestToken) TEST_API_URL else LIVE_API_URL
         val baseUrl = "${host}public/oauth/$providerName/start"
@@ -68,7 +68,7 @@ internal class ThirdPartyOAuthImpl(
                 val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
                 val token = StytchApi.publicToken
                 val host =
-                    StytchClient.bootstrapData.cnameDomain?.let {
+                    StytchClient.configurationManager.bootstrapData.cnameDomain?.let {
                         "https://$it/v1/"
                     } ?: if (StytchApi.isTestToken) TEST_API_URL else LIVE_API_URL
                 val baseUrl = "${host}public/oauth/$providerName/start"

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture
  * The OTP interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS, WhatsApp, and
  * Email.
  */
+
 public interface OTP {
     /**
      * Data class used for wrapping parameters used with OTP authentication
@@ -83,6 +84,7 @@ public interface OTP {
     /**
      * Provides all possible ways to call SMS OTP endpoints
      */
+
     public interface SmsOTP {
         /**
          * Data class used for wrapping parameters used with SMS OTP
@@ -164,6 +166,7 @@ public interface OTP {
     /**
      * Provides all possible ways to call WhatsApp OTP endpoints
      */
+
     public interface WhatsAppOTP {
         /**
          * Data class used for wrapping parameters used with WhatsApp OTP
@@ -239,6 +242,7 @@ public interface OTP {
     /**
      * Provides all possible ways to call Email OTP endpoints
      */
+
     public interface EmailOTP {
         /**
          * Data class used for wrapping parameters used with Email OTP

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture
  * The Passkeys interface provides methods for detecting Passkeys support, registering, and authenticating with
  * Passkeys.
  */
+
 public interface Passkeys {
     /**
      * Data class used for wrapping parameters used with Passkeys registration

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture
  * (either Dropbox’s [zxcvbn](https://github.com/dropbox/zxcvbn) or adjustable LUDS) to guide members towards creating
  * passwords that are easy for humans to remember but difficult for computers to crack.
  */
+
 public interface Passwords {
     /**
      * Data class used for wrapping parameters used with Passwords authentication

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/Sessions.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture
  * The Sessions interface provides methods for authenticating, updating, or revoking sessions, and properties to
  * retrieve the existing session token (opaque or JWT).
  */
+
 public interface Sessions {
     /**
      * Exposes a flow of session data

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/totp/TOTP.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture
  * The TOTP interface provides methods for creating and authenticating TOTP codes; retrieving recovery codes; and
  * consuming a recovery code
  */
+
 public interface TOTP {
     /**
      * A data class wrapping the parameters used in a TOTP create request

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserAuthenticationFactor.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserAuthenticationFactor.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
  * A [UserAuthenticationFactor] represents a primary authentication factor associated with a Stytch User
  * @param id The string representing the unique ID of this authentication factor
  */
+@JacocoExcludeGenerated
 public sealed class UserAuthenticationFactor(
     public open val id: String,
 ) {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagement.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagement.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture
  * The UserManagement interface provides methods for retrieving an authenticated user and deleting authentication
  * factors from an authenticated user.
  */
+
 public interface UserManagement {
     /**
      * Exposes a flow of user data

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BUI.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BUI.kt
@@ -27,7 +27,7 @@ public class StytchB2BUI private constructor(
     private val authHandler: StytchB2BAuthHandler
 
     internal val bootstrapData: BootstrapData
-        get() = StytchB2BClient.bootstrapData
+        get() = StytchB2BClient.configurationManager.bootstrapData
 
     init {
         require(activity != null) { "Missing required activity" }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/AuthenticationResult.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/AuthenticationResult.kt
@@ -6,8 +6,9 @@ import com.stytch.sdk.common.errors.StytchError
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
+@JacocoExcludeGenerated
 public sealed class AuthenticationResult : Parcelable {
-    public data object Authenticated : AuthenticationResult()
+    @JacocoExcludeGenerated public data object Authenticated : AuthenticationResult()
 
     @JacocoExcludeGenerated
     public data class Error(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/AuthenticationResult.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/AuthenticationResult.kt
@@ -1,12 +1,10 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.errors.StytchError
 import kotlinx.parcelize.Parcelize
 
-@Keep
 @Parcelize
 public sealed class AuthenticationResult : Parcelable {
     public data object Authenticated : AuthenticationResult()

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BEmailMagicLinkOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BEmailMagicLinkOptions.kt
@@ -1,13 +1,11 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class B2BEmailMagicLinkOptions(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthOptions.kt
@@ -1,13 +1,11 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class B2BOAuthOptions(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthProviderConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BOAuthProviderConfig.kt
@@ -1,13 +1,11 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class B2BOAuthProviderConfig(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
@@ -1,13 +1,11 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class B2BPasswordOptions(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/DirectLoginForSingleMembershipOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/DirectLoginForSingleMembershipOptions.kt
@@ -1,13 +1,11 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class DirectLoginForSingleMembershipOptions(

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProduct.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProduct.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2b.data
 /**
  * An enum class representing all of the supported Products that you can use with this SDK
  */
+
 public enum class StytchB2BProduct {
     /**
      * An enum value representing the Email Magic Links Product

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/StytchB2BProductConfig.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2b.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.b2b.network.models.MfaMethod
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
@@ -10,7 +9,6 @@ import com.stytch.sdk.ui.shared.data.SessionOptions
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class StytchB2BProductConfig

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseGetRedirectUrl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseGetRedirectUrl.kt
@@ -2,4 +2,4 @@ package com.stytch.sdk.ui.b2b.usecases
 
 import com.stytch.sdk.b2b.StytchB2BClient
 
-internal fun getRedirectUrl(): String = "${StytchB2BClient.publicToken}://b2b-ui"
+internal fun getRedirectUrl(): String = "${StytchB2BClient.configurationManager.publicToken}://b2b-ui"

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/StytchUI.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/StytchUI.kt
@@ -27,7 +27,7 @@ public class StytchUI private constructor(
     private val authHandler: StytchAuthHandler
 
     internal val bootstrapData: BootstrapData
-        get() = StytchClient.bootstrapData
+        get() = StytchClient.configurationManager.bootstrapData
 
     init {
         require(activity != null) { "Missing required activity" }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/EmailMagicLinksOptions.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2c.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
@@ -16,7 +15,6 @@ import kotlinx.parcelize.Parcelize
  * @property signupTemplateId The ID of an email template (defined in the Stytch Dashboard) for signup emails
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class EmailMagicLinksOptions

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/GoogleOAuthOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/GoogleOAuthOptions.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2c.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
@@ -11,7 +10,6 @@ import kotlinx.parcelize.Parcelize
  * @property clientId the client ID you used to configure Google OAuth
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class GoogleOAuthOptions

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OAuthOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OAuthOptions.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2c.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import kotlinx.parcelize.Parcelize
@@ -13,7 +12,6 @@ import kotlinx.parcelize.Parcelize
  * @property providers A list of [OAuthProvider]s that you would like to support
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class OAuthOptions

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OAuthProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OAuthProvider.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.R
 /**
  * An enum class representing all of the supported OAuth providers
  */
+
 public enum class OAuthProvider(
     @DrawableRes internal val iconDrawable: Int,
     @StringRes internal val iconText: Int,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OTPMethods.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OTPMethods.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 /**
  * An enum class representing all of the supported OTP methods
  */
+
 public enum class OTPMethods {
     /**
      * An enum value representing the SMS OTP method

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OTPOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/OTPOptions.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2c.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
@@ -17,7 +16,6 @@ import kotlinx.parcelize.Parcelize
  * @property signupTemplateId The ID of an OTP template (defined in the Stytch Dashboard) for signup requests
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class OTPOptions

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/PasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/PasswordOptions.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2c.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
@@ -15,7 +14,6 @@ import kotlinx.parcelize.Parcelize
  * @property resetPasswordTemplateId The ID of an email template (defined in the Stytch Dashboard) for password resets
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class PasswordOptions

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProduct.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProduct.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.ui.b2c.data
 /**
  * An enum class representing all of the supported Products that you can use with this SDK
  */
+
 public enum class StytchProduct {
     /**
      * An enum value representing the Email Magic Links Product

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProductConfig.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.b2c.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
@@ -19,7 +18,6 @@ import kotlinx.parcelize.Parcelize
  * @property googleOauthOptions an instance of [GoogleOAuthOptions]
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class StytchProductConfig

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/EMLConfirmationScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/EMLConfirmationScreenViewModel.kt
@@ -82,7 +82,7 @@ internal class EMLConfirmationScreenViewModel(
                 val parameters =
                     passwordOptions.toResetByEmailStartParameters(
                         emailAddress = emailAddress,
-                        publicToken = stytchClient.publicToken,
+                        publicToken = stytchClient.configurationManager.publicToken,
                         locale = locale,
                     )
                 when (val result = stytchClient.passwords.resetByEmailStart(parameters)) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
@@ -147,8 +147,8 @@ internal class MainScreenViewModel(
             OAuth.ThirdParty.StartParameters(
                 context = context,
                 oAuthRequestIdentifier = STYTCH_THIRD_PARTY_OAUTH_REQUEST_ID,
-                loginRedirectUrl = "${StytchClient.publicToken}://oauth",
-                signupRedirectUrl = "${StytchClient.publicToken}://oauth",
+                loginRedirectUrl = "${StytchClient.configurationManager.publicToken}://oauth",
+                signupRedirectUrl = "${StytchClient.configurationManager.publicToken}://oauth",
             )
         when (provider) {
             OAuthProvider.AMAZON -> stytchClient.oauth.amazon.start(parameters)
@@ -297,7 +297,7 @@ internal class MainScreenViewModel(
         val parameters =
             emailMagicLinksOptions.toParameters(
                 emailAddress = emailAddress,
-                publicToken = stytchClient.publicToken,
+                publicToken = stytchClient.configurationManager.publicToken,
                 locale = locale,
             )
         return when (val result = stytchClient.magicLinks.email.loginOrCreate(parameters = parameters)) {
@@ -365,7 +365,7 @@ internal class MainScreenViewModel(
         val parameters =
             passwordOptions.toResetByEmailStartParameters(
                 emailAddress = emailAddress,
-                publicToken = stytchClient.publicToken,
+                publicToken = stytchClient.configurationManager.publicToken,
                 locale = locale,
             )
         return when (val result = stytchClient.passwords.resetByEmailStart(parameters = parameters)) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/NewUserScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/NewUserScreenViewModel.kt
@@ -43,7 +43,7 @@ internal class NewUserScreenViewModel(
         val parameters =
             emailMagicLinksOptions.toParameters(
                 emailAddress = emailState.emailAddress,
-                publicToken = stytchClient.publicToken,
+                publicToken = stytchClient.configurationManager.publicToken,
                 locale = locale,
             )
         scope.launch {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModel.kt
@@ -177,7 +177,7 @@ internal class OTPConfirmationScreenViewModel(
                 val parameters =
                     passwordOptions.toResetByEmailStartParameters(
                         emailAddress = emailAddress,
-                        publicToken = stytchClient.publicToken,
+                        publicToken = stytchClient.configurationManager.publicToken,
                         locale = locale,
                     )
                 when (val result = stytchClient.passwords.resetByEmailStart(parameters)) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/PasswordResetSentScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/PasswordResetSentScreenViewModel.kt
@@ -82,7 +82,7 @@ internal class PasswordResetSentScreenViewModel(
             val parameters =
                 emailMagicLinksOptions.toParameters(
                     emailAddress = emailAddress,
-                    publicToken = stytchClient.publicToken,
+                    publicToken = stytchClient.configurationManager.publicToken,
                     locale = locale,
                 )
             when (val result = stytchClient.magicLinks.email.loginOrCreate(parameters)) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModel.kt
@@ -132,7 +132,7 @@ internal class ReturningUserScreenViewModel(
         val parameters =
             passwordOptions.toResetByEmailStartParameters(
                 emailAddress = email,
-                publicToken = stytchClient.publicToken,
+                publicToken = stytchClient.configurationManager.publicToken,
                 locale = locale,
             )
         when (val result = stytchClient.passwords.resetByEmailStart(parameters)) {
@@ -181,7 +181,7 @@ internal class ReturningUserScreenViewModel(
             val parameters =
                 emailMagicLinksOptions.toParameters(
                     emailAddress = uiState.value.emailState.emailAddress,
-                    publicToken = stytchClient.publicToken,
+                    publicToken = stytchClient.configurationManager.publicToken,
                     locale = locale,
                 )
             when (val result = stytchClient.magicLinks.email.loginOrCreate(parameters)) {
@@ -270,7 +270,7 @@ internal class ReturningUserScreenViewModel(
             val parameters =
                 passwordOptions.toResetByEmailStartParameters(
                     emailAddress = uiState.value.emailState.emailAddress,
-                    publicToken = stytchClient.publicToken,
+                    publicToken = stytchClient.configurationManager.publicToken,
                     locale = locale,
                 )
             when (val result = stytchClient.passwords.resetByEmailStart(parameters = parameters)) {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/SessionOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/SessionOptions.kt
@@ -1,7 +1,6 @@
 package com.stytch.sdk.ui.shared.data
 
 import android.os.Parcelable
-import androidx.annotation.Keep
 import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
@@ -12,7 +11,6 @@ import kotlinx.parcelize.Parcelize
  * @property sessionDurationMinutes The number of minutes that a granted session should be active. Defaults to 30
  */
 @Parcelize
-@Keep
 @JsonClass(generateAdapter = true)
 @JacocoExcludeGenerated
 public data class SessionOptions

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -21,11 +21,7 @@ import com.stytch.sdk.utils.verifyDelete
 import com.stytch.sdk.utils.verifyGet
 import com.stytch.sdk.utils.verifyPost
 import com.stytch.sdk.utils.verifyPut
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
 import kotlinx.coroutines.runBlocking
-import okhttp3.Interceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -47,16 +43,11 @@ internal class StytchB2BApiServiceTest {
         mockWebServer = MockWebServer()
         mockWebServer.start(12345)
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
-        val chain = slot<Interceptor.Chain>()
         apiService =
             ApiService
                 .getInitialRetrofitInstance(
                     mockWebServer.url("/").toString(),
-                    mockk {
-                        every { intercept(capture(chain)) } answers {
-                            chain.captured.proceed(chain.captured.request())
-                        }
-                    },
+                    null,
                 ).create(StytchB2BApiService::class.java)
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -44,11 +44,7 @@ internal class StytchB2BApiServiceTest {
         mockWebServer.start(12345)
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
         apiService =
-            ApiService
-                .getInitialRetrofitInstance(
-                    mockWebServer.url("/").toString(),
-                    null,
-                ).create(StytchB2BApiService::class.java)
+            ApiService(mockWebServer.url("/").toString()).retrofit.create(StytchB2BApiService::class.java)
     }
 
     @After

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -21,7 +21,11 @@ import com.stytch.sdk.utils.verifyDelete
 import com.stytch.sdk.utils.verifyGet
 import com.stytch.sdk.utils.verifyPost
 import com.stytch.sdk.utils.verifyPut
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -43,13 +47,17 @@ internal class StytchB2BApiServiceTest {
         mockWebServer = MockWebServer()
         mockWebServer.start(12345)
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        val chain = slot<Interceptor.Chain>()
         apiService =
-            ApiService.createApiService(
-                mockWebServer.url("/").toString(),
-                null,
-                null,
-                StytchB2BApiService::class.java,
-            )
+            ApiService
+                .getInitialRetrofitInstance(
+                    mockWebServer.url("/").toString(),
+                    mockk {
+                        every { intercept(capture(chain)) } answers {
+                            chain.captured.proceed(chain.captured.request())
+                        }
+                    },
+                ).create(StytchB2BApiService::class.java)
     }
 
     @After

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -95,12 +95,6 @@ internal class StytchB2BApiTest {
         assert(StytchB2BApi.isInitialized)
     }
 
-    @Test(expected = StytchSDKNotConfiguredError::class)
-    fun `StytchB2BApi apiService throws exception when not configured`() {
-        every { StytchB2BApi.isInitialized } returns false
-        StytchB2BApi.apiService
-    }
-
     @Test
     fun `StytchB2BApi apiService is available when configured`() {
         StytchB2BClient.configure(mContextMock, "")

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -91,7 +91,7 @@ internal class StytchB2BApiTest {
 
     @Test
     fun `StytchB2BApi isInitialized returns correctly based on configuration state`() {
-        StytchB2BApi.configure("publicToken", DeviceInfo())
+        StytchB2BApi.configure("publicToken", DeviceInfo(), { null })
         assert(StytchB2BApi.isInitialized)
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
@@ -67,8 +67,8 @@ internal class OAuthImplTest {
         every { mockSessionStorage.lastAuthMethodUsed = any() } just runs
         mockkObject(StytchB2BClient)
         every { StytchB2BClient.events } returns mockk(relaxed = true)
-        StytchB2BClient.deviceInfo = mockk(relaxed = true)
-        StytchB2BClient.appSessionId = "app-session-id"
+        StytchB2BClient.configurationManager.deviceInfo = mockk(relaxed = true)
+        StytchB2BClient.configurationManager.appSessionId = "app-session-id"
         impl =
             OAuthImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -10,11 +10,7 @@ import com.stytch.sdk.utils.verifyDelete
 import com.stytch.sdk.utils.verifyGet
 import com.stytch.sdk.utils.verifyPost
 import com.stytch.sdk.utils.verifyPut
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
 import kotlinx.coroutines.runBlocking
-import okhttp3.Interceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -36,16 +32,11 @@ internal class StytchApiServiceTests {
         mockWebServer = MockWebServer()
         mockWebServer.start(12345)
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
-        val chain = slot<Interceptor.Chain>()
         apiService =
             ApiService
                 .getInitialRetrofitInstance(
                     mockWebServer.url("/").toString(),
-                    mockk {
-                        every { intercept(capture(chain)) } answers {
-                            chain.captured.proceed(chain.captured.request())
-                        }
-                    },
+                    null,
                 ).create(StytchApiService::class.java)
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiServiceTests.kt
@@ -32,12 +32,7 @@ internal class StytchApiServiceTests {
         mockWebServer = MockWebServer()
         mockWebServer.start(12345)
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
-        apiService =
-            ApiService
-                .getInitialRetrofitInstance(
-                    mockWebServer.url("/").toString(),
-                    null,
-                ).create(StytchApiService::class.java)
+        apiService = ApiService(mockWebServer.url("/").toString()).retrofit.create(StytchApiService::class.java)
     }
 
     @After

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -80,7 +80,7 @@ internal class StytchApiTest {
 
     @Test
     fun `StytchApi isInitialized returns correctly based on configuration state`() {
-        StytchApi.configure("publicToken", DeviceInfo())
+        StytchApi.configure("publicToken", DeviceInfo(), { null })
         assert(StytchApi.isInitialized)
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -84,12 +84,6 @@ internal class StytchApiTest {
         assert(StytchApi.isInitialized)
     }
 
-    @Test(expected = StytchSDKNotConfiguredError::class)
-    fun `StytchApi apiService throws exception when not configured`() {
-        every { StytchApi.isInitialized } returns false
-        StytchApi.apiService
-    }
-
     @Test
     fun `StytchApi apiService is available when configured`() {
         StytchClient.configure(mContextMock, "")

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -64,8 +64,8 @@ internal class OAuthImplTest {
         mockkObject(StytchClient)
         every { StytchClient.events } returns mockk(relaxed = true)
         every { StytchApi.isInitialized } returns true
-        StytchClient.deviceInfo = mockk(relaxed = true)
-        StytchClient.appSessionId = "app-session-id"
+        StytchClient.configurationManager.deviceInfo = mockk(relaxed = true)
+        StytchClient.configurationManager.appSessionId = "app-session-id"
         impl =
             OAuthImpl(
                 externalScope = TestScope(),

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/EMLConfirmationScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/EMLConfirmationScreenViewModelTest.kt
@@ -86,7 +86,7 @@ internal class EMLConfirmationScreenViewModelTest {
                     any(),
                 )
             } returns StytchResult.Success(BasicData(200, ""))
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val eventFlow =
                 async {
                     viewModel.eventFlow.first()
@@ -109,7 +109,7 @@ internal class EMLConfirmationScreenViewModelTest {
     @Test
     fun `sendResetPasswordEmail delegates to correct method and updates state on error`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             coEvery { mockStytchClient.passwords.resetByEmailStart(any()) } returns
                 StytchResult.Error(
                     StytchInternalError(message = "Testing error state"),

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
@@ -322,7 +322,7 @@ internal class MainScreenViewModelTest {
     @Test
     fun `sendEmailMagicLinkForReturningUserAndGetNavigationRoute returns nav route on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             coEvery { mockStytchClient.magicLinks.email.loginOrCreate(any()) } returns StytchResult.Success(mockk())
             val route =
                 viewModel.sendEmailMagicLinkForReturningUserAndGetNavigationRoute(
@@ -337,7 +337,7 @@ internal class MainScreenViewModelTest {
     @Test
     fun `sendEmailMagicLinkForReturningUserAndGetNavigationRoute updates state and returns null on error`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             coEvery { mockStytchClient.magicLinks.email.loginOrCreate(any()) } returns
                 StytchResult.Error(
                     StytchAPIError(
@@ -399,7 +399,7 @@ internal class MainScreenViewModelTest {
     @Test
     fun `sendResetPasswordForReturningUserAndGetNavigationRoute returns nav route on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             coEvery {
                 mockStytchClient.passwords.resetByEmailStart(any())
             } returns StytchResult.Success(mockk(relaxed = true))
@@ -416,7 +416,7 @@ internal class MainScreenViewModelTest {
     @Test
     fun `sendResetPasswordForReturningUserAndGetNavigationRoute updates state and returns null on error`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             coEvery { mockStytchClient.passwords.resetByEmailStart(any()) } returns
                 StytchResult.Error(
                     StytchAPIError(

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/NewUserScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/NewUserScreenViewModelTest.kt
@@ -64,7 +64,7 @@ internal class NewUserScreenViewModelTest {
     @Test
     fun `sendEmailMagicLink updates state and emits correct event on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Success<BasicData> = mockk(relaxed = true)
             val eventFlow =
                 async {
@@ -82,7 +82,7 @@ internal class NewUserScreenViewModelTest {
     @Test
     fun `sendEmailMagicLink updates state on error`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModelTest.kt
@@ -230,7 +230,7 @@ internal class OTPConfirmationScreenViewModelTest {
     @Test
     fun `sendResetPasswordEmail emits correct event on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Success<BasicData> = mockk(relaxed = true)
             val eventFlow =
                 async {
@@ -247,7 +247,7 @@ internal class OTPConfirmationScreenViewModelTest {
     @Test
     fun `sendResetPasswordEmail updates state on failure`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/PasswordResetSentScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/PasswordResetSentScreenViewModelTest.kt
@@ -97,7 +97,7 @@ internal class PasswordResetSentScreenViewModelTest {
     @Test
     fun `sendEML updates state and emits event on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Success<BasicData> = mockk(relaxed = true)
             val eventFlow =
                 async {
@@ -115,7 +115,7 @@ internal class PasswordResetSentScreenViewModelTest {
     @Test
     fun `sendEML updates state on failure`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModelTest.kt
@@ -106,7 +106,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `authenticate emits correct event on reset_password success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns
@@ -136,7 +136,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `authenticate updates state on reset_password failure`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns
@@ -194,7 +194,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `sendEML updates state and emits event on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Success<BasicData> = mockk(relaxed = true)
             val eventFlow =
                 async {
@@ -212,7 +212,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `sendEML updates state on failure`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns
@@ -268,7 +268,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `onForgotPasswordClicked updates state and emits event on success`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Success<BasicData> = mockk(relaxed = true)
             val eventFlow =
                 async {
@@ -286,7 +286,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `onForgotPasswordClicked updates state on failure`() =
         runTest(dispatcher) {
-            every { mockStytchClient.publicToken } returns "publicToken"
+            every { mockStytchClient.configurationManager.publicToken } returns "publicToken"
             val result: StytchResult.Error =
                 mockk(relaxed = true) {
                     every { exception } returns

--- a/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/MemberViewModel.kt
+++ b/workbench-apps/b2b-workbench/src/main/java/com/stytch/exampleapp/b2b/MemberViewModel.kt
@@ -28,27 +28,28 @@ class MemberViewModel : ViewModel() {
     fun updateMemberName() {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
-                StytchB2BClient.member.update(
-                    Member.UpdateParams(name = nameState.text),
-                ).toFriendlyDisplay()
+                StytchB2BClient.member
+                    .update(
+                        Member.UpdateParams(name = nameState.text),
+                    ).toFriendlyDisplay()
         }
     }
 
     fun deleteMfaPhoneNumber() {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
-                StytchB2BClient.member.deleteFactor(
-                    MemberAuthenticationFactor.MfaPhoneNumber,
-                ).toFriendlyDisplay()
+                StytchB2BClient.member
+                    .deleteFactor(
+                        MemberAuthenticationFactor.MfaPhoneNumber,
+                    ).toFriendlyDisplay()
         }
     }
 
-    private fun CoroutineScope.launchAndToggleLoadingState(block: suspend () -> Unit): DisposableHandle {
-        return launch {
+    private fun CoroutineScope.launchAndToggleLoadingState(block: suspend () -> Unit): DisposableHandle =
+        launch {
             _loadingState.value = true
             block()
         }.invokeOnCompletion {
             _loadingState.value = false
         }
-    }
 }

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/PasskeysViewModel.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/PasskeysViewModel.kt
@@ -16,7 +16,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class PasskeysViewModel(application: Application) : AndroidViewModel(application) {
+class PasskeysViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
     private val _currentResponse = MutableStateFlow("")
     val currentResponse: StateFlow<String>
         get() = _currentResponse
@@ -32,81 +34,87 @@ class PasskeysViewModel(application: Application) : AndroidViewModel(application
     var passkeyNameState by mutableStateOf(TextFieldValue(""))
 
     fun clearPasskeyRegistrations() {
-        viewModelScope.launch {
-            _loadingState.value = true
-            when (val user = StytchClient.user.getUser()) {
-                is StytchResult.Success -> {
-                    user.value.webauthnRegistrations.forEach {
-                        val response =
-                            StytchClient.user.deleteFactor(
-                                factor = UserAuthenticationFactor.WebAuthn(id = it.id),
-                            )
-                        println(response)
+        viewModelScope
+            .launch {
+                _loadingState.value = true
+                when (val user = StytchClient.user.getUser()) {
+                    is StytchResult.Success -> {
+                        user.value.webauthnRegistrations.forEach {
+                            val response =
+                                StytchClient.user.deleteFactor(
+                                    factor = UserAuthenticationFactor.WebAuthn(id = it.id),
+                                )
+                            println(response)
+                        }
                     }
+                    is StytchResult.Error -> println(user.exception)
                 }
-                is StytchResult.Error -> println(user.exception)
+                _currentResponse.value = "Cleared all registrations"
+            }.invokeOnCompletion {
+                _loadingState.value = false
             }
-            _currentResponse.value = "Cleared all registrations"
-        }.invokeOnCompletion {
-            _loadingState.value = false
-        }
     }
 
     fun registerPasskey(activity: FragmentActivity) {
-        viewModelScope.launch {
-            _loadingState.value = true
-            val result =
-                StytchClient.passkeys.register(
-                    Passkeys.RegisterParameters(
-                        activity = activity,
-                        domain = BuildConfig.PASSKEYS_DOMAIN,
-                    ),
-                )
-            _currentResponse.value = result.toFriendlyDisplay()
-            _currentPasskeyRegistrationId.value =
-                when (result) {
-                    is StytchResult.Success -> result.value.webauthnRegistrationId
-                    else -> ""
-                }
-        }.invokeOnCompletion {
-            _loadingState.value = false
-        }
+        viewModelScope
+            .launch {
+                _loadingState.value = true
+                val result =
+                    StytchClient.passkeys.register(
+                        Passkeys.RegisterParameters(
+                            activity = activity,
+                            domain = BuildConfig.PASSKEYS_DOMAIN,
+                        ),
+                    )
+                _currentResponse.value = result.toFriendlyDisplay()
+                _currentPasskeyRegistrationId.value =
+                    when (result) {
+                        is StytchResult.Success -> result.value.webauthnRegistrationId
+                        else -> ""
+                    }
+            }.invokeOnCompletion {
+                _loadingState.value = false
+            }
     }
 
     fun authenticatePasskey(activity: FragmentActivity) {
-        viewModelScope.launch {
-            _loadingState.value = true
-            val result =
-                StytchClient.passkeys.authenticate(
-                    Passkeys.AuthenticateParameters(
-                        activity = activity,
-                        domain = BuildConfig.PASSKEYS_DOMAIN,
-                    ),
-                )
-            _currentPasskeyRegistrationId.value =
-                when (result) {
-                    is StytchResult.Success -> result.value.user.webauthnRegistrations[0].id
-                    else -> ""
-                }
-            _currentResponse.value = result.toFriendlyDisplay()
-        }.invokeOnCompletion {
-            _loadingState.value = false
-        }
+        viewModelScope
+            .launch {
+                _loadingState.value = true
+                val result =
+                    StytchClient.passkeys.authenticate(
+                        Passkeys.AuthenticateParameters(
+                            activity = activity,
+                            domain = BuildConfig.PASSKEYS_DOMAIN,
+                        ),
+                    )
+                _currentPasskeyRegistrationId.value =
+                    when (result) {
+                        is StytchResult.Success ->
+                            result.value.user.webauthnRegistrations[0]
+                                .id
+                        else -> ""
+                    }
+                _currentResponse.value = result.toFriendlyDisplay()
+            }.invokeOnCompletion {
+                _loadingState.value = false
+            }
     }
 
     fun updatePasskey() {
-        viewModelScope.launch {
-            _loadingState.value = true
-            val result =
-                StytchClient.passkeys.update(
-                    Passkeys.UpdateParameters(
-                        id = _currentPasskeyRegistrationId.value,
-                        name = passkeyNameState.text,
-                    ),
-                )
-            _currentResponse.value = result.toFriendlyDisplay()
-        }.invokeOnCompletion {
-            _loadingState.value = false
-        }
+        viewModelScope
+            .launch {
+                _loadingState.value = true
+                val result =
+                    StytchClient.passkeys.update(
+                        Passkeys.UpdateParameters(
+                            id = _currentPasskeyRegistrationId.value,
+                            name = passkeyNameState.text,
+                        ),
+                    )
+                _currentResponse.value = result.toFriendlyDisplay()
+            }.invokeOnCompletion {
+                _loadingState.value = false
+            }
     }
 }


### PR DESCRIPTION
Linear Ticket:
[SDK-2601](https://linear.app/stytch/issue/SDK-2601)
[SDK-2602](https://linear.app/stytch/issue/SDK-2602)
[SDK-2604](https://linear.app/stytch/issue/SDK-2604)

## Changes:

1. Move as much shared client configuration code into a ConfigurationManager (to increase maintainability/not have to make the same changes in multiple places)
2. Change some dependency inclusions to help reduce AAR bloat
3. ~~Include targeted proguard rules to help reduce AAR bloat (got it down from 5mb to 4mb; not earth shattering, but this was the smallest I could manage)~~ This was removed, as it was causing CodeQL issues, and might therefore cause issues for developers :(
4. Remove all of the manual @Keep annotations (they are unnecessary with the proguard rules)
5. Add some additional @JacocoExcludeGenerated annotations to items that were missed
6. Ensure we are reusing the OkHttpClient and Retrofit instances (previously we were creating brand new instances whenever the bootstrap call finished, which caused performance issues w/r/t connection pools)
7. Simplified and consolidated the `isInitialized`/`assertInitialized` logic in the API class itself (which is all that really needed to be checked)
8. Removed any dependency on the global SDK client objects from the API classes

## Notes:

- The logging of configuration step durations should eventually be normalized with iOS and reported to the Events api, but that code is intentionally commented out for now, pending internal discussions on the usage of that endpoint

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A