### PR TITLE
SDK-2791 Add localization support for a subset of network errors

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationViewModel.kt
@@ -24,6 +24,7 @@ import com.stytch.sdk.ui.b2b.data.StytchB2BProductConfig
 import com.stytch.sdk.ui.b2b.domain.B2BUIStateMachine
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.utils.B2BUIViewModelFactory
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -72,7 +73,12 @@ internal class B2BAuthenticationViewModel(
                 }
                 is StytchResult.Error -> {
                     dispatch(SetIsSearchingForOrganizationBySlug(false))
-                    dispatch(SetGenericError(response.exception.message))
+                    dispatch(
+                        SetGenericError(
+                            errorText = response.exception.message,
+                            errorMessageId = response.exception.getUserFacingErrorMessageId(),
+                        ),
+                    )
                 }
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/BaseViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/BaseViewModel.kt
@@ -12,6 +12,7 @@ import com.stytch.sdk.ui.b2b.data.HandleStepUpAuthentication
 import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.data.SetLoading
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -52,7 +53,12 @@ internal open class BaseViewModel(
                     if (shouldSetLoadingIndicator) {
                         dispatch(SetLoading(false))
                     }
-                    dispatch(SetGenericError(response.exception.message))
+                    dispatch(
+                        SetGenericError(
+                            errorText = response.exception.message,
+                            errorMessageId = response.exception.getUserFacingErrorMessageId(),
+                        ),
+                    )
                     Result.failure(response.exception)
                 }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/StytchB2BAuthenticationApp.kt
@@ -248,7 +248,12 @@ internal fun StytchB2BAuthenticationApp(
                         } ?: toastDetails.errorText
                     toastText?.let {
                         FormFieldStatus(text = it, isError = true, autoDismiss = {
-                            dispatch(SetGenericError(null))
+                            dispatch(
+                                SetGenericError(
+                                    errorText = null,
+                                    errorMessageId = null,
+                                ),
+                            )
                         })
                     }
                 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/ssoDiscoveryFallback/SSODiscoveryFallbackScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/screens/ssoDiscoveryFallback/SSODiscoveryFallbackScreenViewModel.kt
@@ -19,6 +19,7 @@ import com.stytch.sdk.ui.b2b.data.SetGenericError
 import com.stytch.sdk.ui.b2b.data.SetNextRoute
 import com.stytch.sdk.ui.b2b.navigation.Routes
 import com.stytch.sdk.ui.b2b.usecases.UseSSOStart
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -61,7 +62,12 @@ internal class SSODiscoveryFallbackScreenViewModel(
                     }
                 }
                 is StytchResult.Error -> {
-                    dispatch(SetGenericError(response.exception.message))
+                    dispatch(
+                        SetGenericError(
+                            errorText = response.exception.message,
+                            errorMessageId = response.exception.getUserFacingErrorMessageId(),
+                        ),
+                    )
                 }
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSSODiscoveryConnections.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/usecases/UseSSODiscoveryConnections.kt
@@ -3,11 +3,13 @@ package com.stytch.sdk.ui.b2b.usecases
 import androidx.core.text.htmlEncode
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.B2BSSODiscoveryConnectionResponseData
+import com.stytch.sdk.common.errors.StytchError
 import com.stytch.sdk.ui.b2b.Dispatch
 import com.stytch.sdk.ui.b2b.PerformRequest
 import com.stytch.sdk.ui.b2b.data.B2BUIState
 import com.stytch.sdk.ui.b2b.data.SetDiscoveredSSOConnections
 import com.stytch.sdk.ui.b2b.data.SetGenericError
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -30,7 +32,12 @@ internal class UseSSODiscoveryConnections(
             }.onSuccess {
                 dispatch(SetDiscoveredSSOConnections(it.connections))
             }.onFailure {
-                dispatch(SetGenericError(it.message))
+                dispatch(
+                    SetGenericError(
+                        errorText = it.message,
+                        errorMessageId = (it as? StytchError)?.getUserFacingErrorMessageId(),
+                    ),
+                )
             }
         }
     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/EMLConfirmationScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/EMLConfirmationScreenViewModel.kt
