### PR TITLE
Bump DFP version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ ktlint = "12.1.0"
 detekt = "1.23.6"
 ksp = "2.1.0-1.0.29"
 kotlinCompilerExtension="1.5.15"
-stytchDfp="1.0.4"
+stytchDfp="1.0.6"
 leakCanary = "2.14"
 
 [libraries]

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 extra["PUBLISH_GROUP_ID"] = "com.stytch.sdk"
-extra["PUBLISH_VERSION"] = "0.51.0"
+extra["PUBLISH_VERSION"] = "0.51.1"
 extra["PUBLISH_ARTIFACT_ID"] = "sdk"
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")


### PR DESCRIPTION
Bump DFP to 1.0.6 to release some fixes for reported crashes.