### PR TITLE
SDK-2822 Add user/member device history

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.common.network.models.CommonAuthenticationData
 import com.stytch.sdk.common.network.models.Feedback
 import com.stytch.sdk.common.network.models.IBasicData
 import com.stytch.sdk.common.network.models.LUDSRequirements
+import com.stytch.sdk.common.network.models.SDKDeviceHistory
 import com.stytch.sdk.common.network.models.StrengthPolicy
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
@@ -88,6 +89,8 @@ public data class SMSAuthenticateResponseData(
     override val sessionToken: String,
     override val member: MemberData,
     override val organization: OrganizationData,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthData,
     Parcelable
 
@@ -118,6 +121,8 @@ public data class B2BEMLAuthenticateData(
     override val mfaRequired: MFARequired?,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
@@ -304,6 +309,8 @@ public data class PasswordsAuthenticateResponseData(
     override val mfaRequired: MFARequired?,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
@@ -334,6 +341,8 @@ public data class EmailResetResponseData(
     override val mfaRequired: MFARequired?,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
@@ -364,6 +373,8 @@ public data class PasswordResetByExistingPasswordResponseData(
     override val mfaRequired: MFARequired?,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
@@ -380,6 +391,8 @@ public data class SessionResetResponseData(
     val memberSession: B2BSessionData,
     val member: MemberData,
     val organization: OrganizationData,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : Parcelable
 
 @JsonClass(generateAdapter = true)
@@ -528,6 +541,8 @@ public data class SSOAuthenticateResponseData(
     override val mfaRequired: MFARequired?,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
@@ -694,6 +709,8 @@ public data class TOTPAuthenticateResponseData(
     override val memberSession: B2BSessionData,
     override val member: MemberData,
     override val organization: OrganizationData,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthData,
     Parcelable
 
@@ -738,6 +755,8 @@ public data class RecoveryCodeRecoverResponseData(
     override val organization: OrganizationData,
     @Json(name = "recovery_codes_remaining")
     val recoveryCodesRemaining: Int,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthData,
     Parcelable
 
@@ -768,6 +787,8 @@ public data class OAuthAuthenticateResponseData(
     override val mfaRequired: MFARequired?,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 
@@ -1278,6 +1299,8 @@ public data class B2BOTPsEmailAuthenticateResponseData(
     val methodId: String,
     @Json(name = "primary_required")
     override val primaryRequired: PrimaryRequired?,
+    @Json(name = "member_device")
+    val memberDevice: SDKDeviceHistory?,
 ) : IB2BAuthDataWithMFA,
     Parcelable
 

--- a/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponseData.kt
@@ -494,3 +494,31 @@ public data class Feedback(
     @Json(name = "luds_requirements")
     val ludsRequirements: LUDSRequirements? = null, // B2C LUDS
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class DeviceAttributeDetails(
+    @Json(name = "is_new")
+    val isNew: Boolean,
+    @Json(name = "first_seen_at")
+    val firstSeenAt: String?,
+    @Json(name = "last_seen_at")
+    val lastSeenAt: String?,
+) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class SDKDeviceHistory(
+    @Json(name = "ip_address")
+    val ipAddress: String?,
+    @Json(name = "ip_address_details")
+    val ipAddressDetails: DeviceAttributeDetails?,
+    @Json(name = "ip_geo_city")
+    val ipGeoCity: String?,
+    @Json(name = "ip_geo_region")
+    val ipGeoRegion: String?,
+    @Json(name = "ip_geo_country")
+    val ipGeoCountry: String?,
+    @Json(name = "ip_geo_country_details")
+    val ipGeoCountryDetails: DeviceAttributeDetails?,
+) : Parcelable

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.common.network.models.OTPSendResponseData
+import com.stytch.sdk.consumer.network.models.B2CPasswordsAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.CreateResponse
 import com.stytch.sdk.consumer.network.models.CryptoWalletAuthenticateStartResponseData
@@ -11,6 +12,10 @@ import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
 import com.stytch.sdk.consumer.network.models.IAuthData
 import com.stytch.sdk.consumer.network.models.INativeOAuthData
 import com.stytch.sdk.consumer.network.models.OAuthData
+import com.stytch.sdk.consumer.network.models.OTPsAuthenticateResponseData
+import com.stytch.sdk.consumer.network.models.PasswordsEmailResetResponseData
+import com.stytch.sdk.consumer.network.models.PasswordsExistingPasswordResetResponseData
+import com.stytch.sdk.consumer.network.models.PasswordsSessionResetResponseData
 import com.stytch.sdk.consumer.network.models.StrengthCheckResponse
 import com.stytch.sdk.consumer.network.models.TOTPAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.TOTPCreateResponseData
@@ -19,6 +24,7 @@ import com.stytch.sdk.consumer.network.models.TOTPRecoveryCodesResponseData
 import com.stytch.sdk.consumer.network.models.UpdateUserResponseData
 import com.stytch.sdk.consumer.network.models.UserData
 import com.stytch.sdk.consumer.network.models.UserSearchResponseData
+import com.stytch.sdk.consumer.network.models.WebAuthnAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.WebAuthnAuthenticateStartData
 import com.stytch.sdk.consumer.network.models.WebAuthnRegisterData
 import com.stytch.sdk.consumer.network.models.WebAuthnRegisterStartData

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.common.network.models.OTPSendResponseData
 import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.CreateResponse
 import com.stytch.sdk.consumer.network.models.CryptoWalletAuthenticateStartResponseData
+import com.stytch.sdk.consumer.network.models.CryptoWalletsAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
 import com.stytch.sdk.consumer.network.models.IAuthData
 import com.stytch.sdk.consumer.network.models.INativeOAuthData
@@ -127,3 +128,11 @@ public typealias TOTPRecoveryCodesResponse = StytchResult<TOTPRecoveryCodesRespo
  * Type alias for StytchResult<TOTPRecoverResponseData> used for TOTP recovery responses
  */
 public typealias TOTPRecoverResponse = StytchResult<TOTPRecoverResponseData>
+
+public typealias CryptoWalletsAuthenticateResponse = StytchResult<CryptoWalletsAuthenticateResponseData>
+public typealias OTPsAuthenticateResponse = StytchResult<OTPsAuthenticateResponseData>
+public typealias PasswordsAuthenticateResponse = StytchResult<B2CPasswordsAuthenticateResponseData>
+public typealias PasswordsEmailResetResponse = StytchResult<PasswordsEmailResetResponseData>
+public typealias PasswordsExistingPasswordResetResponse = StytchResult<PasswordsExistingPasswordResetResponseData>
+public typealias PasswordsSessionResetResponse = StytchResult<PasswordsSessionResetResponseData>
+public typealias WebAuthnAuthenticateResponse = StytchResult<WebAuthnAuthenticateResponseData>

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWallet.kt
@@ -2,8 +2,8 @@ package com.stytch.sdk.consumer.crypto
 
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
-import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
+import com.stytch.sdk.consumer.CryptoWalletsAuthenticateResponse
 import com.stytch.sdk.consumer.network.models.CryptoWalletType
 import java.util.concurrent.CompletableFuture
 
@@ -70,24 +70,26 @@ public interface CryptoWallet {
     /**
      * Complete a crypto wallet authentication flow
      * @param parameters the parameters required to complete a crypto wallet authentication flow
-     * @return [AuthResponse]
+     * @return [CryptoWalletsAuthenticateResponse]
      */
-    public suspend fun authenticate(parameters: AuthenticateParameters): AuthResponse
+    public suspend fun authenticate(parameters: AuthenticateParameters): CryptoWalletsAuthenticateResponse
 
     /**
      * Complete a crypto wallet authentication flow
      * @param parameters the parameters required to complete a crypto wallet authentication flow
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [CryptoWalletsAuthenticateResponse]
      */
     public fun authenticate(
         parameters: AuthenticateParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (CryptoWalletsAuthenticateResponse) -> Unit,
     )
 
     /**
      * Complete a crypto wallet authentication flow
      * @param parameters the parameters required to complete a crypto wallet authentication flow
-     * @return [AuthResponse]
+     * @return [CryptoWalletsAuthenticateResponse]
      */
-    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<AuthResponse>
+    public fun authenticateCompletable(
+        parameters: AuthenticateParameters,
+    ): CompletableFuture<CryptoWalletsAuthenticateResponse>
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWalletImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/crypto/CryptoWalletImpl.kt
@@ -1,9 +1,9 @@
 package com.stytch.sdk.consumer.crypto
 
 import com.stytch.sdk.common.StytchDispatchers
-import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.ConsumerAuthMethod
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
+import com.stytch.sdk.consumer.CryptoWalletsAuthenticateResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
@@ -54,7 +54,9 @@ internal class CryptoWalletImpl(
                 authenticateStart(parameters)
             }.asCompletableFuture()
 
-    override suspend fun authenticate(parameters: CryptoWallet.AuthenticateParameters): AuthResponse =
+    override suspend fun authenticate(
+        parameters: CryptoWallet.AuthenticateParameters,
+    ): CryptoWalletsAuthenticateResponse =
         withContext(dispatchers.io) {
             api
                 .authenticate(
@@ -70,7 +72,7 @@ internal class CryptoWalletImpl(
 
     override fun authenticate(
         parameters: CryptoWallet.AuthenticateParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (CryptoWalletsAuthenticateResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
             callback(authenticate(parameters))
@@ -79,7 +81,7 @@ internal class CryptoWalletImpl(
 
     override fun authenticateCompletable(
         parameters: CryptoWallet.AuthenticateParameters,
-    ): CompletableFuture<AuthResponse> =
+    ): CompletableFuture<CryptoWalletsAuthenticateResponse> =
         externalScope
             .async {
                 authenticate(parameters)

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -40,6 +40,7 @@ import com.stytch.sdk.consumer.network.models.CreateResponse
 import com.stytch.sdk.consumer.network.models.CryptoWalletType
 import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
 import com.stytch.sdk.consumer.network.models.NativeOAuthData
+import com.stytch.sdk.consumer.network.models.OTPsAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.StrengthCheckResponse
 import com.stytch.sdk.consumer.network.models.TOTPAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.TOTPCreateResponseData
@@ -361,7 +362,7 @@ internal object StytchApi : CommonApi {
             token: String,
             methodId: String,
             sessionDurationMinutes: Int = DEFAULT_SESSION_TIME_MINUTES,
-        ): StytchResult<AuthData> =
+        ): StytchResult<OTPsAuthenticateResponseData> =
             safeConsumerApiCall {
                 apiService.authenticateWithOTP(
                     ConsumerRequests.OTP.Authenticate(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -26,14 +26,16 @@ import com.stytch.sdk.common.network.models.NameData
 import com.stytch.sdk.common.network.models.NoResponseData
 import com.stytch.sdk.common.network.models.OTPSendResponseData
 import com.stytch.sdk.common.network.safeApiCall
-import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
+import com.stytch.sdk.consumer.CryptoWalletsAuthenticateResponse
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
+import com.stytch.sdk.consumer.WebAuthnAuthenticateResponse
 import com.stytch.sdk.consumer.WebAuthnAuthenticateStartResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterStartResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
 import com.stytch.sdk.consumer.network.models.AuthData
+import com.stytch.sdk.consumer.network.models.B2CPasswordsAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.ConsumerRequests
 import com.stytch.sdk.consumer.network.models.CreateResponse
@@ -41,6 +43,9 @@ import com.stytch.sdk.consumer.network.models.CryptoWalletType
 import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
 import com.stytch.sdk.consumer.network.models.NativeOAuthData
 import com.stytch.sdk.consumer.network.models.OTPsAuthenticateResponseData
+import com.stytch.sdk.consumer.network.models.PasswordsEmailResetResponseData
+import com.stytch.sdk.consumer.network.models.PasswordsExistingPasswordResetResponseData
+import com.stytch.sdk.consumer.network.models.PasswordsSessionResetResponseData
 import com.stytch.sdk.consumer.network.models.StrengthCheckResponse
 import com.stytch.sdk.consumer.network.models.TOTPAuthenticateResponseData
 import com.stytch.sdk.consumer.network.models.TOTPCreateResponseData
@@ -379,7 +384,7 @@ internal object StytchApi : CommonApi {
             email: String,
             password: String,
             sessionDurationMinutes: Int,
-        ): StytchResult<AuthData> =
+        ): StytchResult<B2CPasswordsAuthenticateResponseData> =
             safeConsumerApiCall {
                 apiService.authenticateWithPasswords(
                     ConsumerRequests.Passwords.AuthenticateRequest(
@@ -437,7 +442,7 @@ internal object StytchApi : CommonApi {
             sessionDurationMinutes: Int,
             codeVerifier: String,
             locale: Locale?,
-        ): StytchResult<AuthData> =
+        ): StytchResult<PasswordsEmailResetResponseData> =
             safeConsumerApiCall {
                 apiService.resetByEmail(
                     ConsumerRequests.Passwords.ResetByEmailRequest(
@@ -454,7 +459,7 @@ internal object StytchApi : CommonApi {
             password: String,
             sessionDurationMinutes: Int,
             locale: Locale?,
-        ): StytchResult<AuthData> =
+        ): StytchResult<PasswordsSessionResetResponseData> =
             safeConsumerApiCall {
                 apiService.resetBySession(
                     ConsumerRequests.Passwords.ResetBySessionRequest(
@@ -470,7 +475,7 @@ internal object StytchApi : CommonApi {
             existingPassword: String,
             newPassword: String,
             sessionDurationMinutes: Int,
-        ): StytchResult<AuthData> =
+        ): StytchResult<PasswordsExistingPasswordResetResponseData> =
             safeConsumerApiCall {
                 apiService.resetByExistingPassword(
                     ConsumerRequests.Passwords.PasswordResetByExistingPasswordRequest(
@@ -714,7 +719,7 @@ internal object StytchApi : CommonApi {
         suspend fun authenticate(
             publicKeyCredential: String,
             sessionDurationMinutes: Int,
-        ): AuthResponse =
+        ): WebAuthnAuthenticateResponse =
             safeConsumerApiCall {
                 apiService.webAuthnAuthenticate(
                     ConsumerRequests.WebAuthn.AuthenticateRequest(
@@ -770,7 +775,7 @@ internal object StytchApi : CommonApi {
             cryptoWalletType: CryptoWalletType,
             signature: String,
             sessionDurationMinutes: Int,
-        ): AuthResponse =
+        ): CryptoWalletsAuthenticateResponse =
             safeConsumerApiCall {
                 apiService.cryptoWalletAuthenticate(
                     ConsumerRequests.Crypto.CryptoWalletAuthenticateRequest(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -110,7 +110,7 @@ internal interface StytchApiService : ApiService.ApiEndpoints {
     @DFPPAEnabled
     suspend fun authenticateWithOTP(
         @Body request: ConsumerRequests.OTP.Authenticate,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.OTP.OTPsAuthenticateResponse
     //endregionOTP
 
     //region passwords
@@ -124,7 +124,7 @@ internal interface StytchApiService : ApiService.ApiEndpoints {
     @DFPPAEnabled
     suspend fun authenticateWithPasswords(
         @Body request: ConsumerRequests.Passwords.AuthenticateRequest,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.Passwords.B2CPasswordsAuthenticateResponse
 
     @POST("passwords/email/reset/start")
     @DFPPAEnabled
@@ -136,19 +136,19 @@ internal interface StytchApiService : ApiService.ApiEndpoints {
     @DFPPAEnabled
     suspend fun resetByEmail(
         @Body request: ConsumerRequests.Passwords.ResetByEmailRequest,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.Passwords.PasswordsEmailResetResponse
 
     @POST("passwords/session/reset")
     @DFPPAEnabled
     suspend fun resetBySession(
         @Body request: ConsumerRequests.Passwords.ResetBySessionRequest,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.Passwords.PasswordsSessionResetResponse
 
     @POST("passwords/existing_password/reset")
     @DFPPAEnabled
     suspend fun resetByExistingPassword(
         @Body request: ConsumerRequests.Passwords.PasswordResetByExistingPasswordRequest,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.Passwords.PasswordsExistingPasswordResetResponse
 
     @POST("passwords/strength_check")
     suspend fun strengthCheck(
@@ -273,7 +273,7 @@ internal interface StytchApiService : ApiService.ApiEndpoints {
     @DFPPAEnabled
     suspend fun webAuthnAuthenticate(
         @Body request: ConsumerRequests.WebAuthn.AuthenticateRequest,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.WebAuthn.WebAuthnAuthenticateResponse
 
     @PUT("webauthn/update/{id}")
     suspend fun webAuthnUpdate(
@@ -305,7 +305,7 @@ internal interface StytchApiService : ApiService.ApiEndpoints {
     @DFPPAEnabled
     suspend fun cryptoWalletAuthenticate(
         @Body request: ConsumerRequests.Crypto.CryptoWalletAuthenticateRequest,
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.Crypto.AuthenticateResponse
     //endregion
 
     //region TOTP

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
@@ -16,6 +16,26 @@ internal object ConsumerResponses {
         class PasswordsStrengthCheckResponse(
             data: StrengthCheckResponse,
         ) : StytchDataResponse<StrengthCheckResponse>(data)
+
+        @JsonClass(generateAdapter = true)
+        class B2CPasswordsAuthenticateResponse(
+            data: B2CPasswordsAuthenticateResponseData,
+        ) : StytchDataResponse<B2CPasswordsAuthenticateResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class PasswordsEmailResetResponse(
+            data: PasswordsEmailResetResponseData,
+        ) : StytchDataResponse<PasswordsEmailResetResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class PasswordsExistingPasswordResetResponse(
+            data: PasswordsExistingPasswordResetResponseData,
+        ) : StytchDataResponse<PasswordsExistingPasswordResetResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class PasswordsSessionResetResponse(
+            data: PasswordsSessionResetResponseData,
+        ) : StytchDataResponse<PasswordsSessionResetResponseData>(data)
     }
 
     object Biometrics {
@@ -84,6 +104,11 @@ internal object ConsumerResponses {
         class UpdateResponse(
             data: WebAuthnUpdateResponseData,
         ) : StytchDataResponse<WebAuthnUpdateResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class WebAuthnAuthenticateResponse(
+            data: WebAuthnAuthenticateResponseData,
+        ) : StytchDataResponse<WebAuthnAuthenticateResponseData>(data)
     }
 
     object Crypto {
@@ -91,6 +116,18 @@ internal object ConsumerResponses {
         class AuthenticateStartResponse(
             data: CryptoWalletAuthenticateStartResponseData,
         ) : StytchDataResponse<CryptoWalletAuthenticateStartResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class AuthenticateResponse(
+            data: CryptoWalletsAuthenticateResponseData,
+        ) : StytchDataResponse<CryptoWalletsAuthenticateResponseData>(data)
+    }
+
+    object OTP {
+        @JsonClass(generateAdapter = true)
+        class OTPsAuthenticateResponse(
+            data: OTPsAuthenticateResponseData,
+        ) : StytchDataResponse<OTPsAuthenticateResponseData>(data)
     }
 
     object TOTP {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
@@ -13,6 +13,7 @@ import com.stytch.sdk.common.network.models.NameData
 import com.stytch.sdk.common.network.models.Password
 import com.stytch.sdk.common.network.models.PhoneNumber
 import com.stytch.sdk.common.network.models.Provider
+import com.stytch.sdk.common.network.models.SDKDeviceHistory
 import com.stytch.sdk.common.network.models.StrengthPolicy
 import com.stytch.sdk.common.network.models.TOTP
 import com.stytch.sdk.common.network.models.WebAuthNRegistrations
@@ -128,6 +129,8 @@ public data class CreateResponse(
     val emailId: String,
     @Json(name = "user_id")
     val userId: String,
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
 ) : IAuthData,
     Parcelable
 
@@ -146,6 +149,8 @@ public data class BiometricsAuthData(
     override val user: UserData,
     @Json(name = "biometric_registration_id")
     val biometricRegistrationId: String,
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
 ) : IAuthData,
     Parcelable
 
@@ -339,6 +344,8 @@ public data class TOTPAuthenticateResponseData(
     @Json(name = "session_token")
     override val sessionToken: String,
     override val user: UserData,
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
 ) : IAuthData,
     Parcelable
 
@@ -371,5 +378,105 @@ public data class TOTPRecoverResponseData(
     @Json(name = "session_token")
     override val sessionToken: String,
     override val user: UserData,
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
 ) : IAuthData,
     Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class CryptoWalletsAuthenticateResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class OTPsAuthenticateResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class B2CPasswordsAuthenticateResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class PasswordsEmailResetResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class PasswordsExistingPasswordResetResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class PasswordsSessionResetResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+public data class WebAuthnAuthenticateResponseData(
+    @Json(name = "user_device")
+    val userDevice: SDKDeviceHistory?,
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+) : Parcelable,
+    IAuthData

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/otp/OTP.kt
@@ -6,9 +6,9 @@ import com.stytch.sdk.common.DEFAULT_OTP_EXPIRATION_TIME_MINUTES
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
-import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
 import com.stytch.sdk.consumer.OTPSendResponse
+import com.stytch.sdk.consumer.OTPsAuthenticateResponse
 import kotlinx.parcelize.Parcelize
 import java.util.concurrent.CompletableFuture
 
@@ -54,9 +54,9 @@ public interface OTP {
      * OTP code at any given time, if a user requests another OTP code before the first one has expired, the first one
      * will be invalidated.
      * @param parameters required to authenticate
-     * @return [AuthResponse]
+     * @return [OTPsAuthenticateResponse]
      */
-    public suspend fun authenticate(parameters: AuthParameters): AuthResponse
+    public suspend fun authenticate(parameters: AuthParameters): OTPsAuthenticateResponse
 
     /**
      * Authenticate a user given a method_id (the associated email_id or phone_id) and a code. This endpoint verifies
@@ -64,11 +64,11 @@ public interface OTP {
      * OTP code at any given time, if a user requests another OTP code before the first one has expired, the first one
      * will be invalidated.
      * @param parameters required to authenticate
-     * @param callback that receives an [AuthResponse]
+     * @param callback that receives an [OTPsAuthenticateResponse]
      */
     public fun authenticate(
         parameters: AuthParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: OTPsAuthenticateResponse) -> Unit,
     )
 
     /**
@@ -77,9 +77,9 @@ public interface OTP {
      * OTP code at any given time, if a user requests another OTP code before the first one has expired, the first one
      * will be invalidated.
      * @param parameters required to authenticate
-     * @return [AuthResponse]
+     * @return [OTPsAuthenticateResponse]
      */
-    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<AuthResponse>
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<OTPsAuthenticateResponse>
 
     /**
      * Provides all possible ways to call SMS OTP endpoints

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -3,7 +3,7 @@ package com.stytch.sdk.consumer.passkeys
 import android.app.Activity
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
-import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.WebAuthnAuthenticateResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
 import java.util.concurrent.CompletableFuture
@@ -83,26 +83,28 @@ public interface Passkeys {
     /**
      * Authenticates a Passkey registration.
      * @param parameters required to authenticate a Passkey registration
-     * @return [AuthResponse]
+     * @return [WebAuthnAuthenticateResponse]
      */
-    public suspend fun authenticate(parameters: AuthenticateParameters): AuthResponse
+    public suspend fun authenticate(parameters: AuthenticateParameters): WebAuthnAuthenticateResponse
 
     /**
      * Authenticates a Passkey registration.
      * @param parameters required to authenticate a Passkey registration
-     * @param callback a callback that receives a [AuthResponse]
+     * @param callback a callback that receives a [WebAuthnAuthenticateResponse]
      */
     public fun authenticate(
         parameters: AuthenticateParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: WebAuthnAuthenticateResponse) -> Unit,
     )
 
     /**
      * Authenticates a Passkey registration.
      * @param parameters required to authenticate a Passkey registration
-     * @return [AuthResponse]
+     * @return [WebAuthnAuthenticateResponse]
      */
-    public fun authenticateCompletable(parameters: AuthenticateParameters): CompletableFuture<AuthResponse>
+    public fun authenticateCompletable(
+        parameters: AuthenticateParameters,
+    ): CompletableFuture<WebAuthnAuthenticateResponse>
 
     /**
      * Updates a Passkey registration.

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
@@ -15,8 +15,8 @@ import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.errors.StytchPasskeysNotSupportedError
 import com.stytch.sdk.common.getValueOrThrow
-import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.ConsumerAuthMethod
+import com.stytch.sdk.consumer.WebAuthnAuthenticateResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
@@ -146,7 +146,7 @@ internal class PasskeysImpl internal constructor(
                 register(parameters)
             }.asCompletableFuture()
 
-    override suspend fun authenticate(parameters: Passkeys.AuthenticateParameters): AuthResponse {
+    override suspend fun authenticate(parameters: Passkeys.AuthenticateParameters): WebAuthnAuthenticateResponse {
         if (!isSupported) return StytchResult.Error(StytchPasskeysNotSupportedError())
         return try {
             withContext(dispatchers.io) {
@@ -186,7 +186,7 @@ internal class PasskeysImpl internal constructor(
 
     override fun authenticate(
         parameters: Passkeys.AuthenticateParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: WebAuthnAuthenticateResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
             val result = authenticate(parameters)
@@ -194,7 +194,9 @@ internal class PasskeysImpl internal constructor(
         }
     }
 
-    override fun authenticateCompletable(parameters: Passkeys.AuthenticateParameters): CompletableFuture<AuthResponse> =
+    override fun authenticateCompletable(
+        parameters: Passkeys.AuthenticateParameters,
+    ): CompletableFuture<WebAuthnAuthenticateResponse> =
         externalScope
             .async {
                 authenticate(parameters)

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passwords/Passwords.kt
@@ -5,8 +5,11 @@ import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.DEFAULT_SESSION_TIME_MINUTES
 import com.stytch.sdk.common.annotations.JacocoExcludeGenerated
 import com.stytch.sdk.common.network.models.Locale
-import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.PasswordsAuthenticateResponse
 import com.stytch.sdk.consumer.PasswordsCreateResponse
+import com.stytch.sdk.consumer.PasswordsEmailResetResponse
+import com.stytch.sdk.consumer.PasswordsExistingPasswordResetResponse
+import com.stytch.sdk.consumer.PasswordsSessionResetResponse
 import com.stytch.sdk.consumer.PasswordsStrengthCheckResponse
 import kotlinx.parcelize.Parcelize
 import java.util.concurrent.CompletableFuture
@@ -137,9 +140,9 @@ public interface Passwords {
      * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
      * the password is securely stored for future authentication and the user is authenticated.
      * @param parameters required to reset a user's password
-     * @return [AuthResponse]
+     * @return [PasswordsSessionResetResponse]
      */
-    public suspend fun resetBySession(parameters: ResetBySessionParameters): AuthResponse
+    public suspend fun resetBySession(parameters: ResetBySessionParameters): PasswordsSessionResetResponse
 
     /**
      * Reset the user’s password and authenticate them. This endpoint checks that the session is valid and hasn’t
@@ -147,11 +150,11 @@ public interface Passwords {
      * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
      * the password is securely stored for future authentication and the user is authenticated.
      * @param parameters required to reset a user's password
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [PasswordsSessionResetResponse]
      */
     public fun resetBySession(
         parameters: ResetBySessionParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (PasswordsSessionResetResponse) -> Unit,
     )
 
     /**
@@ -160,9 +163,11 @@ public interface Passwords {
      * checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted,
      * the password is securely stored for future authentication and the user is authenticated.
      * @param parameters required to reset a user's password
-     * @return [AuthResponse]
+     * @return [PasswordsSessionResetResponse]
      */
-    public fun resetBySessionCompletable(parameters: ResetBySessionParameters): CompletableFuture<AuthResponse>
+    public fun resetBySessionCompletable(
+        parameters: ResetBySessionParameters,
+    ): CompletableFuture<PasswordsSessionResetResponse>
 
     /**
      * Data class used for wrapping parameters used with Passwords StrengthCheck endpoint
@@ -192,19 +197,19 @@ public interface Passwords {
      * order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack
      * account-takeover attack.
      * @param parameters required to authenticate
-     * @return [AuthResponse]
+     * @return [PasswordsAuthenticateResponse]
      */
-    public suspend fun authenticate(parameters: AuthParameters): AuthResponse
+    public suspend fun authenticate(parameters: AuthParameters): PasswordsAuthenticateResponse
 
     /**
      * Authenticate a user with their email address and password. This endpoint verifies that the user has a password
      * currently set, and that the entered password is correct.
      * @param parameters required to authenticate
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [PasswordsAuthenticateResponse]
      */
     public fun authenticate(
         parameters: AuthParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: PasswordsAuthenticateResponse) -> Unit,
     )
 
     /**
@@ -221,9 +226,9 @@ public interface Passwords {
      * order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack
      * account-takeover attack.
      * @param parameters required to authenticate
-     * @return [AuthResponse]
+     * @return [PasswordsAuthenticateResponse]
      */
-    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<AuthResponse>
+    public fun authenticateCompletable(parameters: AuthParameters): CompletableFuture<PasswordsAuthenticateResponse>
 
     /**
      * Create a new user with a password and an authenticated session for the user if requested. If a user with this
@@ -285,9 +290,9 @@ public interface Passwords {
      * be checked in advance with the [strengthCheck] method. If the token and password are accepted, the password is
      * securely stored for future authentication and the user is authenticated.
      * @param parameters required to reset an account password
-     * @return [AuthResponse]
+     * @return [PasswordsEmailResetResponse]
      */
-    public suspend fun resetByEmail(parameters: ResetByEmailParameters): AuthResponse
+    public suspend fun resetByEmail(parameters: ResetByEmailParameters): PasswordsEmailResetResponse
 
     /**
      * Reset the user’s password and authenticate them. This endpoint checks that the magic link token is valid, hasn’t
@@ -295,11 +300,11 @@ public interface Passwords {
      * be checked in advance with the [strengthCheck] method. If the token and password are accepted, the password is
      * securely stored for future authentication and the user is authenticated.
      * @param parameters required to reset an account password
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [PasswordsEmailResetResponse]
      */
     public fun resetByEmail(
         parameters: ResetByEmailParameters,
-        callback: (response: AuthResponse) -> Unit,
+        callback: (response: PasswordsEmailResetResponse) -> Unit,
     )
 
     /**
@@ -308,35 +313,39 @@ public interface Passwords {
      * be checked in advance with the [strengthCheck] method. If the token and password are accepted, the password is
      * securely stored for future authentication and the user is authenticated.
      * @param parameters required to reset an account password
-     * @return [AuthResponse]
+     * @return [PasswordsEmailResetResponse]
      */
-    public fun resetByEmailCompletable(parameters: ResetByEmailParameters): CompletableFuture<AuthResponse>
+    public fun resetByEmailCompletable(
+        parameters: ResetByEmailParameters,
+    ): CompletableFuture<PasswordsEmailResetResponse>
 
     /**
      * Reset a user's password and authenticate them
      * @param parameters required to reset a user's password
-     * @returns [AuthResponse]
+     * @returns [PasswordsExistingPasswordResetResponse]
      */
-    public suspend fun resetByExistingPassword(parameters: ResetByExistingPasswordParameters): AuthResponse
+    public suspend fun resetByExistingPassword(
+        parameters: ResetByExistingPasswordParameters,
+    ): PasswordsExistingPasswordResetResponse
 
     /**
      * Reset a user's password and authenticate them
      * @param parameters required to reset a user's password
-     * @param callback a callback that receives an [AuthResponse]
+     * @param callback a callback that receives an [PasswordsExistingPasswordResetResponse]
      */
     public fun resetByExistingPassword(
         parameters: ResetByExistingPasswordParameters,
-        callback: (AuthResponse) -> Unit,
+        callback: (PasswordsExistingPasswordResetResponse) -> Unit,
     )
 
     /**
      * Reset a user's password and authenticate them
      * @param parameters required to reset a user's password
-     * @returns [AuthResponse]
+     * @returns [PasswordsExistingPasswordResetResponse]
      */
     public fun resetByExistingPasswordCompletable(
         parameters: ResetByExistingPasswordParameters,
-    ): CompletableFuture<AuthResponse>
+    ): CompletableFuture<PasswordsExistingPasswordResetResponse>
 
     /**
      * This method allows you to check whether or not the user’s provided password is valid, and to provide feedback to

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/crypto/CryptoWalletImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/crypto/CryptoWalletImplTest.kt
@@ -1,13 +1,12 @@
 package com.stytch.sdk.consumer.crypto
 
 import com.stytch.sdk.common.StytchDispatchers
-import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.CryptoWalletAuthenticateStartResponse
+import com.stytch.sdk.consumer.CryptoWalletsAuthenticateResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
-import com.stytch.sdk.consumer.network.models.AuthData
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
@@ -39,7 +38,7 @@ internal class CryptoWalletImplTest {
 
     private lateinit var impl: CryptoWalletImpl
     private val dispatcher = Dispatchers.Unconfined
-    private val successfulAuthResponse = StytchResult.Success<AuthData>(mockk(relaxed = true))
+    private val successfulAuthResponse = mockk<CryptoWalletsAuthenticateResponse>(relaxed = true)
 
     @Before
     fun before() {

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
@@ -9,7 +9,7 @@ import com.stytch.sdk.consumer.LoginOrCreateOTPResponse
 import com.stytch.sdk.consumer.OTPSendResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
-import com.stytch.sdk.consumer.network.models.AuthData
+import com.stytch.sdk.consumer.network.models.OTPsAuthenticateResponseData
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
@@ -43,7 +43,7 @@ internal class OTPImplTest {
     private lateinit var impl: OTPImpl
     private val dispatcher = Dispatchers.Unconfined
 
-    private val successfulAuthResponse = StytchResult.Success<AuthData>(mockk(relaxed = true))
+    private val successfulAuthResponse = StytchResult.Success<OTPsAuthenticateResponseData>(mockk(relaxed = true))
     private val authParameters = OTP.AuthParameters("", "", sessionDurationMinutes = 30)
 
     @Before

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
@@ -5,6 +5,7 @@ import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchPasskeysNotSupportedError
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.WebAuthnAuthenticateResponse
 import com.stytch.sdk.consumer.WebAuthnRegisterResponse
 import com.stytch.sdk.consumer.WebAuthnUpdateResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
@@ -254,7 +255,7 @@ internal class PasskeysImplTest {
                 )
             } returns StytchResult.Success(mockk(relaxed = true))
             coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
-            val mockSuccessResponse = mockk<AuthResponse>(relaxed = true)
+            val mockSuccessResponse = mockk<WebAuthnAuthenticateResponse>(relaxed = true)
             coEvery { mockApi.authenticate(any(), any()) } returns mockSuccessResponse
             every { mockSuccessResponse.launchSessionUpdater(any(), any()) } just runs
             impl.authenticate(mockk(relaxed = true))

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/OTPConfirmationScreenViewModelTest.kt
@@ -9,7 +9,7 @@ import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.consumer.StytchClient
-import com.stytch.sdk.consumer.network.models.IAuthData
+import com.stytch.sdk.consumer.network.models.OTPsAuthenticateResponseData
 import com.stytch.sdk.consumer.otp.OTP
 import com.stytch.sdk.ui.b2c.data.EventState
 import com.stytch.sdk.ui.b2c.data.NavigationRoute
@@ -131,7 +131,7 @@ internal class OTPConfirmationScreenViewModelTest {
     @Test
     fun `authenticate updates state and emits event on success`() =
         runTest(dispatcher) {
-            val result: StytchResult.Success<IAuthData> = mockk(relaxed = true)
+            val result: StytchResult.Success<OTPsAuthenticateResponseData> = mockk(relaxed = true)
             val eventFlow =
                 async {
                     viewModel.eventFlow.first()

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/ReturningUserScreenViewModelTest.kt
@@ -9,7 +9,7 @@ import com.stytch.sdk.common.network.models.BasicData
 import com.stytch.sdk.common.network.models.Locale
 import com.stytch.sdk.common.network.models.LoginOrCreateOTPData
 import com.stytch.sdk.consumer.StytchClient
-import com.stytch.sdk.consumer.network.models.IAuthData
+import com.stytch.sdk.consumer.network.models.B2CPasswordsAuthenticateResponseData
 import com.stytch.sdk.ui.b2c.data.EventState
 import com.stytch.sdk.ui.b2c.data.NavigationRoute
 import com.stytch.sdk.ui.b2c.data.PasswordOptions
@@ -90,7 +90,7 @@ internal class ReturningUserScreenViewModelTest {
     @Test
     fun `authenticate updates state and emits correct event on success`() =
         runTest(dispatcher) {
-            val result: StytchResult.Success<IAuthData> = mockk(relaxed = true)
+            val result: StytchResult.Success<B2CPasswordsAuthenticateResponseData> = mockk(relaxed = true)
             coEvery { mockStytchClient.passwords.authenticate(any()) } returns result
             val eventFlow =
                 async {

--- a/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/SetPasswordScreenViewModelTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/ui/b2c/screens/SetPasswordScreenViewModelTest.kt
@@ -6,7 +6,7 @@ import com.stytch.sdk.common.errors.StytchInternalError
 import com.stytch.sdk.common.network.models.Feedback
 import com.stytch.sdk.common.network.models.StrengthPolicy
 import com.stytch.sdk.consumer.StytchClient
-import com.stytch.sdk.consumer.network.models.IAuthData
+import com.stytch.sdk.consumer.network.models.PasswordsEmailResetResponseData
 import com.stytch.sdk.consumer.network.models.StrengthCheckResponse
 import com.stytch.sdk.ui.b2c.data.EventState
 import com.stytch.sdk.ui.shared.data.EmailState
@@ -100,7 +100,7 @@ internal class SetPasswordScreenViewModelTest {
     @Test
     fun `onSubmit delegates to stytchclient and navigates on success`() =
         runTest(dispatcher) {
-            val result = StytchResult.Success(mockk<IAuthData>(relaxed = true))
+            val result = StytchResult.Success(mockk<PasswordsEmailResetResponseData>(relaxed = true))
             coEvery { mockStytchClient.passwords.resetByEmail(any()) } returns result
             val eventFlow =
                 async {


### PR DESCRIPTION
Linear Ticket: [SDK-2822](https://linear.app/stytch/issue/SDK-2822)

## Changes:

1. Adds user/member device history per JS/RN implementation

## Notes:

- Annoyingly, a lot of the B2C auth endpoints were using a shared `AuthData` response, so needed to create custom response types for these instances.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A