### PR TITLE
Add Biometrics To The Consumer Prebuilt UI

### DIFF
--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainActivity.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.stytch.stytchexampleapp
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -18,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,9 +26,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.ui.b2c.StytchUI
+import com.stytch.sdk.ui.b2c.data.BiometricsOptions
+import com.stytch.sdk.ui.b2c.data.OTPMethods
+import com.stytch.sdk.ui.b2c.data.OTPOptions
+import com.stytch.sdk.ui.b2c.data.StytchProduct
+import com.stytch.sdk.ui.b2c.data.StytchProductConfig
 import com.stytch.stytchexampleapp.ui.screens.loading.LoadingScreen
 import com.stytch.stytchexampleapp.ui.screens.login.LoginRoute
 import com.stytch.stytchexampleapp.ui.screens.profile.ProfileRoute
@@ -36,7 +44,7 @@ import com.stytch.stytchexampleapp.ui.theme.StytchAndroidSDKTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
     private val viewModel by viewModels<MainViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -49,6 +57,25 @@ class MainActivity : ComponentActivity() {
             fun navigateTo(route: Route) {
                 navController.navigate(route.route)
             }
+            val stytchUi =
+                StytchUI
+                    .Builder()
+                    .apply {
+                        activity(this@MainActivity)
+                        productConfig(
+                            StytchProductConfig(
+                                products = listOf(StytchProduct.OTP, StytchProduct.BIOMETRICS),
+                                otpOptions = OTPOptions(methods = listOf(OTPMethods.SMS)),
+                                biometricsOptions = BiometricsOptions(forceRegistrationOnLoginIfNoneFound = false),
+                            ),
+                        )
+                        onAuthenticated {
+                            when (it) {
+                                is StytchResult.Success -> navigateTo(Route.Profile)
+                                is StytchResult.Error -> navigateTo(Route.Login)
+                            }
+                        }
+                    }.build()
             StytchAndroidSDKTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Box(
@@ -102,6 +129,11 @@ class MainActivity : ComponentActivity() {
                                             authenticationState = state.value,
                                             navigateTo = ::navigateTo,
                                         )
+                                    }
+                                    composable(Route.UILogin.route) {
+                                        LaunchedEffect(Unit) {
+                                            stytchUi.authenticate()
+                                        }
                                     }
                                 }
                             }

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainActivity.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : FragmentActivity() {
                             StytchProductConfig(
                                 products = listOf(StytchProduct.BIOMETRICS, StytchProduct.OTP),
                                 otpOptions = OTPOptions(methods = listOf(OTPMethods.SMS)),
-                                biometricsOptions = BiometricsOptions(forceRegistrationOnLoginIfNoneFound = true),
+                                biometricsOptions = BiometricsOptions(showBiometricRegistrationOnLogin = true),
                             ),
                         )
                         onAuthenticated {

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainActivity.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainActivity.kt
@@ -64,9 +64,9 @@ class MainActivity : FragmentActivity() {
                         activity(this@MainActivity)
                         productConfig(
                             StytchProductConfig(
-                                products = listOf(StytchProduct.OTP, StytchProduct.BIOMETRICS),
+                                products = listOf(StytchProduct.BIOMETRICS, StytchProduct.OTP),
                                 otpOptions = OTPOptions(methods = listOf(OTPMethods.SMS)),
-                                biometricsOptions = BiometricsOptions(forceRegistrationOnLoginIfNoneFound = false),
+                                biometricsOptions = BiometricsOptions(forceRegistrationOnLoginIfNoneFound = true),
                             ),
                         )
                         onAuthenticated {

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainViewModel.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/MainViewModel.kt
@@ -7,47 +7,38 @@ import com.stytch.sdk.common.StytchObjectInfo
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.models.SessionData
 import com.stytch.sdk.consumer.network.models.UserData
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
 class MainViewModel : ViewModel() {
-    private var _authenticationState = MutableStateFlow(AuthenticationState())
-    var authenticationState: StateFlow<AuthenticationState> = _authenticationState.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            authenticationState =
-                combine(
-                    StytchClient.isInitialized,
-                    StytchClient.user.onChange,
-                    StytchClient.sessions.onChange,
-                ) { isInitialized, stytchUser, stytchSession ->
-                    val userData =
-                        if (stytchUser is StytchObjectInfo.Available) {
-                            stytchUser.value
-                        } else {
-                            null
-                        }
-                    val sessionData =
-                        if (stytchSession is StytchObjectInfo.Available) {
-                            stytchSession.value
-                        } else {
-                            null
-                        }
-                    AuthenticationState(
-                        isInitialized = isInitialized,
-                        userData = userData,
-                        sessionData = sessionData,
-                    )
-                }.stateIn(viewModelScope, SharingStarted.Lazily, AuthenticationState())
-        }
-    }
+    var authenticationState: StateFlow<AuthenticationState> =
+        combine(
+            StytchClient.isInitialized,
+            StytchClient.user.onChange,
+            StytchClient.sessions.onChange,
+        ) { isInitialized, stytchUser, stytchSession ->
+            val userData =
+                if (stytchUser is StytchObjectInfo.Available) {
+                    stytchUser.value
+                } else {
+                    null
+                }
+            val sessionData =
+                if (stytchSession is StytchObjectInfo.Available) {
+                    stytchSession.value
+                } else {
+                    null
+                }
+            AuthenticationState(
+                isInitialized = isInitialized,
+                userData = userData,
+                sessionData = sessionData,
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AuthenticationState())
 }
 
 @Parcelize

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/Route.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/Route.kt
@@ -8,4 +8,6 @@ internal sealed class Route(
     data object Login : Route("login")
 
     data object Profile : Route("profile")
+
+    data object UILogin : Route("ui-login")
 }

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/ui/screens/login/LoginRoute.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/ui/screens/login/LoginRoute.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -49,6 +50,7 @@ internal fun LoginRoute(
                 setConfirmationCode = viewModel::setConfirmationCode,
                 submitPhoneNumber = viewModel::submitPhoneNumber,
                 confirmCode = viewModel::confirmCode,
+                launchUILogin = { navigateTo(Route.UILogin) },
             )
     }
 }
