### PR TITLE
Add missing properties to BootstrapData and B2B UI PasswordOptions

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -58,6 +58,7 @@ import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.events.Events
 import com.stytch.sdk.common.events.EventsImpl
 import com.stytch.sdk.common.network.CommonApi
+import com.stytch.sdk.common.network.models.Vertical
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -666,6 +667,8 @@ public object StytchB2BClient {
         override var onFinishedInitialization: () -> Unit,
     ) : StytchClientCommon {
         override val commonApi: CommonApi = StytchB2BApi
+
+        override val expectedVertical: Vertical = Vertical.B2B
 
         override fun logEvent(
             eventName: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -10,6 +10,7 @@ import com.stytch.sdk.common.dfp.DFPProviderImpl
 import com.stytch.sdk.common.extensions.getDeviceInfo
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
+import com.stytch.sdk.common.network.models.Vertical
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManagerImpl
 import com.stytch.sdk.common.smsRetriever.StytchSMSRetriever
@@ -148,6 +149,22 @@ internal class ConfigurationManager {
                 is StytchResult.Success -> res.value
                 else -> bootstrapData
             }
+        when {
+            client.expectedVertical == Vertical.CONSUMER && bootstrapData.vertical == Vertical.B2B -> {
+                StytchLog.e(
+                    "This application is using a Stytch client for Consumer projects, but the public token is for a " +
+                        "Stytch B2B project. Use a B2B Stytch client instead, or verify that the public token is " +
+                        "correct.",
+                )
+            }
+            client.expectedVertical == Vertical.B2B && bootstrapData.vertical == Vertical.CONSUMER -> {
+                StytchLog.e(
+                    "This application is using a Stytch client for B2B projects, but the public token is for a " +
+                        "Stytch Consumer project. Use a Consumer Stytch client instead, or verify that the public " +
+                        "token is correct.",
+                )
+            }
+        }
         isRefreshingBootstrap = false
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
@@ -1,9 +1,12 @@
 package com.stytch.sdk.common
 
 import com.stytch.sdk.common.network.CommonApi
+import com.stytch.sdk.common.network.models.Vertical
 import kotlinx.coroutines.Job
 
 internal interface StytchClientCommon {
+    val expectedVertical: Vertical
+
     val commonApi: CommonApi
 
     fun logEvent(

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -353,7 +353,14 @@ public data class BootstrapData(
     val passwordConfig: PasswordConfig? = null,
     @Json(name = "rbac_policy")
     val rbacPolicy: RBACPolicy? = null,
+    val vertical: Vertical = Vertical.CONSUMER,
 ) : Parcelable
+
+@JsonClass(generateAdapter = false)
+public enum class Vertical {
+    B2B,
+    CONSUMER,
+}
 
 @JsonClass(generateAdapter = true)
 @Parcelize

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -26,6 +26,7 @@ import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.events.Events
 import com.stytch.sdk.common.events.EventsImpl
 import com.stytch.sdk.common.network.CommonApi
+import com.stytch.sdk.common.network.models.Vertical
 import com.stytch.sdk.consumer.biometrics.Biometrics
 import com.stytch.sdk.consumer.biometrics.BiometricsImpl
 import com.stytch.sdk.consumer.biometrics.BiometricsProviderImpl
@@ -568,6 +569,8 @@ public object StytchClient {
         override var onFinishedInitialization: () -> Unit,
     ) : StytchClientCommon {
         override val commonApi: CommonApi = StytchApi
+
+        override val expectedVertical: Vertical = Vertical.CONSUMER
 
         override fun logEvent(
             eventName: String,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/data/B2BPasswordOptions.kt
@@ -11,4 +11,5 @@ import kotlinx.parcelize.Parcelize
 public data class B2BPasswordOptions(
     val resetPasswordTemplateId: String? = null,
     val verifyEmailTemplateId: String? = null,
+    val resetPasswordExpirationMinutes: Int? = null,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordDiscoveryResetByEmailStart.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordDiscoveryResetByEmailStart.kt
@@ -31,6 +31,7 @@ internal class UsePasswordDiscoveryResetByEmailStart(
                         resetPasswordRedirectUrl = getRedirectUrl(),
                         resetPasswordTemplateId = productConfig.passwordOptions.resetPasswordTemplateId,
                         verifyEmailTemplateId = productConfig.passwordOptions.verifyEmailTemplateId,
+                        resetPasswordExpirationMinutes = productConfig.passwordOptions.resetPasswordExpirationMinutes,
                         locale = productConfig.locale,
                     ),
                 )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmailStart.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UsePasswordResetByEmailStart.kt
@@ -32,6 +32,7 @@ internal class UsePasswordResetByEmailStart(
                         resetPasswordRedirectUrl = getRedirectUrl(),
                         resetPasswordTemplateId = productConfig.passwordOptions.resetPasswordTemplateId,
                         verifyEmailTemplateId = productConfig.passwordOptions.verifyEmailTemplateId,
+                        resetPasswordExpirationMinutes = productConfig.passwordOptions.resetPasswordExpirationMinutes,
                         locale = productConfig.locale,
                     ),
                 )


### PR DESCRIPTION
Linear Ticket:
[SDK-2611](https://linear.app/stytch/issue/SDK-2611)
[SDK-2613](https://linear.app/stytch/issue/SDK-2613)

## Changes:

1. Add resetPasswordExpirationMinutes to B2B UI config passwordoptions and pass to underlying client methods where appropriate
2. Add vertical to bootstrapdata and add logging when misconfigured

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A