### PR TITLE
SDK-2676 Handle cases of insecure biometric factors

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.50.0"
+extra["PUBLISH_VERSION"] = "0.50.1"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")


### PR DESCRIPTION
Linear Ticket: [SDK-2676](https://linear.app/stytch/issue/SDK-2676)

## Changes:

1. Explicitly handle IllegalStateException/InvalidAlgorithmParameterException when generating the secret key since the fallback method can return incorrect results

## Notes:

- See: https://issuetracker.google.com/issues/147374428

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A