@@ -109,6 +111,7 @@ private fun LoginScreen(
     setConfirmationCode: (String) -> Unit,
     submitPhoneNumber: () -> Unit,
     confirmCode: () -> Unit,
+    launchUILogin: () -> Unit,
 ) {
     Column {
         if (!uiState.methodIdExists) {
@@ -153,6 +156,16 @@ private fun LoginScreen(
                 text = uiState.screenState.error.message ?: "Something went wrong",
                 style = MaterialTheme.typography.bodySmall,
                 color = Color.Red,
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = launchUILogin,
+        ) {
+            Text(
+                text = "Try Stytch UI",
+                style = MaterialTheme.typography.bodySmall,
             )
         }
     }

--- a/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/ui/screens/profile/ProfileRoute.kt
+++ b/example-apps/stytchexampleapp/src/main/java/com/stytch/stytchexampleapp/ui/screens/profile/ProfileRoute.kt
@@ -1,5 +1,7 @@
 package com.stytch.stytchexampleapp.ui.screens.profile
 
+import android.R.attr.text
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,20 +10,30 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.stytch.sdk.consumer.StytchClient
+import com.stytch.sdk.consumer.biometrics.Biometrics
 import com.stytch.sdk.consumer.network.models.SessionData
 import com.stytch.sdk.consumer.network.models.UserData
 import com.stytch.stytchexampleapp.AuthenticationState
 import com.stytch.stytchexampleapp.Route
 import com.stytch.stytchexampleapp.ScreenState
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun ProfileRoute(
@@ -72,12 +84,93 @@ private fun ProfileScreen(
     logout: () -> Unit,
     extendSession: () -> Unit,
 ) {
+    val context = LocalActivity.current as FragmentActivity
+    val scope = rememberCoroutineScope()
+    var biometricsAreAvailable = remember { mutableStateOf(false) }
+    var canRegisterBiometrics = remember { mutableStateOf(false) }
+    var canRemoveBiometrics = remember { mutableStateOf(false) }
+    var canAddBiometricsToSession = remember { mutableStateOf(false) }
+    var didDeleteBiometrics = remember { mutableStateOf(false) }
+
+    LaunchedEffect(sessionData, didDeleteBiometrics) {
+        biometricsAreAvailable.value = StytchClient.biometrics.isRegistrationAvailable(context)
+        canRegisterBiometrics.value = !biometricsAreAvailable.value
+        var hasAlreadyAuthedWithBiometrics = sessionData.authenticationFactors.any { it.biometricFactor != null }
+        canRemoveBiometrics.value =
+            biometricsAreAvailable.value &&
+            hasAlreadyAuthedWithBiometrics &&
+            sessionData.authenticationFactors.size >= 2
+        canAddBiometricsToSession.value = biometricsAreAvailable.value && !hasAlreadyAuthedWithBiometrics
+    }
+
+    fun removeBiometrics() {
+        scope.launch {
+            StytchClient.biometrics.removeRegistration()
+            didDeleteBiometrics.value = true
+        }
+    }
+
+    fun addBiometrics() {
+        scope.launch {
+            StytchClient.biometrics.register(
+                Biometrics.RegisterParameters(context = context),
+            )
+        }
+    }
+
+    fun authenticateBiometrics() {
+        scope.launch {
+            StytchClient.biometrics.authenticate(
+                Biometrics.AuthenticateParameters(context = context),
+            )
+        }
+    }
     Column {
         KeyValueRow(key = "User Id", value = userData.userId)
         KeyValueRow(key = "Phone Number", value = userData.phoneNumbers.first().phoneNumber)
         KeyValueRow(key = "Session Id", value = sessionData.sessionId)
         KeyValueRow(key = "Session Start", value = sessionData.startedAt)
         KeyValueRow(key = "Session Expires", value = sessionData.expiresAt)
+        if (canRegisterBiometrics.value) {
+            Row(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+                OutlinedButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = ::addBiometrics,
+                ) {
+                    Text(
+                        text = "Register biometrics",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+        if (canRemoveBiometrics.value) {
+            Row(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+                OutlinedButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = ::removeBiometrics,
+                ) {
+                    Text(
+                        text = "Delete biometrics",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+        if (canAddBiometricsToSession.value) {
+            Row(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+                OutlinedButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = ::authenticateBiometrics,
+                ) {
+                    Text(
+                        text = "Auth with biometrics",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.47.3"
+extra["PUBLISH_VERSION"] = "0.48.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/androidTest/java/com/stytch/sdk/ui/b2c/BaseAndroidComposeTest.kt
+++ b/source/sdk/src/androidTest/java/com/stytch/sdk/ui/b2c/BaseAndroidComposeTest.kt
@@ -3,8 +3,11 @@ package com.stytch.sdk.ui.b2c
 import android.content.Intent
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.ui.b2c.data.DEFAULT_STYTCH_UI_CONFIG
 import com.stytch.sdk.ui.utils.createAndroidIntentComposeRule
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -13,6 +16,9 @@ internal abstract class BaseAndroidComposeTest {
     @get:Rule
     val composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<AuthenticationActivity>, AuthenticationActivity> =
         createAndroidIntentComposeRule {
+            MainScope().launch {
+                StytchClient.configure(it)
+            }
             Intent(it, AuthenticationActivity::class.java).apply {
                 // we launch with a default config just so the activity doesn't auto exit.
                 // We override the actual content in the robots themselves

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationActivity.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationActivity.kt
@@ -38,7 +38,7 @@ internal class AuthenticationActivity : FragmentActivity() {
                 return@onCreate
             }
         viewModel.enableBiometricRegistrationOnAuthentication(
-            uiConfig.productConfig.biometricsOptions.forceRegistrationOnLoginIfNoneFound &&
+            uiConfig.productConfig.biometricsOptions.showBiometricRegistrationOnLogin &&
                 StytchClient.biometrics.areBiometricsAvailable(this) == AvailableNoRegistrations,
         )
         // log render_login_screen

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import kotlin.collections.set
 
 internal class AuthenticationViewModel(
     private val stytchClient: StytchClient,
@@ -32,6 +33,11 @@ internal class AuthenticationViewModel(
     val eventFlow = _eventFlow.asSharedFlow()
 
     val uiState = savedStateHandle.getStateFlow(ApplicationUIState.SAVED_STATE_KEY, ApplicationUIState())
+
+    fun enableBiometricRegistrationOnAuthentication(value: Boolean) {
+        savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
+            uiState.value.copy(showBiometricRegistrationOnLogin = value)
+    }
 
     fun authenticateThirdPartyOAuth(
         resultCode: Int,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/ApplicationUIState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/ApplicationUIState.kt
@@ -15,6 +15,7 @@ internal data class ApplicationUIState(
     val showLoadingDialog: Boolean = false,
     val showResendDialog: Boolean = false,
     val expirationTimeFormatted: String = "",
+    val showBiometricRegistrationOnLogin: Boolean = false,
 ) : Parcelable {
     internal companion object {
         const val SAVED_STATE_KEY = "StytchAuthApplicationUIState"

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/BiometricsOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/BiometricsOptions.kt
@@ -1,0 +1,15 @@
+package com.stytch.sdk.ui.b2c.data
+
+import android.os.Parcelable
+import com.squareup.moshi.JsonClass
+import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonClass(generateAdapter = true)
+@JacocoExcludeGenerated
+public data class BiometricsOptions
+    @JvmOverloads
+    constructor(
+        val forceRegistrationOnLoginIfNoneFound: Boolean = false,
+    ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/BiometricsOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/BiometricsOptions.kt
@@ -11,5 +11,5 @@ import kotlinx.parcelize.Parcelize
 public data class BiometricsOptions
     @JvmOverloads
     constructor(
-        val forceRegistrationOnLoginIfNoneFound: Boolean = false,
+        val showBiometricRegistrationOnLogin: Boolean = false,
     ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProduct.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProduct.kt
@@ -24,4 +24,9 @@ public enum class StytchProduct {
      * An enum value representing the Passwords Product
      */
     PASSWORDS,
+
+    /**
+     * An enum value representing the Biometrics Product
+     */
+    BIOMETRICS,
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProductConfig.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/data/StytchProductConfig.kt
@@ -35,5 +35,6 @@ public data class StytchProductConfig
         val sessionOptions: SessionOptions = SessionOptions(),
         val passwordOptions: PasswordOptions = PasswordOptions(),
         val googleOauthOptions: GoogleOAuthOptions = GoogleOAuthOptions(),
+        val biometricsOptions: BiometricsOptions = BiometricsOptions(),
         val locale: Locale = Locale.EN,
     ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.androidx.AndroidScreen
+import com.stytch.sdk.R
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.ui.b2c.AuthenticationActivity
 import com.stytch.sdk.ui.b2c.data.EventState
@@ -57,11 +59,14 @@ private fun BiometricRegistrationScreenComposable(
     val context = LocalActivity.current as FragmentActivity
     Column(modifier = Modifier.padding(bottom = 32.dp)) {
         PageTitle(
-            text = "Enable Biometric Login?",
+            text = stringResource(R.string.stytch_b2c_enable_biometric_login),
             textAlign = TextAlign.Start,
         )
-        BodyText(text = "Use biometrics to log into your account.")
-        StytchButton(enabled = true, onClick = { registerBiometrics(context) }, text = "Enroll in Biometrics")
-        StytchTextButton(text = "Skip for now", onClick = skipRegistration)
+        BodyText(text = stringResource(R.string.stytch_b2c_use_biometrics_to_log_into_your_account))
+        StytchButton(enabled = true, onClick = { registerBiometrics(context) }, text =
+            stringResource(
+                R.string.stytch_b2c_enroll_in_biometrics)
+        )
+        StytchTextButton(text = stringResource(R.string.stytch_b2c_skip_for_now), onClick = skipRegistration)
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
@@ -1,0 +1,55 @@
+package com.stytch.sdk.ui.b2c.screens
+
+import android.os.Parcelable
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cafe.adriel.voyager.androidx.AndroidScreen
+import com.stytch.sdk.ui.b2c.AuthenticationActivity
+import com.stytch.sdk.ui.b2c.data.EventState
+import com.stytch.sdk.ui.shared.components.PageTitle
+import com.stytch.sdk.ui.shared.components.StytchButton
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data object BiometricRegistrationScreen :
+    AndroidScreen(),
+    Parcelable {
+    @Composable
+    override fun Content() {
+        val context = LocalActivity.current as AuthenticationActivity
+        val viewModel =
+            viewModel<BiometricRegistrationScreenViewModel>(
+                factory = BiometricRegistrationScreenViewModel.factory(context.savedStateHandle),
+            )
+        LaunchedEffect(Unit) {
+            viewModel.eventFlow.collectLatest {
+                when (it) {
+                    is EventState.Authenticated -> context.returnAuthenticationResult(it.result)
+                    else -> {}
+                }
+            }
+        }
+        BiometricRegistrationScreenComposable(registerBiometrics = viewModel::registerBiometrics)
+    }
+}
+
+@Composable
+private fun BiometricRegistrationScreenComposable(registerBiometrics: (FragmentActivity) -> Unit) {
+    val context = LocalActivity.current as FragmentActivity
+    Column(modifier = Modifier.padding(bottom = 32.dp)) {
+        PageTitle(
+            text = "Register Biometrics",
+            textAlign = TextAlign.Start,
+        )
+        StytchButton(enabled = true, onClick = { registerBiometrics(context) }, text = "Enroll in Biometrics")
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
@@ -12,16 +12,20 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.androidx.AndroidScreen
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.ui.b2c.AuthenticationActivity
 import com.stytch.sdk.ui.b2c.data.EventState
+import com.stytch.sdk.ui.shared.components.BodyText
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.StytchButton
+import com.stytch.sdk.ui.shared.components.StytchTextButton
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data object BiometricRegistrationScreen :
-    AndroidScreen(),
+internal data class BiometricRegistrationScreen(
+    val previousAuthenticationResult: StytchResult<*>,
+) : AndroidScreen(),
     Parcelable {
     @Composable
     override fun Content() {
@@ -38,18 +42,26 @@ internal data object BiometricRegistrationScreen :
                 }
             }
         }
-        BiometricRegistrationScreenComposable(registerBiometrics = viewModel::registerBiometrics)
+        BiometricRegistrationScreenComposable(
+            registerBiometrics = viewModel::registerBiometrics,
+            skipRegistration = { context.returnAuthenticationResult(previousAuthenticationResult, false) },
+        )
     }
 }
 
 @Composable
-private fun BiometricRegistrationScreenComposable(registerBiometrics: (FragmentActivity) -> Unit) {
+private fun BiometricRegistrationScreenComposable(
+    registerBiometrics: (FragmentActivity) -> Unit,
+    skipRegistration: () -> Unit,
+) {
     val context = LocalActivity.current as FragmentActivity
     Column(modifier = Modifier.padding(bottom = 32.dp)) {
         PageTitle(
-            text = "Register Biometrics",
+            text = "Enable Biometric Login?",
             textAlign = TextAlign.Start,
         )
+        BodyText(text = "Use biometrics to log into your account.")
         StytchButton(enabled = true, onClick = { registerBiometrics(context) }, text = "Enroll in Biometrics")
+        StytchTextButton(text = "Skip for now", onClick = skipRegistration)
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreen.kt
@@ -63,10 +63,14 @@ private fun BiometricRegistrationScreenComposable(
             textAlign = TextAlign.Start,
         )
         BodyText(text = stringResource(R.string.stytch_b2c_use_biometrics_to_log_into_your_account))
-        StytchButton(enabled = true, onClick = { registerBiometrics(context) }, text =
-            stringResource(
-                R.string.stytch_b2c_enroll_in_biometrics)
+        StytchButton(
+            enabled = true,
+            onClick = { registerBiometrics(context) },
+            text = stringResource(R.string.stytch_b2c_enroll_in_biometrics),
         )
-        StytchTextButton(text = stringResource(R.string.stytch_b2c_skip_for_now), onClick = skipRegistration)
+        StytchTextButton(
+            text = stringResource(R.string.stytch_b2c_skip_for_now),
+            onClick = skipRegistration,
+        )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/BiometricRegistrationScreenViewModel.kt
@@ -1,0 +1,48 @@
+package com.stytch.sdk.ui.b2c.screens
+
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.stytch.sdk.consumer.StytchClient
+import com.stytch.sdk.consumer.biometrics.Biometrics
+import com.stytch.sdk.ui.b2c.data.ApplicationUIState
+import com.stytch.sdk.ui.b2c.data.EventState
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+internal class BiometricRegistrationScreenViewModel(
+    private val savedStateHandle: SavedStateHandle,
+    private val stytchClient: StytchClient,
+) : ViewModel() {
+    val uiState = savedStateHandle.getStateFlow(ApplicationUIState.SAVED_STATE_KEY, ApplicationUIState())
+
+    private val _eventFlow = MutableSharedFlow<EventState>()
+    val eventFlow = _eventFlow.asSharedFlow()
+
+    fun registerBiometrics(context: FragmentActivity) {
+        viewModelScope.launch {
+            val result =
+                stytchClient.biometrics.register(
+                    Biometrics.RegisterParameters(context = context),
+                )
+            _eventFlow.emit(EventState.Authenticated(result))
+        }
+    }
+
+    companion object {
+        fun factory(savedStateHandle: SavedStateHandle): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    BiometricRegistrationScreenViewModel(
+                        stytchClient = StytchClient,
+                        savedStateHandle = savedStateHandle,
+                    )
+                }
+            }
+    }
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
@@ -2,9 +2,13 @@ package com.stytch.sdk.ui.b2c.screens
 
 import android.os.Parcelable
 import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults.SecondaryIndicator
@@ -16,7 +20,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -25,16 +31,21 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.androidx.AndroidScreen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.stytch.sdk.R
+import com.stytch.sdk.consumer.StytchClient
+import com.stytch.sdk.consumer.biometrics.BiometricAvailability.AvailableNoRegistrations
+import com.stytch.sdk.consumer.biometrics.Biometrics
 import com.stytch.sdk.ui.b2c.AuthenticationActivity
 import com.stytch.sdk.ui.b2c.data.ApplicationUIState
 import com.stytch.sdk.ui.b2c.data.EventState
 import com.stytch.sdk.ui.b2c.data.OAuthProvider
 import com.stytch.sdk.ui.b2c.data.OTPOptions
+import com.stytch.sdk.ui.b2c.data.StytchProduct
 import com.stytch.sdk.ui.b2c.data.StytchProductConfig
 import com.stytch.sdk.ui.shared.components.BackButton
 import com.stytch.sdk.ui.shared.components.DividerWithText
@@ -44,10 +55,12 @@ import com.stytch.sdk.ui.shared.components.LoadingDialog
 import com.stytch.sdk.ui.shared.components.PageTitle
 import com.stytch.sdk.ui.shared.components.PhoneEntry
 import com.stytch.sdk.ui.shared.components.SocialLoginButton
+import com.stytch.sdk.ui.shared.components.StytchButton
 import com.stytch.sdk.ui.shared.theme.LocalStytchProductConfig
 import com.stytch.sdk.ui.shared.theme.LocalStytchTheme
 import com.stytch.sdk.ui.shared.theme.LocalStytchTypography
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -57,9 +70,18 @@ internal object MainScreen : AndroidScreen(), Parcelable {
         val navigator = LocalNavigator.currentOrThrow
         val productConfig = LocalStytchProductConfig.current
         val context = LocalActivity.current as AuthenticationActivity
-        val viewModel = viewModel<MainScreenViewModel>(factory = MainScreenViewModel.factory(context.savedStateHandle))
+        val viewModel =
+            viewModel<MainScreenViewModel>(
+                factory = MainScreenViewModel.factory(context.savedStateHandle),
+            )
         val uiState = viewModel.uiState.collectAsState()
         LaunchedEffect(Unit) {
+            // enable biometrics after authentication if the developer requires them AND its available AND not
+            // already registered
+            viewModel.enableBiometricRegistrationOnAuthentication(
+                productConfig.biometricsOptions.forceRegistrationOnLoginIfNoneFound &&
+                    StytchClient.biometrics.areBiometricsAvailable(context) == AvailableNoRegistrations,
+            )
             viewModel.eventFlow.collectLatest {
                 when (it) {
                     is EventState.NavigationRequested -> navigator.push(it.navigationRoute.screen)
@@ -80,6 +102,7 @@ internal object MainScreen : AndroidScreen(), Parcelable {
             exitWithoutAuthenticating = context::exitWithoutAuthenticating,
             productComponents = viewModel.getProductComponents(productConfig.products),
             tabTypes = viewModel.getTabTitleOrdering(productConfig.products, productConfig.otpOptions.methods),
+            onToggleBiometricsRegistration = viewModel::enableBiometricRegistrationOnAuthentication,
         )
     }
 }
@@ -97,6 +120,7 @@ private fun MainScreenComposable(
     exitWithoutAuthenticating: () -> Unit,
     productComponents: List<ProductComponent>,
     tabTypes: List<TabTypes>,
+    onToggleBiometricsRegistration: (Boolean) -> Unit,
 ) {
     val productConfig = LocalStytchProductConfig.current
     val theme = LocalStytchTheme.current
@@ -113,6 +137,18 @@ private fun MainScreenComposable(
     val phoneState = uiState.phoneNumberState
     val emailState = uiState.emailState
     val semanticsOAuthButton = stringResource(id = R.string.semantics_oauth_button)
+    val context = LocalActivity.current as FragmentActivity
+    val scope = rememberCoroutineScope()
+
+    fun loginWithBiometrics() {
+        scope.launch {
+            StytchClient.biometrics.authenticate(
+                Biometrics.AuthenticateParameters(
+                    context = context,
+                ),
+            )
+        }
+    }
 
     Column(modifier = Modifier.padding(bottom = 24.dp)) {
         BackButton { exitWithoutAuthenticating() }
@@ -201,6 +237,39 @@ private fun MainScreenComposable(
                                 statusText = phoneState.error,
                             )
                         else -> Text(stringResource(id = R.string.misconfigured_otp))
+                    }
+                }
+            }
+        }
+        if (productConfig.products.contains(StytchProduct.BIOMETRICS)) {
+            if (StytchClient.biometrics.isRegistrationAvailable(context)) {
+                StytchButton(
+                    enabled = true,
+                    text = "Login With Biometrics",
+                    onClick = ::loginWithBiometrics,
+                )
+            } else {
+                if (!productConfig.biometricsOptions.forceRegistrationOnLoginIfNoneFound &&
+                    StytchClient.biometrics.areBiometricsAvailable(context) == AvailableNoRegistrations
+                ) {
+                    // not forced, and available, so show toggle
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            text = "Enroll in biometrics",
+                            style =
+                                type.body2.copy(
+                                    color = Color(theme.primaryTextColor),
+                                    lineHeight = 48.sp,
+                                ),
+                        )
+                        Switch(
+                            checked = uiState.showBiometricRegistrationOnLogin,
+                            onCheckedChange = { onToggleBiometricsRegistration(it) },
+                        )
                     }
                 }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
@@ -164,7 +164,7 @@ private fun MainScreenComposable(
                         modifier = Modifier.padding(bottom = 12.dp),
                         onClick = ::loginWithBiometrics,
                         imageVector = Icons.Default.Fingerprint,
-                        text = "Continue with Biometrics",
+                        text = stringResource(R.string.stytch_b2c_continue_with_biometrics),
                     )
                 }
                 ProductComponent.DIVIDER -> {
@@ -179,7 +179,10 @@ private fun MainScreenComposable(
                         TabRow(
                             selectedTabIndex = selectedTabIndex,
                             containerColor = Color(theme.backgroundColor),
-                            modifier = Modifier.padding(bottom = 12.dp).semantics { contentDescription = semanticTabs },
+                            modifier =
+                                Modifier
+                                    .padding(bottom = 12.dp)
+                                    .semantics { contentDescription = semanticTabs },
                             indicator = { tabPositions ->
                                 SecondaryIndicator(
                                     modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
@@ -71,9 +71,9 @@ internal class MainScreenViewModel(
             products.any {
                 listOf(StytchProduct.OTP, StytchProduct.PASSWORDS, StytchProduct.EMAIL_MAGIC_LINKS).contains(it)
             }
-        val hasBiometrics = products.contains(StytchProduct.BIOMETRICS)
-        val enrolledInBiometrics = StytchClient.biometrics.isRegistrationAvailable(context)
-        val hasDivider = (hasButtons || (hasBiometrics && enrolledInBiometrics)) && hasInput
+        val hasBiometrics =
+            products.contains(StytchProduct.BIOMETRICS) && StytchClient.biometrics.isRegistrationAvailable(context)
+        val hasDivider = (hasButtons || hasBiometrics) && hasInput
         return mutableListOf<ProductComponent>()
             .apply {
                 products.forEachIndexed { index, product ->
@@ -89,7 +89,7 @@ internal class MainScreenViewModel(
                     ) {
                         add(ProductComponent.INPUTS)
                     }
-                    if (product == StytchProduct.BIOMETRICS && enrolledInBiometrics) {
+                    if (product == StytchProduct.BIOMETRICS && hasBiometrics) {
                         add(ProductComponent.BIOMETRICS)
                     }
                 }
@@ -157,8 +157,8 @@ internal class MainScreenViewModel(
             OAuth.ThirdParty.StartParameters(
                 context = context,
                 oAuthRequestIdentifier = STYTCH_THIRD_PARTY_OAUTH_REQUEST_ID,
-                loginRedirectUrl = "${StytchClient.configurationManager.publicToken}://oauth",
-                signupRedirectUrl = "${StytchClient.configurationManager.publicToken}://oauth",
+                loginRedirectUrl = "${stytchClient.configurationManager.publicToken}://oauth",
+                signupRedirectUrl = "${stytchClient.configurationManager.publicToken}://oauth",
             )
         when (provider) {
             OAuthProvider.AMAZON -> stytchClient.oauth.amazon.start(parameters)

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
@@ -60,6 +60,11 @@ internal class MainScreenViewModel(
     private val _eventFlow = MutableSharedFlow<EventState>()
     val eventFlow = _eventFlow.asSharedFlow()
 
+    fun enableBiometricRegistrationOnAuthentication(value: Boolean) {
+        savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
+            uiState.value.copy(showBiometricRegistrationOnLogin = value)
+    }
+
     fun getProductComponents(products: List<StytchProduct>): List<ProductComponent> {
         val hasButtons = products.contains(StytchProduct.OAUTH)
         val hasInput =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/SocialLoginButton.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/SocialLoginButton.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -28,6 +29,7 @@ internal fun SocialLoginButton(
     onClick: () -> Unit = {},
     iconDrawable: Painter? = null,
     iconDescription: String? = null,
+    imageVector: ImageVector? = null,
     text: String,
 ) {
     val theme = LocalStytchTheme.current
@@ -50,6 +52,13 @@ internal fun SocialLoginButton(
             if (iconDrawable != null) {
                 Image(
                     painter = iconDrawable,
+                    contentDescription = iconDescription,
+                    modifier = Modifier.width(24.dp).padding(end = 4.dp),
+                )
+            }
+            if (imageVector != null) {
+                Image(
+                    imageVector = imageVector,
                     contentDescription = iconDescription,
                     modifier = Modifier.width(24.dp).padding(end = 4.dp),
                 )

--- a/source/sdk/src/main/res/values/strings.xml
+++ b/source/sdk/src/main/res/values/strings.xml
@@ -103,4 +103,9 @@
     <string name="semantics_loading_dialog">Loading</string>
     <string name="semantics_email_password_entry">Entry form for email and password</string>
     <string name="semantics_otp_entry">Entry form for One Time Passcode</string>
+    <string name="stytch_b2c_enable_biometric_login">Enable Biometric Login?</string>
+    <string name="stytch_b2c_use_biometrics_to_log_into_your_account">Use biometrics to log into your account.</string>
+    <string name="stytch_b2c_enroll_in_biometrics">Enroll in Biometrics</string>
+    <string name="stytch_b2c_skip_for_now">Skip for now</string>
+    <string name="stytch_b2c_continue_with_biometrics">Continue with Biometrics</string>
 </resources>

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModelTest.kt
@@ -55,6 +55,10 @@ internal class MainScreenViewModelTest {
                     mockk(relaxed = true) {
                         every { logEvent(any(), any()) } just runs
                     }
+                every { configurationManager } returns
+                    mockk(relaxed = true) {
+                        every { publicToken } returns ""
+                    }
             }
         viewModel = spyk(MainScreenViewModel(savedStateHandle, mockStytchClient))
     }
@@ -525,31 +529,31 @@ internal class MainScreenViewModelTest {
     fun `getProductComponents returns the expected order`() {
         var given = listOf(StytchProduct.EMAIL_MAGIC_LINKS, StytchProduct.OAUTH)
         var expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
 
         given = listOf(StytchProduct.OTP, StytchProduct.OAUTH)
         expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
 
         given = listOf(StytchProduct.PASSWORDS, StytchProduct.OAUTH)
         expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
 
         given = listOf(StytchProduct.PASSWORDS, StytchProduct.EMAIL_MAGIC_LINKS, StytchProduct.OAUTH)
         expected = listOf(ProductComponent.INPUTS, ProductComponent.DIVIDER, ProductComponent.BUTTONS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
 
         given = listOf(StytchProduct.OAUTH, StytchProduct.EMAIL_MAGIC_LINKS)
         expected = listOf(ProductComponent.BUTTONS, ProductComponent.DIVIDER, ProductComponent.INPUTS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
 
         given = listOf(StytchProduct.OAUTH)
         expected = listOf(ProductComponent.BUTTONS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
 
         given = listOf(StytchProduct.EMAIL_MAGIC_LINKS)
         expected = listOf(ProductComponent.INPUTS)
-        assert(viewModel.getProductComponents(given) == expected)
+        assert(viewModel.getProductComponents(given, mockk()) == expected)
     }
 
     @Test


### PR DESCRIPTION
Linear Ticket: [SDK-2681](https://linear.app/stytch/issue/SDK-2681)

## Changes:

1. Add support to the consumer prebuilt UI for biometrics registration and authentication.
2. You can configure it so that you do or do not register after authentication via the `BiometricsOptions`.
3. If you choose not to register via the prebuilt UI you will have to call register from elsewhere.
4. In either case if the user is somehow registered and you include in the product config `StytchProduct.Biometrics` then a button will be added to the home screen to authenticate with biometrics.

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A