### PR TITLE
SDK-2719 Add configuration option to choose between webview and native DFP implementations

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.50.2"
+extra["PUBLISH_VERSION"] = "0.51.0"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/source/sdk/src/main/assets/dfp.html
+++ b/source/sdk/src/main/assets/dfp.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+    <head>
+        <script src="https://elements.stytch.com/telemetry.js"></script>
+    </head>
+    <body>
+        <script>
+            function fetchTelemetryId(publicToken, dfppaDomain) {
+                window.GetTelemetryID({ publicToken: publicToken, platform: "Android", submitURL: dfppaDomain })
+                    .then((telemetryId) => StytchDFP.reportTelemetryId(telemetryId))
+                    .catch((error) => StytchDFP.reportTelemetryId(error.message));
+            }
+        </script>
+    </body>
+</html>

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -6,6 +6,8 @@ import com.stytch.sdk.common.dfp.CaptchaProviderImpl
 import com.stytch.sdk.common.dfp.DFPConfiguration
 import com.stytch.sdk.common.dfp.DFPProvider
 import com.stytch.sdk.common.dfp.DFPProviderImpl
+import com.stytch.sdk.common.dfp.DFPType
+import com.stytch.sdk.common.dfp.WebviewActivityProvider
 import com.stytch.sdk.common.extensions.getDeviceInfo
 import com.stytch.sdk.common.network.models.BootstrapData
 import com.stytch.sdk.common.network.models.DFPProtectedAuthMode
