### PR TITLE
Use updated docs task

### DIFF
--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -27,7 +27,7 @@ jobs:
         java-version: 17
     - name: Generate docs
       working-directory: main
-      run: ./gradlew dokkaHtmlMultiModule
+      run: ./gradlew dokkaJavadoc
 
     - name: Zip docs site
       run: |


### PR DESCRIPTION
Linear Ticket: [SDK-2716](https://linear.app/stytch/issue/SDK-2716)

## Changes:

1. We had to change to javadoc format instead of dokkaHtml because of a conflict in jackson between dokka and jReleaser (see: #340 )

## Notes:

- Docs publishing has been broken for at least 9 months now, I believe
- Once this is merged and working, I need to go in and manually clean up the docs branch to remove the old docs
- I think (?) this is all we need to do to get docs back up and publishing, but as with all changes to github actions, only time will tell!

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A