@@ -19,6 +19,7 @@ import com.stytch.sdk.ui.b2c.data.PasswordOptions
 import com.stytch.sdk.ui.b2c.data.PasswordResetDetails
 import com.stytch.sdk.ui.b2c.data.PasswordResetType
 import com.stytch.sdk.ui.shared.data.EventTypes
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -58,7 +59,11 @@ internal class EMLConfirmationScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showResendDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
                 }
             }
@@ -108,7 +113,11 @@ internal class EMLConfirmationScreenViewModel(
                     is StytchResult.Error ->
                         savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                             uiState.value.copy(
-                                genericErrorMessage = GenericErrorDetails(result.exception.message),
+                                genericErrorMessage =
+                                    GenericErrorDetails(
+                                        errorText = result.exception.message,
+                                        errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                    ),
                             )
                 }
             } ?: run {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreen.kt
@@ -124,6 +124,7 @@ private fun MainScreenComposable(
     val semanticsOAuthButton = stringResource(id = R.string.stytch_semantics_oauth_button)
     val context = LocalActivity.current as FragmentActivity
     val scope = rememberCoroutineScope()
+    val phoneError = phoneState.errorMessageId?.let { stringResource(it) } ?: phoneState.error
 
     fun loginWithBiometrics() {
         scope.launch {
@@ -233,7 +234,7 @@ private fun MainScreenComposable(
                                 phoneNumber = phoneState.phoneNumber,
                                 onPhoneNumberChanged = onPhoneNumberChanged,
                                 onPhoneNumberSubmit = { sendSmsOtp(productConfig.otpOptions) },
-                                statusText = phoneState.error,
+                                statusText = phoneError,
                             )
                         stringResource(id = R.string.stytch_b2c_whatsapp_tab_title) ->
                             PhoneEntry(
@@ -242,7 +243,7 @@ private fun MainScreenComposable(
                                 phoneNumber = phoneState.phoneNumber,
                                 onPhoneNumberChanged = onPhoneNumberChanged,
                                 onPhoneNumberSubmit = { sendWhatsAppOTP(productConfig.otpOptions) },
-                                statusText = phoneState.error,
+                                statusText = phoneError,
                             )
                         else -> Text(stringResource(id = R.string.stytch_b2c_misconfigured_otp_warning))
                     }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/MainScreenViewModel.kt
@@ -40,6 +40,7 @@ import com.stytch.sdk.ui.b2c.data.StytchProductConfig
 import com.stytch.sdk.ui.shared.data.EmailState
 import com.stytch.sdk.ui.shared.data.EventTypes
 import com.stytch.sdk.ui.shared.data.PhoneNumberState
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import com.stytch.sdk.ui.shared.utils.isValidEmailAddress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -216,6 +217,7 @@ internal class MainScreenViewModel(
                     PhoneNumberState(
                         countryCode = countryCode,
                         error = null,
+                        errorMessageId = null,
                     ),
                 genericErrorMessage = null,
             )
@@ -228,6 +230,7 @@ internal class MainScreenViewModel(
                     PhoneNumberState(
                         phoneNumber = phoneNumber,
                         error = null,
+                        errorMessageId = null,
                     ),
                 genericErrorMessage = null,
             )
@@ -355,8 +358,12 @@ internal class MainScreenViewModel(
             is StytchResult.Error -> {
                 savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                     uiState.value.copy(
-                        genericErrorMessage = GenericErrorDetails(result.exception.message),
-                    ) // TODO
+                        genericErrorMessage =
+                            GenericErrorDetails(
+                                errorText = result.exception.message,
+                                errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                            ),
+                    )
                 null
             }
         }
@@ -390,8 +397,12 @@ internal class MainScreenViewModel(
             is StytchResult.Error -> {
                 savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                     uiState.value.copy(
-                        genericErrorMessage = GenericErrorDetails(result.exception.message),
-                    ) // TODO
+                        genericErrorMessage =
+                            GenericErrorDetails(
+                                errorText = result.exception.message,
+                                errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                            ),
+                    )
                 null
             }
         }
@@ -423,8 +434,12 @@ internal class MainScreenViewModel(
             is StytchResult.Error -> {
                 savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                     uiState.value.copy(
-                        genericErrorMessage = GenericErrorDetails(result.exception.message),
-                    ) // TODO
+                        genericErrorMessage =
+                            GenericErrorDetails(
+                                errorText = result.exception.message,
+                                errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                            ),
+                    )
                 null
             }
         }
@@ -460,6 +475,7 @@ internal class MainScreenViewModel(
                             phoneNumberState =
                                 phoneNumberState.copy(
                                     error = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                             showLoadingDialog = false,
                         )
@@ -498,6 +514,7 @@ internal class MainScreenViewModel(
                             phoneNumberState =
                                 phoneNumberState.copy(
                                     error = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                             showLoadingDialog = false,
                         )

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/NewUserScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/NewUserScreenViewModel.kt
@@ -18,6 +18,7 @@ import com.stytch.sdk.ui.b2c.data.NavigationRoute
 import com.stytch.sdk.ui.b2c.data.OTPDetails
 import com.stytch.sdk.ui.b2c.data.OTPOptions
 import com.stytch.sdk.ui.shared.data.EventTypes
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import com.stytch.sdk.ui.shared.utils.isValidEmailAddress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -71,6 +72,7 @@ internal class NewUserScreenViewModel(
                             emailState =
                                 emailState.copy(
                                     errorMessage = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                         )
                 }
@@ -117,6 +119,7 @@ internal class NewUserScreenViewModel(
                             emailState =
                                 emailState.copy(
                                     errorMessage = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                         )
                 }
@@ -176,6 +179,7 @@ internal class NewUserScreenViewModel(
                             passwordState =
                                 uiState.value.passwordState.copy(
                                     errorMessage = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                         )
                 }
@@ -212,6 +216,7 @@ internal class NewUserScreenViewModel(
                             passwordState =
                                 uiState.value.passwordState.copy(
                                     errorMessage = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                         )
                 }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModel.kt
@@ -23,6 +23,7 @@ import com.stytch.sdk.ui.b2c.data.PasswordResetDetails
 import com.stytch.sdk.ui.b2c.data.PasswordResetType
 import com.stytch.sdk.ui.shared.data.EventTypes
 import com.stytch.sdk.ui.shared.data.SessionOptions
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -117,7 +118,11 @@ internal class OTPConfirmationScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showLoadingDialog = false,
-                            genericErrorMessage = GenericErrorDetails(errorText = result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
                 }
             }
@@ -161,7 +166,11 @@ internal class OTPConfirmationScreenViewModel(
                         uiState.value.copy(
                             showLoadingDialog = false,
                             showResendDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
                 }
             }
@@ -203,7 +212,11 @@ internal class OTPConfirmationScreenViewModel(
                     is StytchResult.Error ->
                         savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                             uiState.value.copy(
-                                genericErrorMessage = GenericErrorDetails(result.exception.message),
+                                genericErrorMessage =
+                                    GenericErrorDetails(
+                                        errorText = result.exception.message,
+                                        errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                    ),
                             )
                 }
             } ?: run {

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/PasswordResetSentScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/PasswordResetSentScreenViewModel.kt
@@ -19,6 +19,7 @@ import com.stytch.sdk.ui.b2c.data.NavigationRoute
 import com.stytch.sdk.ui.b2c.data.OTPDetails
 import com.stytch.sdk.ui.b2c.data.OTPOptions
 import com.stytch.sdk.ui.shared.data.EventTypes
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -61,7 +62,11 @@ internal class PasswordResetSentScreenViewModel(
                 is StytchResult.Error -> {
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
                 }
             }
@@ -110,7 +115,11 @@ internal class PasswordResetSentScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showLoadingDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
             }
         }
