### PR TITLE
SDK-2816 biometrics registration management

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # @stytchauth/mobile-sdks will be requested for
 # review when someone opens a pull request.
-*       @stytchauth/mobile-sdks @stytchauth/frontend 
+*       @stytchauth/engineering

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.57.1"
+val publishVersion = "0.58.0"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
@@ -41,4 +41,3 @@ internal const val PREFERENCES_NAME_ORGANIZATION_DATA = "stytch_organization_dat
 internal const val IST_EXPIRATION_TIME = 10 * 60 * 1000L // 10 minutes
 internal const val PREFERENCES_NAME_LAST_AUTH_METHOD_USED = "stytch_last_auth_method_used"
 internal const val PREFERENCES_NAME_LAST_AUTHENTICATED_USER_ID = "stytch_last_authenticated_user_id"
-internal const val PREFERENCES_NAME_BIOMETRIC_PENDING_DELETE = "stytch_biometric_registration_pending_delete_for_"

--- a/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/Constants.kt
@@ -40,3 +40,5 @@ internal const val PREFERENCES_NAME_MEMBER_DATA = "stytch_member_data"
 internal const val PREFERENCES_NAME_ORGANIZATION_DATA = "stytch_organization_data"
 internal const val IST_EXPIRATION_TIME = 10 * 60 * 1000L // 10 minutes
 internal const val PREFERENCES_NAME_LAST_AUTH_METHOD_USED = "stytch_last_auth_method_used"
+internal const val PREFERENCES_NAME_LAST_AUTHENTICATED_USER_ID = "stytch_last_authenticated_user_id"
+internal const val PREFERENCES_NAME_BIOMETRIC_PENDING_DELETE = "stytch_biometric_registration_pending_delete_for_"

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -7,6 +7,8 @@ import com.stytch.sdk.common.EncryptionManager.KEY_PREFERENCES_FILE_NAME
 import com.stytch.sdk.common.EncryptionManager.MASTER_KEY_ALIAS
 import com.stytch.sdk.common.StorageHelper.sharedPreferences
 import com.stytch.sdk.common.extensions.clearPreferences
