### PR TITLE
SDK-2688 Support custom API domains

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.49.0"
+extra["PUBLISH_VERSION"] = "0.50.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -69,10 +69,10 @@ import com.stytch.sdk.b2b.network.models.TOTPCreateResponseData
 import com.stytch.sdk.b2b.network.models.UpdateMemberResponseData
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeviceInfo
-import com.stytch.sdk.common.LIVE_SDK_URL
+import com.stytch.sdk.common.EndpointOptions
 import com.stytch.sdk.common.NoResponseResponse
+import com.stytch.sdk.common.SDK_URL_PATH
 import com.stytch.sdk.common.StytchResult
-import com.stytch.sdk.common.TEST_SDK_URL
 import com.stytch.sdk.common.dfp.DFPConfiguration
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.events.EventsAPI
@@ -95,16 +95,19 @@ internal object StytchB2BApi : CommonApi {
     private lateinit var deviceInfo: DeviceInfo
     private lateinit var apiServiceClass: ApiService
     private lateinit var dfpInterceptor: StytchDFPInterceptor
+    private lateinit var endpointOptions: EndpointOptions
 
     override fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
+        endpointOptions: EndpointOptions,
         getSessionToken: () -> String?,
         dfpConfiguration: DFPConfiguration,
     ) {
         this.publicToken = publicToken
         this.deviceInfo = deviceInfo
         this.dfpInterceptor = StytchDFPInterceptor(dfpConfiguration)
+        this.endpointOptions = endpointOptions
         apiServiceClass =
             ApiService(
                 sdkUrl,
@@ -132,14 +135,9 @@ internal object StytchB2BApi : CommonApi {
             return publicToken.contains("public-token-test")
         }
 
-    private val sdkUrl: String
-        get() {
-            return if (isTestToken) {
-                TEST_SDK_URL
-            } else {
-                LIVE_SDK_URL
-            }
-        }
+    private val sdkUrl: String by lazy {
+        "https://${if (isTestToken) endpointOptions.testDomain else endpointOptions.liveDomain}$SDK_URL_PATH"
+    }
 
     internal fun assertInitialized() {
         if (!isInitialized) {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -10,17 +10,15 @@ import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
-import com.stytch.sdk.common.LIVE_API_URL
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
-import com.stytch.sdk.common.TEST_API_URL
 import com.stytch.sdk.common.errors.NoActivityProvided
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.ProvidedReceiverManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
-import com.stytch.sdk.common.sso.SSOManagerActivity.Companion.URI_KEY
 import com.stytch.sdk.common.utils.buildUri
+import com.stytch.sdk.common.utils.getApiUrl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
@@ -108,9 +106,11 @@ internal class OAuthImpl(
         override fun start(parameters: OAuth.Provider.StartParameters) {
             val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
             val host =
-                StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
-                    "https://$it/"
-                } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                getApiUrl(
+                    StytchB2BClient.configurationManager.bootstrapData.cnameDomain,
+                    StytchB2BClient.configurationManager.options.endpointOptions,
+                    StytchB2BApi.isTestToken,
+                )
             val baseUrl = "${host}b2b/public/oauth/$providerName/start"
             val urlParams =
                 mapOf(
@@ -142,9 +142,11 @@ internal class OAuthImpl(
                     }
                     val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
                     val host =
-                        StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
-                            "https://$it/"
-                        } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                        getApiUrl(
+                            StytchB2BClient.configurationManager.bootstrapData.cnameDomain,
+                            StytchB2BClient.configurationManager.options.endpointOptions,
+                            StytchB2BApi.isTestToken,
+                        )
                     val baseUrl = "${host}b2b/public/oauth/$providerName/start"
                     val urlParams =
                         mapOf(
@@ -194,9 +196,11 @@ internal class OAuthImpl(
         override fun start(parameters: OAuth.ProviderDiscovery.DiscoveryStartParameters) {
             val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
             val host =
-                StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
-                    "https://$it/v1/"
-                } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                getApiUrl(
+                    StytchB2BClient.configurationManager.bootstrapData.cnameDomain,
+                    StytchB2BClient.configurationManager.options.endpointOptions,
+                    StytchB2BApi.isTestToken,
+                )
             val baseUrl = "${host}b2b/public/oauth/$providerName/discovery/start"
             val urlParams =
                 mapOf(
@@ -225,9 +229,11 @@ internal class OAuthImpl(
                     }
                     val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
                     val host =
-                        StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
-                            "https://$it/v1/"
-                        } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                        getApiUrl(
+                            StytchB2BClient.configurationManager.bootstrapData.cnameDomain,
+                            StytchB2BClient.configurationManager.options.endpointOptions,
+                            StytchB2BApi.isTestToken,
+                        )
                     val baseUrl = "${host}b2b/public/oauth/$providerName/discovery/start"
                     val urlParams =
                         mapOf(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/oauth/OAuthImpl.kt
@@ -193,7 +193,10 @@ internal class OAuthImpl(
     ) : OAuth.ProviderDiscovery {
         override fun start(parameters: OAuth.ProviderDiscovery.DiscoveryStartParameters) {
             val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
-            val host = if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+            val host =
+                StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
+                    "https://$it/v1/"
+                } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
             val baseUrl = "${host}b2b/public/oauth/$providerName/discovery/start"
             val urlParams =
                 mapOf(
@@ -221,7 +224,10 @@ internal class OAuthImpl(
                         return@suspendCancellableCoroutine
                     }
                     val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
-                    val host = if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                    val host =
+                        StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
+                            "https://$it/v1/"
+                        } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
                     val baseUrl = "${host}b2b/public/oauth/$providerName/discovery/start"
                     val urlParams =
                         mapOf(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sso/SSOImpl.kt
@@ -16,16 +16,15 @@ import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.sessions.B2BSessionStorage
-import com.stytch.sdk.common.LIVE_API_URL
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
-import com.stytch.sdk.common.TEST_API_URL
 import com.stytch.sdk.common.errors.NoActivityProvided
 import com.stytch.sdk.common.errors.StytchMissingPKCEError
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.ProvidedReceiverManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.utils.buildUri
+import com.stytch.sdk.common.utils.getApiUrl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
@@ -48,9 +47,11 @@ internal class SSOImpl(
 
     override fun start(params: SSO.StartParams) {
         val host =
-            StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
-                "https://$it/v1/"
-            } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+            getApiUrl(
+                StytchB2BClient.configurationManager.bootstrapData.cnameDomain,
+                StytchB2BClient.configurationManager.options.endpointOptions,
+                StytchB2BApi.isTestToken,
+            )
         val potentialParameters =
             mapOf(
                 "connection_id" to params.connectionId,
@@ -75,9 +76,11 @@ internal class SSOImpl(
                     return@suspendCancellableCoroutine
                 }
                 val host =
-                    StytchB2BClient.configurationManager.bootstrapData.cnameDomain?.let {
-                        "https://$it/v1/"
-                    } ?: if (StytchB2BApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                    getApiUrl(
+                        StytchB2BClient.configurationManager.bootstrapData.cnameDomain,
+                        StytchB2BClient.configurationManager.options.endpointOptions,
+                        StytchB2BApi.isTestToken,
+                    )
                 val potentialParameters =
                     mapOf(
                         "connection_id" to parameters.connectionId,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 internal class ConfigurationManager {
     internal lateinit var deviceInfo: DeviceInfo
     internal lateinit var appSessionId: String
-    private var options: StytchClientOptions = StytchClientOptions()
+    internal var options: StytchClientOptions = StytchClientOptions()
     internal var applicationContext = WeakReference<Context>(null)
     internal var dispatchers: StytchDispatchers = StytchDispatchers()
     internal var externalScope: CoroutineScope = CoroutineScope(SupervisorJob())

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -80,7 +80,13 @@ internal class ConfigurationManager {
                 dfpProtectedAuthEnabled = bootstrapData.dfpProtectedAuthEnabled,
                 dfpProtectedAuthMode = bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
             )
-        client.commonApi.configure(publicToken, deviceInfo, client::getSessionToken, dfpConfiguration)
+        client.commonApi.configure(
+            publicToken,
+            deviceInfo,
+            options.endpointOptions,
+            client::getSessionToken,
+            dfpConfiguration,
+        )
         val bootstrapJob = refreshBootstrapAndApi(true)
         val sessionRehydrationJob = client.rehydrateSession()
         externalScope.launch(dispatchers.io) {

--- a/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
@@ -1,9 +1,11 @@
 package com.stytch.sdk.common
 
-internal const val TEST_SDK_URL: String = "https://test.stytch.com/sdk/v1/"
-internal const val LIVE_SDK_URL: String = "https://api.stytch.com/sdk/v1/"
-internal const val TEST_API_URL: String = "https://test.stytch.com/v1/"
-internal const val LIVE_API_URL: String = "https://api.stytch.com/v1/"
+internal const val TEST_BASE_DOMAIN: String = "test.stytch.com"
+internal const val LIVE_BASE_DOMAIN: String = "api.stytch.com"
+internal const val DEFAULT_DFPPA_DOMAIN: String = "telemetry.stytch.com"
+internal const val SDK_URL_PATH: String = "/sdk/v1/"
+internal const val TEST_API_URL: String = "https://$TEST_BASE_DOMAIN/v1/"
+internal const val LIVE_API_URL: String = "https://$LIVE_BASE_DOMAIN/v1/"
 
 // Auth headers
 internal const val AUTH_HEADER_SDK_NAME = "stytch-android"

--- a/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
@@ -4,8 +4,7 @@ internal const val TEST_BASE_DOMAIN: String = "test.stytch.com"
 internal const val LIVE_BASE_DOMAIN: String = "api.stytch.com"
 internal const val DEFAULT_DFPPA_DOMAIN: String = "telemetry.stytch.com"
 internal const val SDK_URL_PATH: String = "/sdk/v1/"
-internal const val TEST_API_URL: String = "https://$TEST_BASE_DOMAIN/v1/"
-internal const val LIVE_API_URL: String = "https://$LIVE_BASE_DOMAIN/v1/"
+internal const val API_URL_PATH: String = "/v1/"
 
 // Auth headers
 internal const val AUTH_HEADER_SDK_NAME = "stytch-android"

--- a/source/sdk/src/main/java/com/stytch/sdk/common/EndpointOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/EndpointOptions.kt
@@ -10,5 +10,7 @@ import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 public data class EndpointOptions
     @JvmOverloads
     constructor(
-        val dfppaDomain: String = "telemetry.stytch.com",
+        val testDomain: String = TEST_BASE_DOMAIN,
+        val liveDomain: String = LIVE_BASE_DOMAIN,
+        val dfppaDomain: String = DEFAULT_DFPPA_DOMAIN,
     )

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/CommonApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/CommonApi.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.common.network
 
 import com.stytch.sdk.common.DeviceInfo
+import com.stytch.sdk.common.EndpointOptions
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.DFPConfiguration
 import com.stytch.sdk.common.network.models.BootstrapData
@@ -9,6 +10,7 @@ internal interface CommonApi {
     fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
+        endpointOptions: EndpointOptions,
         getSessionToken: () -> String?,
         dfpConfiguration: DFPConfiguration,
     )

--- a/source/sdk/src/main/java/com/stytch/sdk/common/utils/GetApiUrl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/utils/GetApiUrl.kt
@@ -1,0 +1,13 @@
+package com.stytch.sdk.common.utils
+
+import com.stytch.sdk.common.API_URL_PATH
+import com.stytch.sdk.common.EndpointOptions
+
+internal fun getApiUrl(
+    cnameDomain: String?,
+    endpointOptions: EndpointOptions,
+    isTestToken: Boolean,
+): String {
+    val domain = cnameDomain ?: if (isTestToken) endpointOptions.testDomain else endpointOptions.liveDomain
+    return "https://$domain$API_URL_PATH"
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -2,10 +2,10 @@ package com.stytch.sdk.consumer.network
 
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.DeviceInfo
-import com.stytch.sdk.common.LIVE_SDK_URL
+import com.stytch.sdk.common.EndpointOptions
 import com.stytch.sdk.common.NoResponseResponse
+import com.stytch.sdk.common.SDK_URL_PATH
 import com.stytch.sdk.common.StytchResult
-import com.stytch.sdk.common.TEST_SDK_URL
 import com.stytch.sdk.common.dfp.DFPConfiguration
 import com.stytch.sdk.common.errors.StytchSDKNotConfiguredError
 import com.stytch.sdk.common.events.EventsAPI
@@ -54,16 +54,19 @@ internal object StytchApi : CommonApi {
     private lateinit var deviceInfo: DeviceInfo
     private lateinit var apiServiceClass: ApiService
     private lateinit var dfpInterceptor: StytchDFPInterceptor
+    private lateinit var endpointOptions: EndpointOptions
 
     override fun configure(
         publicToken: String,
         deviceInfo: DeviceInfo,
+        endpointOptions: EndpointOptions,
         getSessionToken: () -> String?,
         dfpConfiguration: DFPConfiguration,
     ) {
         this.publicToken = publicToken
         this.deviceInfo = deviceInfo
         this.dfpInterceptor = StytchDFPInterceptor(dfpConfiguration)
+        this.endpointOptions = endpointOptions
         apiServiceClass =
             ApiService(
                 sdkUrl,
@@ -93,11 +96,7 @@ internal object StytchApi : CommonApi {
         }
 
     private val sdkUrl: String by lazy {
-        if (isTestToken) {
-            TEST_SDK_URL
-        } else {
-            LIVE_SDK_URL
-        }
+        "https://${if (isTestToken) endpointOptions.testDomain else endpointOptions.liveDomain}$SDK_URL_PATH"
     }
 
     internal fun assertInitialized() {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/oauth/ThirdPartyOAuthImpl.kt
@@ -3,15 +3,14 @@ package com.stytch.sdk.consumer.oauth
 import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
-import com.stytch.sdk.common.LIVE_API_URL
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
-import com.stytch.sdk.common.TEST_API_URL
 import com.stytch.sdk.common.errors.NoActivityProvided
 import com.stytch.sdk.common.pkcePairManager.PKCEPairManager
 import com.stytch.sdk.common.sso.SSOManagerActivity
 import com.stytch.sdk.common.sso.SSOManagerActivity.Companion.URI_KEY
 import com.stytch.sdk.common.utils.buildUri
+import com.stytch.sdk.common.utils.getApiUrl
 import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.StytchApi
 import kotlinx.coroutines.CoroutineScope
@@ -35,9 +34,11 @@ internal class ThirdPartyOAuthImpl(
         val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
         val token = StytchApi.publicToken
         val host =
-            StytchClient.configurationManager.bootstrapData.cnameDomain?.let {
-                "https://$it/v1/"
-            } ?: if (StytchApi.isTestToken) TEST_API_URL else LIVE_API_URL
+            getApiUrl(
+                StytchClient.configurationManager.bootstrapData.cnameDomain,
+                StytchClient.configurationManager.options.endpointOptions,
+                StytchApi.isTestToken,
+            )
         val baseUrl = "${host}public/oauth/$providerName/start"
         val potentialParameters =
             mapOf(
@@ -68,9 +69,11 @@ internal class ThirdPartyOAuthImpl(
                 val pkce = pkcePairManager.generateAndReturnPKCECodePair().codeChallenge
                 val token = StytchApi.publicToken
                 val host =
-                    StytchClient.configurationManager.bootstrapData.cnameDomain?.let {
-                        "https://$it/v1/"
-                    } ?: if (StytchApi.isTestToken) TEST_API_URL else LIVE_API_URL
+                    getApiUrl(
+                        StytchClient.configurationManager.bootstrapData.cnameDomain,
+                        StytchClient.configurationManager.options.endpointOptions,
+                        StytchApi.isTestToken,
+                    )
                 val baseUrl = "${host}public/oauth/$providerName/start"
                 val potentialParameters =
                     mapOf(

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -146,7 +146,7 @@ internal class StytchB2BClientTest {
         every { mContextMock.getDeviceInfo() } returns deviceInfo
         val publicToken = UUID.randomUUID().toString()
         stytchClientObject.configure(mContextMock, publicToken)
-        verify { StytchB2BApi.configure(publicToken, deviceInfo, any(), any()) }
+        verify { StytchB2BApi.configure(publicToken, deviceInfo, any(), any(), any()) }
     }
 
     @Test

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -14,6 +14,7 @@ import com.stytch.sdk.b2b.sessions.B2BSessionStorage
 import com.stytch.sdk.common.AppLifecycleListener
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
+import com.stytch.sdk.common.EndpointOptions
 import com.stytch.sdk.common.NetworkChangeListener
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
@@ -90,7 +91,7 @@ internal class StytchB2BApiTest {
 
     @Test
     fun `StytchB2BApi isInitialized returns correctly based on configuration state`() {
-        StytchB2BApi.configure("publicToken", DeviceInfo(), { null }, mockk())
+        StytchB2BApi.configure("publicToken", DeviceInfo(), EndpointOptions(), { null }, mockk())
         assert(StytchB2BApi.isInitialized)
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/common/utils/GetApiUrlTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/common/utils/GetApiUrlTest.kt
@@ -1,0 +1,37 @@
+package com.stytch.sdk.common.utils
+
+import com.stytch.sdk.common.API_URL_PATH
+import com.stytch.sdk.common.EndpointOptions
+import com.stytch.sdk.common.LIVE_BASE_DOMAIN
+import com.stytch.sdk.common.TEST_BASE_DOMAIN
+import org.junit.Test
+
+internal class GetApiUrlTest {
+    @Test
+    fun `getApiUrl returns as expected`() {
+        // with cname
+        var apiUrl = getApiUrl("my.custom.domain", EndpointOptions(), true)
+        assert(apiUrl == "https://my.custom.domain$API_URL_PATH")
+
+        // no cname, no custom domain, test token
+        apiUrl = getApiUrl(null, EndpointOptions(), true)
+        assert(apiUrl == "https://${TEST_BASE_DOMAIN}$API_URL_PATH")
+
+        // no cname, no custom domain, live token
+        apiUrl = getApiUrl(null, EndpointOptions(), false)
+        assert(apiUrl == "https://${LIVE_BASE_DOMAIN}$API_URL_PATH")
+
+        val customDomains =
+            EndpointOptions(
+                testDomain = "my-test-domain.com",
+                liveDomain = "my-live-domain.com",
+            )
+        // no cname, with custom domains, test token
+        apiUrl = getApiUrl(null, customDomains, true)
+        assert(apiUrl == "https://${customDomains.testDomain}$API_URL_PATH")
+
+        // no cname, with custom domains, live token
+        apiUrl = getApiUrl(null, customDomains, false)
+        assert(apiUrl == "https://${customDomains.liveDomain}$API_URL_PATH")
+    }
+}

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -144,7 +144,7 @@ internal class StytchClientTest {
         every { mContextMock.getDeviceInfo() } returns deviceInfo
         val publicToken = UUID.randomUUID().toString()
         stytchClientObject.configure(mContextMock, publicToken)
-        verify { StytchApi.configure(publicToken, deviceInfo, any(), any()) }
+        verify { StytchApi.configure(publicToken, deviceInfo, any(), any(), any()) }
     }
 
     @Test

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
+import com.stytch.sdk.common.EndpointOptions
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchAPIError
@@ -77,7 +78,7 @@ internal class StytchApiTest {
 
     @Test
     fun `StytchApi isInitialized returns correctly based on configuration state`() {
-        StytchApi.configure("publicToken", DeviceInfo(), { null }, mockk())
+        StytchApi.configure("publicToken", DeviceInfo(), EndpointOptions(), { null }, mockk())
         assert(StytchApi.isInitialized)
     }
 


### PR DESCRIPTION
Linear Ticket: [SDK-2688](https://linear.app/stytch/issue/SDK-2688)

## Changes:

1. Adds support for custom domains
2. Adds CNAME checking to B2B OAuth where it was missing

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A