### PR TITLE
SDK-2666 Minor B2B UI Fixes

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.47.1"
+extra["PUBLISH_VERSION"] = "0.47.2"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -102,6 +102,28 @@ internal fun StytchB2BAuthenticationApp(
             rootAppState.currentRoute ?: Routes.Loading
         }
 
+    val deepLinkViewModel = createViewModelHelper(DeepLinkParserScreenViewModel::class.java)
+    val discoveryViewModel = createViewModelHelper(DiscoveryScreenViewModel::class.java)
+    val emailConfirmationScreenViewModel = createViewModelHelper(EmailConfirmationScreenViewModel::class.java)
+    val emailMethodSelectionViewModel = createViewModelHelper(EmailMethodSelectionScreenViewModel::class.java)
+    val emailOTPEntryViewModel = createViewModelHelper(EmailOTPEntryScreenViewModel::class.java)
+    val errorViewModel = createViewModelHelper(ErrorScreenViewModel::class.java)
+    val mainViewModel = createViewModelHelper(MainScreenViewModel::class.java)
+    val mfaEnrollmentViewModel = createViewModelHelper(MFAEnrollmentSelectionScreenViewModel::class.java)
+    val passwordAuthenticateViewModel = createViewModelHelper(PasswordAuthenticateScreenViewModel::class.java)
+    val passwordForgotViewModel = createViewModelHelper(PasswordForgotScreenViewModel::class.java)
+    val passwordResetViewModel = createViewModelHelper(PasswordResetScreenViewModel::class.java)
+    val passwordSetNewViewModel = createViewModelHelper(PasswordSetNewScreenViewModel::class.java)
+    val recoveryCodesEntryViewModel = createViewModelHelper(RecoveryCodesEntryScreenViewModel::class.java)
+    val recoveryCodesSaveViewModel = createViewModelHelper(RecoveryCodesSaveScreenViewModel::class.java)
+    val smsOTPEnrollmentViewModel = createViewModelHelper(SMSOTPEnrollmentScreenViewModel::class.java)
+    val smsOTPEntryViewModel = createViewModelHelper(SMSOTPEntryScreenViewModel::class.java)
+    val ssoDiscoveryEmailViewModel = createViewModelHelper(SSODiscoveryEmailScreenViewModel::class.java)
+    val ssoDiscoveryFallbackViewModel = createViewModelHelper(SSODiscoveryFallbackScreenViewModel::class.java)
+    val ssoDiscoveryMenuViewModel = createViewModelHelper(SSODiscoveryMenuScreenViewModel::class.java)
+    val totpEnrollmentViewModel = createViewModelHelper(TOTPEnrollmentScreenViewModel::class.java)
+    val totpEntryViewModel = createViewModelHelper(TOTPEntryScreenViewModel::class.java)
+
     LaunchedEffect(rootAppState.currentRoute) {
         rootAppState.currentRoute?.let {
             navController.navigate(it) {
@@ -135,111 +157,87 @@ internal fun StytchB2BAuthenticationApp(
                     }
                     composable<Routes.DeeplinkParser> {
                         DeepLinkParserScreen(
-                            viewModel = createViewModelHelper(DeepLinkParserScreenViewModel::class.java),
+                            viewModel = deepLinkViewModel,
                             deepLinkTokenPair = rootAppState.deeplinkTokenPair,
                         )
                     }
                     composable<Routes.Discovery> {
-                        DiscoveryScreen(viewModel = createViewModelHelper(DiscoveryScreenViewModel::class.java))
+                        DiscoveryScreen(viewModel = discoveryViewModel)
                     }
                     composable<Routes.EmailConfirmation> {
                         EmailConfirmationScreen(
                             route = EmailConfirmationScreenRoute.EmailConfirmation,
-                            viewModel = createViewModelHelper(EmailConfirmationScreenViewModel::class.java),
+                            viewModel = emailConfirmationScreenViewModel,
                         )
                     }
                     composable<Routes.EmailMethodSelection> {
-                        EmailMethodSelectionScreen(
-                            viewModel = createViewModelHelper(EmailMethodSelectionScreenViewModel::class.java),
-                        )
+                        EmailMethodSelectionScreen(viewModel = emailMethodSelectionViewModel)
                     }
                     composable<Routes.EmailOTPEntry> {
-                        EmailOTPEntryScreen(viewModel = createViewModelHelper(EmailOTPEntryScreenViewModel::class.java))
+                        EmailOTPEntryScreen(viewModel = emailOTPEntryViewModel)
                     }
                     composable<Routes.Error> {
-                        ErrorScreen(viewModel = createViewModelHelper(ErrorScreenViewModel::class.java))
+                        ErrorScreen(viewModel = errorViewModel)
                     }
                     composable<Routes.Main> {
-                        MainScreen(viewModel = createViewModelHelper(MainScreenViewModel::class.java))
+                        MainScreen(viewModel = mainViewModel)
                     }
                     composable<Routes.MFAEnrollmentSelection> {
-                        MFAEnrollmentSelectionScreen(
-                            viewModel = createViewModelHelper(MFAEnrollmentSelectionScreenViewModel::class.java),
-                        )
+                        MFAEnrollmentSelectionScreen(viewModel = mfaEnrollmentViewModel)
                     }
                     composable<Routes.PasswordAuthenticate> {
-                        PasswordAuthenticateScreen(
-                            viewModel = createViewModelHelper(PasswordAuthenticateScreenViewModel::class.java),
-                        )
+                        PasswordAuthenticateScreen(viewModel = passwordAuthenticateViewModel)
                     }
                     composable<Routes.PasswordForgot> {
-                        PasswordForgotScreen(
-                            viewModel = createViewModelHelper(PasswordForgotScreenViewModel::class.java),
-                        )
+                        PasswordForgotScreen(viewModel = passwordForgotViewModel)
                     }
                     composable<Routes.PasswordReset> {
-                        PasswordResetScreen(viewModel = createViewModelHelper(PasswordResetScreenViewModel::class.java))
+                        PasswordResetScreen(viewModel = passwordResetViewModel)
                     }
                     composable<Routes.PasswordResetVerifyConfirmation> {
                         EmailConfirmationScreen(
                             route = EmailConfirmationScreenRoute.PasswordResetVerifyConfirmation,
-                            viewModel = createViewModelHelper(EmailConfirmationScreenViewModel::class.java),
+                            viewModel = emailConfirmationScreenViewModel,
                         )
                     }
                     composable<Routes.PasswordSetNew> {
-                        PasswordSetNewScreen(
-                            viewModel = createViewModelHelper(PasswordSetNewScreenViewModel::class.java),
-                        )
+                        PasswordSetNewScreen(viewModel = passwordSetNewViewModel)
                     }
                     composable<Routes.PasswordSetNewConfirmation> {
                         EmailConfirmationScreen(
                             route = EmailConfirmationScreenRoute.PasswordSetNewConfirmation,
-                            viewModel = createViewModelHelper(EmailConfirmationScreenViewModel::class.java),
+                            viewModel = emailConfirmationScreenViewModel,
                         )
                     }
                     composable<Routes.RecoveryCodeEntry> {
-                        RecoveryCodesEntryScreen(
-                            viewModel = createViewModelHelper(RecoveryCodesEntryScreenViewModel::class.java),
-                        )
+                        RecoveryCodesEntryScreen(viewModel = recoveryCodesEntryViewModel)
                     }
                     composable<Routes.RecoveryCodeSave> {
-                        RecoveryCodesSaveScreen(
-                            viewModel = createViewModelHelper(RecoveryCodesSaveScreenViewModel::class.java),
-                        )
+                        RecoveryCodesSaveScreen(viewModel = recoveryCodesSaveViewModel)
                     }
                     composable<Routes.SMSOTPEnrollment> {
-                        SMSOTPEnrollmentScreen(
-                            viewModel = createViewModelHelper(SMSOTPEnrollmentScreenViewModel::class.java),
-                        )
+                        SMSOTPEnrollmentScreen(viewModel = smsOTPEnrollmentViewModel)
                     }
                     composable<Routes.SMSOTPEntry> {
-                        SMSOTPEntryScreen(viewModel = createViewModelHelper(SMSOTPEntryScreenViewModel::class.java))
+                        SMSOTPEntryScreen(viewModel = smsOTPEntryViewModel)
                     }
                     composable<Routes.SSODiscoveryEmail> {
-                        SSODiscoveryEmailScreen(
-                            viewModel = createViewModelHelper(SSODiscoveryEmailScreenViewModel::class.java),
-                        )
+                        SSODiscoveryEmailScreen(viewModel = ssoDiscoveryEmailViewModel)
                     }
                     composable<Routes.SSODiscoveryFallback> {
-                        SSODiscoveryFallbackScreen(
-                            viewModel = createViewModelHelper(SSODiscoveryFallbackScreenViewModel::class.java),
-                        )
+                        SSODiscoveryFallbackScreen(viewModel = ssoDiscoveryFallbackViewModel)
                     }
                     composable<Routes.SSODiscoveryMenu> {
-                        SSODiscoveryMenuScreen(
-                            viewModel = createViewModelHelper(SSODiscoveryMenuScreenViewModel::class.java),
-                        )
+                        SSODiscoveryMenuScreen(viewModel = ssoDiscoveryMenuViewModel)
                     }
                     composable<Routes.Success> {
                         SuccessScreen()
                     }
                     composable<Routes.TOTPEnrollment> {
-                        TOTPEnrollmentScreen(
-                            viewModel = createViewModelHelper(TOTPEnrollmentScreenViewModel::class.java),
-                        )
+                        TOTPEnrollmentScreen(viewModel = totpEnrollmentViewModel)
                     }
                     composable<Routes.TOTPEntry> {
-                        TOTPEntryScreen(viewModel = createViewModelHelper(TOTPEntryScreenViewModel::class.java))
+                        TOTPEntryScreen(viewModel = totpEntryViewModel)
                     }
                 }
                 rootAppState.errorToastText?.let {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/discovery/DiscoveryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/discovery/DiscoveryScreen.kt
@@ -28,8 +28,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -160,6 +162,7 @@ private fun DiscoveryScreenComposable(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Row(
+                        modifier = Modifier.weight(0.9F),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Logo(
@@ -170,10 +173,13 @@ private fun DiscoveryScreenComposable(
                             modifier = Modifier.padding(start = 8.dp),
                             text = discoveredOrganization.organization.organizationName,
                             color = Color(theme.primaryTextColor),
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.End,
                     ) {
                         ArrowText(type = discoveredOrganization.membership.type)
                         Icon(
@@ -250,6 +256,7 @@ private fun Logo(
     if (!logoUrl.isNullOrEmpty()) {
         AsyncImage(
             model = logoUrl,
+            contentScale = ContentScale.FillBounds,
             contentDescription = name,
             modifier =
                 Modifier

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/smsOTPEntry/SMSOTPEntryScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/smsOTPEntry/SMSOTPEntryScreen.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.ui.b2b.screens.smsOTPEntry
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -10,6 +11,9 @@ import com.stytch.sdk.ui.b2b.components.ResendableOTP
 @Composable
 internal fun SMSOTPEntryScreen(viewModel: SMSOTPEntryScreenViewModel) {
     val state = viewModel.smsOtpEntryState.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.onScreenLoad()
+    }
     SMSOTPEntryScreenComposable(
         state = state.value,
         dispatch = viewModel::handle,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/smsOTPEntry/SMSOTPEntryScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/smsOTPEntry/SMSOTPEntryScreenViewModel.kt
@@ -49,7 +49,7 @@ internal class SMSOTPEntryScreenViewModel(
         }
     }
 
-    init {
+    fun onScreenLoad() {
         val smsImplicitlySent = state.value.mfaPrimaryInfoState?.smsImplicitlySent == true
         val didSend = state.value.mfaSMSState?.didSend == true
         // If we haven't already sent one ourselves, and an SMS message was not already sent by the server, send it now

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/totpEnrollment/TOTPEnrollmentScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/totpEnrollment/TOTPEnrollmentScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +48,9 @@ import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
 @Composable
 internal fun TOTPEnrollmentScreen(viewModel: TOTPEnrollmentScreenViewModel) {
     val totpState = viewModel.totpState.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) {
+        viewModel.onScreenLoad()
+    }
     TOTPEnrollmentScreenComposable(
         state = totpState.value,
         dispatch = viewModel::handle,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/totpEnrollment/TOTPEnrollmentScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/totpEnrollment/TOTPEnrollmentScreenViewModel.kt
@@ -21,7 +21,7 @@ internal class TOTPEnrollmentScreenViewModel(
 
     private val useTOTPCreate = UseTOTPCreate(viewModelScope, state, ::dispatch, ::request)
 
-    init {
+    fun onScreenLoad() {
         // if we're enrolling, make sure we always set the postauthscreen to recoverycodesave
         dispatch(SetPostAuthScreen(Routes.RecoveryCodeSave))
         if (state.value.mfaTOTPState == null) {


### PR DESCRIPTION
Linear Ticket: [SDK-2666](https://linear.app/stytch/issue/SDK-2666)

## Changes:

1. Fix overflowing long organization names in discovery screen and ensure the logo is scaled to fill
2. Noticed some VM recreation and ensured VMs are only created once. As a caveat of that, there were some places we were relying on the initialization behavior that we now need to explicitly call on screen load (NB: this means that these inits were running multiple times previously, which could potentially cause issues with triggering multiple TOTP or SMS events)

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A