@@ -153,7 +162,11 @@ internal class PasswordResetSentScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showLoadingDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
             }
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModel.kt
@@ -26,6 +26,7 @@ import com.stytch.sdk.ui.b2c.data.PasswordResetType
 import com.stytch.sdk.ui.shared.data.EmailState
 import com.stytch.sdk.ui.shared.data.EventTypes
 import com.stytch.sdk.ui.shared.data.SessionOptions
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import com.stytch.sdk.ui.shared.utils.isValidEmailAddress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -107,7 +108,11 @@ internal class ReturningUserScreenViewModel(
                                 savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                                     uiState.value.copy(
                                         showLoadingDialog = false,
-                                        genericErrorMessage = GenericErrorDetails(result.exception.message),
+                                        genericErrorMessage =
+                                            GenericErrorDetails(
+                                                errorText = result.exception.message,
+                                                errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                            ),
                                     )
                             }
                         }
@@ -115,7 +120,11 @@ internal class ReturningUserScreenViewModel(
                             savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                                 uiState.value.copy(
                                     showLoadingDialog = false,
-                                    genericErrorMessage = GenericErrorDetails(result.exception.message),
+                                    genericErrorMessage =
+                                        GenericErrorDetails(
+                                            errorText = result.exception.message,
+                                            errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                        ),
                                 )
                         }
                     }
