### PR TITLE
Fix B2C UI memory leak

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.47.3"
+extra["PUBLISH_VERSION"] = "0.47.4"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationActivity.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationActivity.kt
@@ -41,14 +41,14 @@ internal class AuthenticationActivity : ComponentActivity() {
                 eventName = "render_login_screen",
                 details = mapOf("options" to uiConfig.productConfig),
             )
-            StytchClient.user.onChange {
-                if (it is StytchObjectInfo.Available) {
-                    returnAuthenticationResult(StytchResult.Success(it.value))
-                }
-            }
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
+                StytchClient.user.onChange.collect {
+                    if (it is StytchObjectInfo.Available) {
+                        returnAuthenticationResult(StytchResult.Success(it.value))
+                    }
+                }
                 viewModel
                     .eventFlow
                     .collect {


### PR DESCRIPTION
Detected a potential memory leak in B2C prebuilt UI if launched multiple times. Instead of using the callback form for listening to user changes, instead collect changes with lifecycle awareness.