### PR TITLE
Do session hydration checking on lifecycle changes

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.57.2"
+val publishVersion = "0.57.3"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -113,8 +113,14 @@ internal class ConfigurationManager {
             )
             client.onFinishedInitialization()
         }
-        NetworkChangeListener.configure(context.applicationContext, ::refreshBootstrapAndApi)
-        AppLifecycleListener.configure(::refreshBootstrapAndApi)
+        NetworkChangeListener.configure(context.applicationContext) {
+            refreshBootstrapAndApi()
+            client.rehydrateSession()
+        }
+        AppLifecycleListener.configure {
+            refreshBootstrapAndApi()
+            client.rehydrateSession()
+        }
     }
 
     private fun isAlreadyConfiguredFor(


### PR DESCRIPTION
## Changes:

1. Trigger a session validation check when the network or lifecycle changes to ensure stale tokens are not persisted when a session expires while backgrounded

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A