@@ -56,12 +58,20 @@ internal class ConfigurationManager {
         this.applicationContext = WeakReference(context.applicationContext)
         this.deviceInfo = context.getDeviceInfo()
         this.appSessionId = "app-session-id-${UUID.randomUUID()}"
+        val activityProvider =
+            if (options.dfpType == DFPType.Webview) {
+                WebviewActivityProvider(context.applicationContext as Application)
+            } else {
+                null
+            }
         this.dfpProvider =
             DFPProviderImpl(
                 scope = externalScope,
                 context = context.applicationContext,
                 publicToken = publicToken,
                 dfppaDomain = options.endpointOptions.dfppaDomain,
+                dfpType = options.dfpType,
+                activityProvider = activityProvider,
             )
         this.smsRetriever =
             StytchSMSRetrieverImpl(context) { code, sessionDurationMinutes ->

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.common
 
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
+import com.stytch.sdk.common.dfp.DFPType
 
 /**
  * Options for configuring the StytchClient
@@ -11,4 +12,5 @@ public data class StytchClientOptions
     @JvmOverloads
     constructor(
         val endpointOptions: EndpointOptions = EndpointOptions(),
+        val dfpType: DFPType = DFPType.Native,
     )

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPProvider.kt
@@ -1,8 +1,15 @@
 package com.stytch.sdk.common.dfp
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
@@ -15,30 +22,89 @@ internal interface DFPProvider {
 internal class DFPProviderImpl(
     scope: CoroutineScope,
     context: Context,
-    publicToken: String,
-    dfppaDomain: String,
+    private val publicToken: String,
+    private val dfppaDomain: String,
+    private val dfpType: DFPType,
+    private val activityProvider: WebviewActivityProvider? = null,
 ) : DFPProvider {
     private var dfp: StytchDFP? = null
+    private var continuation: CancellableContinuation<String>? = null
+    private var webview: WebView? = null
 
     init {
-        scope.launch(Dispatchers.IO) {
-            dfp =
-                try {
-                    StytchDFP(context = context, publicToken = publicToken, submissionUrl = dfppaDomain)
-                } catch (_: UnsatisfiedLinkError) {
-                    null
-                } catch (_: NoClassDefFoundError) {
-                    null
-                }
+        if (dfpType == DFPType.Native) {
+            scope.launch(Dispatchers.IO) {
+                dfp =
+                    try {
+                        StytchDFP(context = context, publicToken = publicToken, submissionUrl = dfppaDomain)
+                    } catch (_: UnsatisfiedLinkError) {
+                        null
+                    } catch (_: NoClassDefFoundError) {
+                        null
+                    }
+            }
         }
     }
 
     override suspend fun getTelemetryId(): String =
-        suspendCancellableCoroutine { continuation ->
-            dfp?.getTelemetryId { telemetryId ->
-                continuation.resume(telemetryId)
-            } ?: run {
-                continuation.resume("")
+        suspendCancellableCoroutine { cont ->
+            if (dfpType == DFPType.Native) {
+                dfp?.getTelemetryId { telemetryId ->
+                    cont.resume(telemetryId)
+                } ?: run {
+                    cont.resume("")
+                }
+            } else {
+                continuation = cont
+                activityProvider?.currentActivity?.let {
+                    it.runOnUiThread {
+                        webview = createWebView(it)
+                        it.addContentView(webview, ViewGroup.LayoutParams(0, 0))
+                    }
+                } ?: run {
+                    cont.resume("")
+                }
+            }
+        }
+
+    @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
+    // for some reason the linter isn't detecting the @JavascriptInterface annotation, so we need to suppress it
+    private fun createWebView(context: Context): WebView {
+        val dfpWebView = WebView(context)
+        dfpWebView.webViewClient =
+            object : WebViewClient() {
+                override fun onPageFinished(
+                    view: WebView,
+                    url: String,
+                ) {
+                    view.evaluateJavascript("fetchTelemetryId('$publicToken', 'https://$dfppaDomain/submit');", null)
+                }
+            }
+        dfpWebView.settings.javaScriptEnabled = true
+        dfpWebView.settings.databaseEnabled = true
+        dfpWebView.settings.domStorageEnabled = true
+        dfpWebView.addJavascriptInterface(stytchDfpInterface, "StytchDFP")
+        dfpWebView.loadUrl("file:///android_asset/dfp.html")
+        return dfpWebView
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val stytchDfpInterface =
+        object {
+            @JavascriptInterface
+            fun reportTelemetryId(telemetryId: String) {
+                activityProvider?.currentActivity?.let { currentActivity ->
+                    webview?.let {
+                        currentActivity.runOnUiThread {
+                            (it.parent as? ViewGroup)?.removeView(it)
+                        }
+                    }
+                }
+                webview = null
+                if (continuation?.isActive == true) {
+                    continuation?.resume(telemetryId, null)
+                }
+                continuation = null
             }
         }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPType.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/DFPType.kt
@@ -1,0 +1,6 @@
+package com.stytch.sdk.common.dfp
+
+public enum class DFPType {
+    Native,
+    Webview,
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/dfp/WebviewActivityProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/dfp/WebviewActivityProvider.kt
@@ -1,0 +1,53 @@
+package com.stytch.sdk.common.dfp
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.lang.ref.WeakReference
+
+internal class WebviewActivityProvider(
+    application: Application,
+) : Application.ActivityLifecycleCallbacks {
+    @Suppress("ktlint:standard:backing-property-naming")
+    private var _currentActivity = WeakReference<Activity>(null)
+    internal val currentActivity: Activity?
+        get() = _currentActivity.get()
+
+    init {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(
+        activity: Activity,
+        bundle: Bundle?,
+    ) {
+        // noop
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        // noop
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        _currentActivity = WeakReference(activity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        // noop
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // noop
+    }
+
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle,
+    ) {
+        // noop
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // noop
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-2719](https://linear.app/stytch/issue/SDK-2719)

## Changes:

1. Adds a new option to `StytchClientOptions` to switch between native and webview DFP implementations
2. Updates `DFPProvider` to instantiate and use the correct DFP implementation based on configuration

## Notes:

- To use webview DFP, one would need to pass the following to `StytchClient.configure()`: `StytchClientOptions(dfpType = DFPType.Webview)`

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A