### PR TITLE
Startup race condition

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.53.2"
+val publishVersion = "0.54.0"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -223,26 +223,28 @@ public object StytchB2BClient {
         // any exception in storage initialization immediately, because we want to log the error to the Events API,
         // which requires the API to be configured (which happens in the configure call). So, catch and hold any error
         // until _after_ configuration completes, at which point it is safe to log it.
-        val storageInitializationError =
-            try {
-                StorageHelper.initialize(context)
-                sessionStorage = B2BSessionStorage(StorageHelper)
-                null
-            } catch (ex: Exception) {
+        runCatching {
+            val storageHelperInitializationJob = StorageHelper.initialize(context)
+            sessionStorage = B2BSessionStorage(StorageHelper)
+            configurationManager.configure(
+                client =
+                    StytchB2BClientCommonConfiguration {
+                        sessionStorage.emitCurrent()
+                        callback(true)
+                    },
+                context = context,
+                publicToken = publicToken,
+                options = options,
+                storageHelperInitializationJob = storageHelperInitializationJob,
+            )
+        }.onFailure {
+            val error =
                 StytchInternalError(
                     message = "Failed to initialize the SDK",
-                    exception = ex,
+                    exception = it,
                 )
-            }
-        configurationManager.configure(
-            client = StytchB2BClientCommonConfiguration { callback(true) },
-            context = context,
-            publicToken = publicToken,
-            options = options,
-        )
-        storageInitializationError?.let {
-            events.logEvent("client_initialization_failure", null, it)
-            throw it
+            events.logEvent("client_initialization_failure", null, error)
+            throw error
         }
     }
 

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/member/MemberImpl.kt
@@ -34,7 +34,7 @@ internal class MemberImpl(
             .stateIn(
                 externalScope,
                 SharingStarted.WhileSubscribed(),
-                stytchObjectMapper(sessionStorage.member, sessionStorage.lastValidatedAt),
+                StytchObjectInfo.Loading,
             )
 
     init {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/organization/OrganizationImpl.kt
@@ -42,7 +42,7 @@ internal class OrganizationImpl(
             .stateIn(
                 externalScope,
                 SharingStarted.WhileSubscribed(),
-                stytchObjectMapper<OrganizationData>(sessionStorage.organization, sessionStorage.lastValidatedAt),
+                StytchObjectInfo.Loading,
             )
 
     init {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
@@ -237,7 +237,7 @@ internal class B2BSessionStorage(
     val persistedSessionIdentifiersExist: Boolean
         get() = sessionToken != null || sessionJwt != null
 
-    init {
+    fun emitCurrent() {
         _sessionFlow.tryEmit(memberSession)
         _memberFlow.tryEmit(member)
         _organizationFlow.tryEmit(organization)

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionsImpl.kt
@@ -53,7 +53,7 @@ internal class B2BSessionsImpl internal constructor(
             .stateIn(
                 externalScope,
                 SharingStarted.WhileSubscribed(),
-                stytchObjectMapper<B2BSessionData>(sessionStorage.memberSession, sessionStorage.lastValidatedAt),
+                StytchObjectInfo.Loading,
             )
 
     init {

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -47,6 +47,7 @@ internal class ConfigurationManager {
         context: Context,
         publicToken: String,
         options: StytchClientOptions = StytchClientOptions(),
+        storageHelperInitializationJob: Job,
     ) {
         if (isAlreadyConfiguredFor(publicToken, options)) {
             return
@@ -97,9 +98,10 @@ internal class ConfigurationManager {
             client::getSessionToken,
             dfpConfiguration,
         )
-        val bootstrapJob = refreshBootstrapAndApi(true)
-        val sessionRehydrationJob = client.rehydrateSession()
         externalScope.launch(dispatchers.io) {
+            storageHelperInitializationJob.join()
+            val bootstrapJob = refreshBootstrapAndApi(true)
+            val sessionRehydrationJob = client.rehydrateSession()
             listOf(bootstrapJob, sessionRehydrationJob).joinAll()
             client.logEvent("client_initialization_success", null, null)
             isInitialized.value = true

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -5,9 +5,11 @@ import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import com.stytch.sdk.common.EncryptionManager.KEY_PREFERENCES_FILE_NAME
 import com.stytch.sdk.common.EncryptionManager.MASTER_KEY_ALIAS
+import com.stytch.sdk.common.StorageHelper.sharedPreferences
 import com.stytch.sdk.common.extensions.clearPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.security.KeyStore
@@ -20,7 +22,7 @@ internal object StorageHelper {
     @VisibleForTesting
     internal lateinit var sharedPreferences: SharedPreferences
 
-    fun initialize(context: Context) {
+    fun initialize(context: Context): Job =
         CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
             keyStore.load(null)
             if (!keyStore.containsAlias(MASTER_KEY_ALIAS)) {
@@ -34,7 +36,6 @@ internal object StorageHelper {
             sharedPreferences = context.getSharedPreferences(STYTCH_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
             EncryptionManager.createNewKeys(context)
         }
-    }
 
     /**
      * Encrypt and save value to SharedPreferences

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchObjectInfo.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchObjectInfo.kt
@@ -7,6 +7,8 @@ import java.util.Date
 public sealed interface StytchObjectInfo<out T> {
     @JacocoExcludeGenerated public data object Unavailable : StytchObjectInfo<Nothing>
 
+    @JacocoExcludeGenerated public data object Loading : StytchObjectInfo<Nothing>
+
     @JacocoExcludeGenerated
     public data class Available<out T>(
         val lastValidatedAt: Date,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
@@ -2,7 +2,6 @@ package com.stytch.sdk.consumer.sessions
 
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapter
 import com.stytch.sdk.common.PREFERENCES_NAME_LAST_AUTH_METHOD_USED
 import com.stytch.sdk.common.PREFERENCES_NAME_LAST_VALIDATED_AT
 import com.stytch.sdk.common.PREFERENCES_NAME_SESSION_DATA
@@ -165,7 +164,7 @@ internal class ConsumerSessionStorage(
 
     var methodId: String? = null
 
-    init {
+    fun emitCurrent() {
         _sessionFlow.tryEmit(session)
         _userFlow.tryEmit(user)
         _lastValidatedAtFlow.tryEmit(lastValidatedAt)

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
@@ -52,7 +52,7 @@ internal class SessionsImpl internal constructor(
             .stateIn(
                 externalScope,
                 SharingStarted.WhileSubscribed(),
-                stytchObjectMapper<SessionData>(sessionStorage.session, sessionStorage.lastValidatedAt),
+                StytchObjectInfo.Loading,
             )
 
     init {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/UserManagementImpl.kt
@@ -35,7 +35,7 @@ internal class UserManagementImpl(
             .stateIn(
                 externalScope,
                 SharingStarted.WhileSubscribed(),
-                stytchObjectMapper<UserData>(sessionStorage.user, sessionStorage.lastValidatedAt),
+                StytchObjectInfo.Loading,
             )
 
     init {

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -100,7 +100,10 @@ internal class StytchB2BClientTest {
         mockkObject(Recaptcha)
         MockKAnnotations.init(this, true, true)
         coEvery { Recaptcha.fetchClient(any(), any()) } returns mockk(relaxed = true)
-        every { StorageHelper.initialize(any()) } just runs
+        every { StorageHelper.initialize(any()) } returns
+            mockk {
+                coEvery { join() } just runs
+            }
         every { StorageHelper.loadValue(any()) } returns "{}"
         every { StorageHelper.saveValue(any(), any()) } just runs
         every { StorageHelper.saveLong(any(), any()) } just runs

--- a/source/sdk/src/test/java/com/stytch/sdk/common/pkcePairManager/PKCEPairManagerImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/common/pkcePairManager/PKCEPairManagerImplTest.kt
@@ -27,7 +27,7 @@ internal class PKCEPairManagerImplTest {
         mockkObject(EncryptionManager)
         every { EncryptionManager.createNewKeys(any()) } just runs
         mockkObject(StorageHelper)
-        every { StorageHelper.initialize(any()) } just runs
+        every { StorageHelper.initialize(any()) } returns mockk()
 
         impl = PKCEPairManagerImpl(StorageHelper, EncryptionManager)
     }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -98,7 +98,10 @@ internal class StytchClientTest {
         mockkObject(Recaptcha)
         MockKAnnotations.init(this, true, true)
         coEvery { Recaptcha.fetchClient(any(), any()) } returns mockk(relaxed = true)
-        every { StorageHelper.initialize(any()) } just runs
+        every { StorageHelper.initialize(any()) } returns
+            mockk {
+                coEvery { join() } just runs
+            }
         every { StorageHelper.loadValue(any()) } returns "{}"
         every { StorageHelper.saveValue(any(), any()) } just runs
         every { StorageHelper.saveLong(any(), any()) } just runs


### PR DESCRIPTION
Linear Ticket: No ticket

## Changes:

1. Return the job created when instantiating the StorageHelper so that we can wait for it to complete before trying to access persisted data
2. Don't emit values from persisted data until after everything is loaded
3. Introduce a new default "Loading" state to prevent publishing `Unavailable` when what we really mean is "we don't know yet"

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A