@@ -162,7 +171,11 @@ internal class ReturningUserScreenViewModel(
                 savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                     uiState.value.copy(
                         showLoadingDialog = false,
-                        genericErrorMessage = GenericErrorDetails(result.exception.message),
+                        genericErrorMessage =
+                            GenericErrorDetails(
+                                errorText = result.exception.message,
+                                errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                            ),
                     )
             }
         }
@@ -209,7 +222,11 @@ internal class ReturningUserScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showLoadingDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
             }
         }
@@ -251,7 +268,11 @@ internal class ReturningUserScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showLoadingDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
             }
         }
@@ -297,7 +318,11 @@ internal class ReturningUserScreenViewModel(
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
                             showLoadingDialog = false,
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
                 }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/SetPasswordScreenViewModel.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/screens/SetPasswordScreenViewModel.kt
@@ -13,6 +13,7 @@ import com.stytch.sdk.ui.b2c.data.ApplicationUIState
 import com.stytch.sdk.ui.b2c.data.EventState
 import com.stytch.sdk.ui.b2c.data.GenericErrorDetails
 import com.stytch.sdk.ui.shared.data.SessionOptions
+import com.stytch.sdk.ui.shared.utils.getUserFacingErrorMessageId
 import com.stytch.sdk.ui.shared.utils.isValidEmailAddress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -89,6 +90,7 @@ internal class SetPasswordScreenViewModel(
                             passwordState =
                                 uiState.value.passwordState.copy(
                                     errorMessage = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
                                 ),
                         )
                 }
@@ -117,7 +119,11 @@ internal class SetPasswordScreenViewModel(
                 is StytchResult.Error -> {
                     savedStateHandle[ApplicationUIState.SAVED_STATE_KEY] =
                         uiState.value.copy(
-                            genericErrorMessage = GenericErrorDetails(result.exception.message),
+                            genericErrorMessage =
+                                GenericErrorDetails(
+                                    errorText = result.exception.message,
+                                    errorMessageId = result.exception.getUserFacingErrorMessageId(),
+                                ),
                         )
                 }
             }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailInput.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/EmailInput.kt
