### PR TITLE
Adopt guardrails around session storms

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.56.0"
+val publishVersion = "0.57.0"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
@@ -78,6 +78,9 @@ internal fun <T : CommonAuthenticationData> StytchResult<T>.launchSessionUpdater
             clearSession = {
                 sessionStorage.revoke()
             },
+            getCurrentSessionId = {
+                sessionStorage.memberSession?.memberSessionId
+            },
         )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/common/sessions/SessionAutoUpdater.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/sessions/SessionAutoUpdater.kt
@@ -36,7 +36,7 @@ internal object SessionAutoUpdater {
         updateSession: suspend () -> StytchResult<CommonAuthenticationData>,
         saveSession: (CommonAuthenticationData) -> Unit,
         clearSession: () -> Unit = {},
-        getCurrentSessionId: () -> String?,
+        getCurrentSessionId: () -> String? = { null },
     ) {
         // prevent multiple update jobs running
         stopSessionUpdateJob()

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
@@ -50,6 +50,9 @@ internal fun <T : IAuthData> StytchResult<T>.launchSessionUpdater(
             clearSession = {
                 sessionStorage.revoke()
             },
+            getCurrentSessionId = {
+                sessionStorage.session?.sessionId
+            },
         )
     }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/SessionsImpl.kt
@@ -91,17 +91,29 @@ internal class SessionsImpl internal constructor(
 
     override suspend fun authenticate(authParams: Sessions.AuthParams): AuthResponse =
         withContext(dispatchers.io) {
-            var result =
-                api
-                    .authenticate(
-                        authParams.sessionDurationMinutes,
-                    ).apply {
+            val initialSessionId = sessionStorage.session?.sessionId
+            val result = api.authenticate(authParams.sessionDurationMinutes)
+            if (initialSessionId != sessionStorage.session?.sessionId) {
+                // The session was updated out from under us while the request was in flight;
+                // discard the response and retry
+                return@withContext authenticate(authParams)
+            }
+            return@withContext when (result) {
+                is StytchResult.Success -> {
+                    result.apply {
                         launchSessionUpdater(dispatchers, sessionStorage)
                     }
-            if (result is StytchResult.Error) {
-                result = maybeForceClearSession(result, false)
+                }
+                is StytchResult.Error -> {
+                    if (initialSessionId != sessionStorage.session?.sessionId) {
+                        // The session was updated out from under us while the request was in flight;
+                        // discard the response and retry
+                        return@withContext authenticate(authParams)
+                    }
+                    // Session was NOT updated, but was an error, so maybe clear session
+                    maybeForceClearSession(result, false)
+                }
             }
-            result
         }
 
     override fun authenticate(


### PR DESCRIPTION
Linear Ticket: No ticket

## Changes:

1. Same as https://github.com/stytchauth/stytch-ios/pull/513, except for the unnecessary error propagation

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A