### PR TITLE
SDK-2640 Add backup/extraction rules

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.47.0"
+extra["PUBLISH_VERSION"] = "0.47.1"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/AndroidManifest.xml
+++ b/source/sdk/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
-        android:allowBackup="true"
+        android:fullBackupContent="@xml/android_11_and_lower_backup_rules"
+        android:dataExtractionRules="@xml/android_12_and_higher_backup_rules"
         android:supportsRtl="true">
         <activity
             android:name=".common.sso.SSOManagerActivity"

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -9,8 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.security.KeyStore
 
-private const val KEY_ALIAS = "Stytch RSA 2048"
-private const val PREFERENCES_FILE_NAME = "stytch_preferences"
+internal const val STYTCH_PREFERENCES_FILE_NAME = "stytch_preferences"
 
 internal object StorageHelper {
     internal val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore")
@@ -21,8 +20,8 @@ internal object StorageHelper {
     fun initialize(context: Context) {
         CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
             keyStore.load(null)
-            sharedPreferences = context.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
-            EncryptionManager.createNewKeys(context, KEY_ALIAS)
+            sharedPreferences = context.getSharedPreferences(STYTCH_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+            EncryptionManager.createNewKeys(context)
         }
     }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/extensions/ContextExt.kt
@@ -32,12 +32,16 @@ internal fun Context.getDeviceInfo(): DeviceInfo {
     return deviceInfo
 }
 
-internal fun Context.clearPreferences(preferencesName: String) {
+internal fun Context.clearPreferences(preferenceFileNames: List<String>) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        deleteSharedPreferences(preferencesName)
+        preferenceFileNames.forEach {
+            deleteSharedPreferences(it)
+        }
     } else {
-        getSharedPreferences(preferencesName, Context.MODE_PRIVATE).edit().clear().apply()
-        val dir = File(applicationInfo.dataDir, "shared_prefs")
-        File(dir, "$preferencesName.xml").delete()
+        preferenceFileNames.forEach {
+            getSharedPreferences(it, Context.MODE_PRIVATE).edit().clear().apply()
+            val dir = File(applicationInfo.dataDir, "shared_prefs")
+            File(dir, "$it.xml").delete()
+        }
     }
 }

--- a/source/sdk/src/main/res/xml/android_11_and_lower_backup_rules.xml
+++ b/source/sdk/src/main/res/xml/android_11_and_lower_backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="stytch_secured_pref.xml"/>
+    <exclude domain="sharedpref" path="stytch_preferences.xml"/>
+</full-backup-content>

--- a/source/sdk/src/main/res/xml/android_12_and_higher_backup_rules.xml
+++ b/source/sdk/src/main/res/xml/android_12_and_higher_backup_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="stytch_secured_pref.xml"/>
+        <exclude domain="sharedpref" path="stytch_preferences.xml"/>
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="stytch_secured_pref.xml"/>
+        <exclude domain="sharedpref" path="stytch_preferences.xml"/>
+    </device-transfer>
+</data-extraction-rules>

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -79,7 +79,7 @@ internal class StytchB2BClientTest {
             "com.stytch.sdk.b2b.extensions.StytchResultExtKt",
         )
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         mockkObject(NetworkChangeListener)
         every { NetworkChangeListener.configure(any(), any()) } just runs
         every { NetworkChangeListener.networkIsAvailable } returns true

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -62,7 +62,7 @@ internal class B2BMagicLinksImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/member/MemberImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/member/MemberImplTest.kt
@@ -57,7 +57,7 @@ internal class MemberImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { EncryptionManager.encryptString(any()) } returns ""
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -77,7 +77,7 @@ internal class StytchB2BApiTest {
         mockkObject(AppLifecycleListener)
         every { AppLifecycleListener.configure(any()) } just runs
         MockKAnnotations.init(this, true, true)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         StytchB2BClient.sessionStorage = mockB2BSessionStorage
     }

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
@@ -54,7 +54,7 @@ internal class OAuthImplTest {
         mockkStatic(KeyStore::class)
         mockkStatic("com.stytch.sdk.common.extensions.StringExtKt", "com.stytch.sdk.common.extensions.ByteArrayExtKt")
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/organization/OrganizationImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/organization/OrganizationImplTest.kt
@@ -69,7 +69,7 @@ internal class OrganizationImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { EncryptionManager.encryptString(any()) } returns ""
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -67,7 +67,7 @@ internal class PasswordsImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/rbac/RBACImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/rbac/RBACImplTest.kt
@@ -108,7 +108,7 @@ internal class RBACImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StytchB2BClient)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
@@ -58,7 +58,7 @@ internal class B2BSessionsImplTest {
         MockKAnnotations.init(this, true, true)
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -59,7 +59,7 @@ internal class SSOImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/common/pkcePairManager/PKCEPairManagerImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/common/pkcePairManager/PKCEPairManagerImplTest.kt
@@ -25,7 +25,7 @@ internal class PKCEPairManagerImplTest {
         mockkStatic(KeyStore::class)
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } just runs
+        every { EncryptionManager.createNewKeys(any()) } just runs
         mockkObject(StorageHelper)
         every { StorageHelper.initialize(any()) } just runs
 

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -77,7 +77,7 @@ internal class StytchClientTest {
             "com.stytch.sdk.consumer.extensions.StytchResultExtKt",
         )
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         mockkObject(NetworkChangeListener)
         every { NetworkChangeListener.configure(any(), any()) } just runs
         every { NetworkChangeListener.networkIsAvailable } returns true

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -82,7 +82,7 @@ internal class BiometricsImplTest {
             "com.stytch.sdk.consumer.extensions.StytchResultExtKt",
         )
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
@@ -58,7 +58,7 @@ internal class MagicLinksImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -63,7 +63,7 @@ internal class StytchApiTest {
         mockkObject(EncryptionManager)
         mockkObject(StytchApi)
         MockKAnnotations.init(this, true, true)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         StytchClient.sessionStorage = mockConsumerSessionStorage

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -53,7 +53,7 @@ internal class OAuthImplTest {
         mockkStatic(KeyStore::class)
         mockkStatic("com.stytch.sdk.common.extensions.StringExtKt", "com.stytch.sdk.common.extensions.ByteArrayExtKt")
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
@@ -51,7 +51,7 @@ internal class OTPImplTest {
         MockKAnnotations.init(this, true, true)
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -72,7 +72,7 @@ internal class PasswordsImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/SessionsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/SessionsImplTest.kt
@@ -54,7 +54,7 @@ internal class SessionsImplTest {
         MockKAnnotations.init(this, true, true)
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
@@ -49,7 +49,7 @@ internal class UserManagementImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         MockKAnnotations.init(this, true, true)


### PR DESCRIPTION
Linear Ticket: [SDK-2640](https://linear.app/stytch/issue/SDK-2640)

## Changes:

1. We persist our encryption key data to a shared preferences file that, by default, is backed up and restored when reinstalling an application. However, the key that that data points to is _not_ persisted between installs (enforced by Android; working as expected). So when we allow our data to be persisted, it means that first launches of an app after reinstall attempt to use an invalid key, and fail to decrypt the data. This change is to explicitly disallow backing up our preference files, preventing the app from attempting to use an invalid key. In the event that data was previously persisted (ie: someone had an older version installed, then uninstalled the app, and reinstalled with an app using _this_ version), explicitly delete BOTH shared preferences files when we detect that we can't read them. Subsequent reinstalls will respect the new backup rules.

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A