### PR TITLE
SDK-2780 Bump dfp to support 16kb page sizes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ ktlint = "12.1.0"
 detekt = "1.23.6"
 ksp = "2.1.0-1.0.29"
 kotlinCompilerExtension="1.5.15"
-stytchDfp="1.0.6"
+stytchDfp="1.0.7"
 leakCanary = "2.14"
 
 [libraries]

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.55.0"
+val publishVersion = "0.56.0"
 val publishArtifactId = "sdk"
 
 android {


### PR DESCRIPTION
Linear Ticket: [SDK-2780](https://linear.app/stytch/issue/SDK-2780)

## Changes:

1. Bump DFP version to 16kb supporting version

## Notes:

- https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A