@@ -22,7 +22,7 @@ internal fun EmailInput(
     onEmailAddressChanged: (String) -> Unit,
 ) {
     val emailAddress = emailState.emailAddress
-    val isError = emailState.errorMessage != null || emailState.validEmail == false
+    val isError = emailState.errorMessage != null || emailState.errorMessageId != null || emailState.validEmail == false
     val semanticsInput = stringResource(id = R.string.stytch_semantics_email_input)
     val semanticsError = stringResource(id = R.string.stytch_semantics_email_error)
     Column {
@@ -45,7 +45,8 @@ internal fun EmailInput(
             FormFieldStatus(
                 modifier = Modifier.semantics { contentDescription = semanticsError },
                 text =
-                    emailState.errorMessage ?: stringResource(id = R.string.stytch_error_invalid_email_address),
+                    emailState.errorMessageId?.let { stringResource(it) }
+                        ?: emailState.errorMessage ?: stringResource(id = R.string.stytch_error_invalid_email_address),
                 isError = true,
             )
         }

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/PasswordInput.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/components/PasswordInput.kt
@@ -34,6 +34,7 @@ internal fun PasswordInput(
     label: String? = null,
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
+    val passwordErrorString = passwordState.errorMessageId?.let { stringResource(it) } ?: passwordState.errorMessage
     Column {
         StytchInput(
             modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp),
@@ -83,7 +84,7 @@ internal fun PasswordInput(
                 }
             }
         }
-        passwordState.errorMessage?.let {
+        passwordErrorString?.let {
             FormFieldStatus(
                 text = it,
                 isError = true,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/EmailState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/EmailState.kt
@@ -9,6 +9,7 @@ internal data class EmailState(
     val emailVerified: Boolean? = null,
     val validEmail: Boolean? = null,
     val errorMessage: String? = null,
+    val errorMessageId: Int? = null,
     val readOnly: Boolean = false,
     val shouldValidateEmail: Boolean = true,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/PasswordState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/PasswordState.kt
@@ -14,4 +14,5 @@ internal data class PasswordState(
     val score: Int = 0,
     val validPassword: Boolean = false,
     val errorMessage: String? = null,
+    val errorMessageId: Int? = null,
 ) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/PhoneNumberState.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/data/PhoneNumberState.kt
@@ -10,6 +10,7 @@ internal data class PhoneNumberState(
     val countryCode: String = "1",
     val phoneNumber: String = "",
     val error: String? = null,
+    val errorMessageId: Int? = null,
 ) : Parcelable {
     fun toE164(): String {
         val phone =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/shared/utils/StringExtensions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/shared/utils/StringExtensions.kt
@@ -3,6 +3,8 @@ package com.stytch.sdk.ui.shared.utils
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.stytch.sdk.R
+import com.stytch.sdk.common.errors.StytchAPIError
+import com.stytch.sdk.common.errors.StytchError
 import java.util.regex.Pattern
 
 private val EMAIL_ADDRESS_PATTERN =
@@ -73,4 +75,14 @@ internal fun String.mapZxcvbnToStringResource(): String =
             )
         "Common names and surnames are easy to guess." -> stringResource(R.string.stytch_zxcvbn_suggestion_27)
         else -> this
+    }
+
+internal fun StytchError.getUserFacingErrorMessageId(): Int? =
+    if (this is StytchAPIError) {
+        when (errorType) {
+            // TODO: based on error type, which ones do we want to localize? Add them here
+            else -> null
+        }
+    } else {
+        null
     }

--- a/tutorials/Localization.md
+++ b/tutorials/Localization.md
@@ -13,6 +13,3 @@ If you want to add localization/internationalization to your app, just create a 
 You can find all of our strings [here](../source/sdk/src/main/res/values/strings.xml).
 
 If you find that you need more granular control than what is currently provided, please open a GitHub issue or submit a pull request describing your use case. We’re happy to review and add additional keys as needed.
-
----
-_* NOTE: There are no hardcoded strings in our UI components, and as such they are fully customizable as described above. However, there may be instances where strings are returned from the network (in the case of an API error) which are not currently customizable. We are actively working to ensure that these are customizable in the future._


### PR DESCRIPTION
Linear Ticket: [SDK-2791](https://linear.app/stytch/issue/SDK-2791)

## Changes:

1. Everywhere that we are setting a raw string from the API as an error message, we are also setting a potential localizable string resource.
2. Wherever we are displaying an error message, we are checking for the localizable reference first, and falling back to the raw error message if it doesn’t exist.

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [X] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A