### PR TITLE
SDK-2646 address StrictMode violations and fix session revocation on heartbeat

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.46.0"
+extra["PUBLISH_VERSION"] = "0.47.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
@@ -75,6 +75,9 @@ internal fun <T : CommonAuthenticationData> StytchResult<T>.launchSessionUpdater
                     saveSession(result, sessionStorage)
                 }
             },
+            clearSession = {
+                sessionStorage.revoke()
+            },
         )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -82,6 +82,7 @@ import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchAuthHeaderInterceptor
 import com.stytch.sdk.common.network.StytchDFPInterceptor
 import com.stytch.sdk.common.network.StytchDataResponse
+import com.stytch.sdk.common.network.ThreadingInterceptor
 import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.common.network.models.CommonRequests
@@ -108,6 +109,7 @@ internal object StytchB2BApi : CommonApi {
             ApiService(
                 sdkUrl,
                 listOf(
+                    ThreadingInterceptor(),
                     StytchAuthHeaderInterceptor(deviceInfo, publicToken, getSessionToken),
                     dfpInterceptor,
                 ),

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -58,6 +58,7 @@ internal class ConfigurationManager {
         this.appSessionId = "app-session-id-${UUID.randomUUID()}"
         this.dfpProvider =
             DFPProviderImpl(
+                scope = externalScope,
                 context = context.applicationContext,
                 publicToken = publicToken,
                 dfppaDomain = options.endpointOptions.dfppaDomain,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -3,6 +3,10 @@ package com.stytch.sdk.common
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import java.security.KeyStore
 
 private const val KEY_ALIAS = "Stytch RSA 2048"
@@ -15,9 +19,11 @@ internal object StorageHelper {
     internal lateinit var sharedPreferences: SharedPreferences
 
     fun initialize(context: Context) {
-        keyStore.load(null)
-        sharedPreferences = context.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
-        EncryptionManager.createNewKeys(context, KEY_ALIAS)
+        CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
+            keyStore.load(null)
+            sharedPreferences = context.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+            EncryptionManager.createNewKeys(context, KEY_ALIAS)
+        }
     }
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/ThreadingInterceptor.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/ThreadingInterceptor.kt
@@ -1,0 +1,12 @@
+package com.stytch.sdk.common.network
+
+import android.net.TrafficStats
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class ThreadingInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        TrafficStats.setThreadStatsTag(Thread.currentThread().id.toInt())
+        return chain.proceed(chain.request())
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sessions/SessionAutoUpdater.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sessions/SessionAutoUpdater.kt
@@ -35,7 +35,7 @@ internal object SessionAutoUpdater {
         dispatchers: StytchDispatchers,
         updateSession: suspend () -> StytchResult<CommonAuthenticationData>,
         saveSession: (CommonAuthenticationData) -> Unit,
-        clearSession: () -> Unit,
+        clearSession: () -> Unit = {},
     ) {
         // prevent multiple update jobs running
         stopSessionUpdateJob()

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
@@ -47,6 +47,9 @@ internal fun <T : IAuthData> StytchResult<T>.launchSessionUpdater(
                     saveSession(result, sessionStorage)
                 }
             },
+            clearSession = {
+                sessionStorage.revoke()
+            },
         )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -15,6 +15,7 @@ import com.stytch.sdk.common.network.InfoHeaderModel
 import com.stytch.sdk.common.network.StytchAuthHeaderInterceptor
 import com.stytch.sdk.common.network.StytchDFPInterceptor
 import com.stytch.sdk.common.network.StytchDataResponse
+import com.stytch.sdk.common.network.ThreadingInterceptor
 import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.BiometricsStartResponse
 import com.stytch.sdk.common.network.models.BootstrapData
@@ -67,6 +68,7 @@ internal object StytchApi : CommonApi {
             ApiService(
                 sdkUrl,
                 listOf(
+                    ThreadingInterceptor(),
                     StytchAuthHeaderInterceptor(deviceInfo, publicToken, getSessionToken),
                     dfpInterceptor,
                 ),

--- a/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/App.kt
+++ b/workbench-apps/consumer-workbench/src/main/java/com/stytch/exampleapp/App.kt
@@ -1,6 +1,7 @@
 package com.stytch.exampleapp
 
 import android.app.Application
+import android.os.StrictMode
 import androidx.appcompat.app.AppCompatDelegate
 import com.stytch.sdk.consumer.StytchClient
 import kotlinx.coroutines.CoroutineScope
@@ -10,6 +11,20 @@ import kotlinx.coroutines.launch
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy
+                .Builder()
+                .detectAll()
+                .penaltyLog()
+                .build(),
+        )
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy
+                .Builder()
+                .detectAll()
+                .penaltyLog()
+                .build(),
+        )
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         StytchClient.configure(this) {
             println("Stytch has been initialized and configured and is ready for use")


### PR DESCRIPTION
Linear Ticket: [SDK-2646](https://linear.app/stytch/issue/SDK-2646)

## Changes:

1. Enables strict mode in the demo app to try and track down any potential violations that might cause ANRs. Everything that was reported has been fixed, except some initialization stuff deep in the heart of reCAPTCHA that we have no control over
2. Fix a bug where we weren't clearing sessions on a failed heartbeat

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A