+import com.stytch.sdk.consumer.biometrics.BIOMETRIC_KEY_NAME
+import com.stytch.sdk.consumer.biometrics.KEYS_REQUIRED_FOR_REGISTRATION
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,7 +19,7 @@ import java.security.KeyStore
 internal const val STYTCH_PREFERENCES_FILE_NAME = "stytch_preferences"
 
 internal object StorageHelper {
-    internal val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore")
+    private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore")
 
     @VisibleForTesting
     internal lateinit var sharedPreferences: SharedPreferences
@@ -151,4 +153,9 @@ internal object StorageHelper {
         } catch (e: Exception) {
             false
         }
+
+    internal fun deleteAllBiometricsKeys() {
+        KEYS_REQUIRED_FOR_REGISTRATION.forEach { deletePreference(it) }
+        keyStore.deleteEntry(BIOMETRIC_KEY_NAME)
+    }
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -230,6 +230,12 @@ public object StytchClient {
                 options = options,
                 storageHelperInitializationJob = storageHelperInitializationJob,
             )
+            configurationManager.externalScope.launch(configurationManager.dispatchers.io) {
+                sessionStorage.biometricCleanupNotificationFlow.collect { biometricRegistrationIdToDelete ->
+                    // TODO: this needs to use the new flag to indicate it's a PD deletion
+                    StytchApi.UserManagement.deleteBiometricRegistrationById(biometricRegistrationIdToDelete)
+                }
+            }
         }.onFailure {
             val error =
                 StytchInternalError(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -230,12 +230,6 @@ public object StytchClient {
                 options = options,
                 storageHelperInitializationJob = storageHelperInitializationJob,
             )
-            configurationManager.externalScope.launch(configurationManager.dispatchers.io) {
-                sessionStorage.biometricCleanupNotificationFlow.collect { biometricRegistrationIdToDelete ->
-                    // TODO: this needs to use the new flag to indicate it's a PD deletion
-                    StytchApi.UserManagement.deleteBiometricRegistrationById(biometricRegistrationIdToDelete)
-                }
-            }
         }.onFailure {
             val error =
                 StytchInternalError(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
@@ -109,8 +109,7 @@ internal class BiometricsImpl internal constructor(
     }
 
     private fun removeLocalRegistrationOnly() {
-        KEYS_REQUIRED_FOR_REGISTRATION.forEach { key -> storageHelper.deletePreference(key) }
-        biometricsProvider.deleteSecretKey()
+        storageHelper.deleteAllBiometricsKeys()
     }
 
     override suspend fun removeRegistration(): Boolean =

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProvider.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProvider.kt
@@ -22,7 +22,5 @@ internal interface BiometricsProvider {
         allowedAuthenticators: Int,
     ): Int
 
-    fun deleteSecretKey()
-
     fun ensureSecretKeyIsAvailable(allowedAuthenticators: Int)
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProviderImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsProviderImpl.kt
@@ -151,10 +151,6 @@ internal class BiometricsProviderImpl : BiometricsProvider {
         allowedAuthenticators: Int,
     ): Int = BiometricManager.from(context).canAuthenticate(allowedAuthenticators)
 
-    override fun deleteSecretKey() {
-        keyStore.deleteEntry(BIOMETRIC_KEY_NAME)
-    }
-
     override fun ensureSecretKeyIsAvailable(allowedAuthenticators: Int) {
         val secretKey = getSecretKey(allowedAuthenticators) ?: error("SecretKey cannot be null")
         // initialize a cipher (that we won't use) with the secretkey to ensure it hasn't been invalidated

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/UserDataExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/UserDataExt.kt
@@ -1,8 +1,6 @@
 package com.stytch.sdk.consumer.extensions
 
 import com.stytch.sdk.common.StorageHelper
-import com.stytch.sdk.consumer.biometrics.BIOMETRIC_KEY_NAME
-import com.stytch.sdk.consumer.biometrics.KEYS_REQUIRED_FOR_REGISTRATION
 import com.stytch.sdk.consumer.biometrics.LAST_USED_BIOMETRIC_REGISTRATION_ID
 import com.stytch.sdk.consumer.network.models.UserData
 
@@ -11,7 +9,6 @@ internal fun UserData.keepLocalBiometricRegistrationsInSync(storageHelper: Stora
     // delete the local registration, as it is no longer valid
     val localRegistrationId = storageHelper.loadValue(LAST_USED_BIOMETRIC_REGISTRATION_ID)
     if (localRegistrationId != null && !biometricRegistrations.map { it.id }.contains(localRegistrationId)) {
-        KEYS_REQUIRED_FOR_REGISTRATION.forEach { storageHelper.deletePreference(it) }
-        storageHelper.keyStore.deleteEntry(BIOMETRIC_KEY_NAME)
+        storageHelper.deleteAllBiometricsKeys()
     }
 }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/extensions/UserDataExtTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/extensions/UserDataExtTest.kt
@@ -22,7 +22,10 @@ internal class UserDataExtTest {
     @Before
     fun before() {
         mockkStatic(KeyStore::class)
-        every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
+        every { KeyStore.getInstance(any()) } returns
+            mockk(relaxed = true) {
+                every { deleteEntry(any()) } just runs
+            }
         mockkObject(StorageHelper)
     }
 
@@ -33,25 +36,19 @@ internal class UserDataExtTest {
         val mockUser: UserData = mockk(relaxed = true)
         mockUser.keepLocalBiometricRegistrationsInSync(StorageHelper)
         verify(exactly = 0) { StorageHelper.deletePreference(any()) }
-        verify(exactly = 0) { StorageHelper.keyStore.deleteEntry(any()) }
+        verify(exactly = 0) { StorageHelper.deleteAllBiometricsKeys() }
 
         // local registration that exists on the user, does nothing
         every { StorageHelper.loadValue(LAST_USED_BIOMETRIC_REGISTRATION_ID) } returns MOCK_REGISTRATION_ID
         every { mockUser.biometricRegistrations } returns listOf(BiometricRegistrations(MOCK_REGISTRATION_ID, true))
         mockUser.keepLocalBiometricRegistrationsInSync(StorageHelper)
         verify(exactly = 0) { StorageHelper.deletePreference(any()) }
-        verify(exactly = 0) { StorageHelper.keyStore.deleteEntry(any()) }
+        verify(exactly = 0) { StorageHelper.deleteAllBiometricsKeys() }
 
         // local registration that doesn't exist on the user, deletes local
         every { StorageHelper.loadValue(LAST_USED_BIOMETRIC_REGISTRATION_ID) } returns MOCK_REGISTRATION_ID
         every { mockUser.biometricRegistrations } returns emptyList()
-        val mockKeystore: KeyStore =
-            mockk(relaxed = true) {
-                every { deleteEntry(any()) } just runs
-            }
-        every { StorageHelper.keyStore } returns mockKeystore
         mockUser.keepLocalBiometricRegistrationsInSync(StorageHelper)
         verify(exactly = KEYS_REQUIRED_FOR_REGISTRATION.size) { StorageHelper.deletePreference(any()) }
-        verify(exactly = 1) { mockKeystore.deleteEntry(any()) }
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-2816](https://linear.app/stytch/issue/SDK-2816)

## Changes:

1. Keep track of the last authenticated user, and when the user changes, clean up biometric registrations as appropriate. If there was no previous user, or the previous user and current user are the same, just clean up any potentially device-orphaned registrations (existing behavior). If a _new_ user is logged in, remove any existing biometric registrations to enable the new user to create their own. This creates a server-orphaned registration but new changes in the API will handle these as necessary.

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A