### PR TITLE
SDK-2718 Fallback to regular Google OAuth if CredentialManager fails

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.50.1"
+extra["PUBLISH_VERSION"] = "0.50.2"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
@@ -141,7 +141,18 @@ internal class MainScreenViewModel(
                                 clientId = clientId,
                             ),
                         )
-                    _eventFlow.emit(EventState.Authenticated(result))
+                    when (result) {
+                        is StytchResult.Success -> {
+                            _eventFlow.emit(EventState.Authenticated(result))
+                        }
+                        is StytchResult.Error -> {
+                            onStartThirdPartyOAuth(
+                                context,
+                                provider = provider,
+                                oAuthOptions = productConfig.oAuthOptions,
+                            )
+                        }
+                    }
                 } ?: onStartThirdPartyOAuth(context, provider = provider, oAuthOptions = productConfig.oAuthOptions)
             }
         } else {
@@ -182,6 +193,7 @@ internal class MainScreenViewModel(
             OAuthProvider.TWITCH -> stytchClient.oauth.twitch.start(parameters)
             OAuthProvider.TWITTER -> stytchClient.oauth.twitter.start(parameters)
         }
+        savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] = uiState.value.copy(showLoadingDialog = false)
     }
 
     fun onCountryCodeChanged(countryCode: String) {


### PR DESCRIPTION
Linear Ticket: [SDK-2718](https://linear.app/stytch/issue/SDK-2718)

## Changes:

1. Adds a failure check to Google Credential Manager (OneTap) flow in PreBuilt B2C UI to fallback to regular OAuth if it fails for some reason
2. Fixes an issue where the loading spinner doesn't disappear on a canceled/failed OAuth flow

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A