### PR TITLE
SDK-2901 auto extend session

### DIFF
--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -682,14 +682,17 @@ public object StytchB2BClient {
                 sessionStorage.memberSession?.let {
                     // if we have a session, it's expiration date has already been validated, now attempt
                     // to validate it with the Stytch servers
-                    sessions.authenticate(B2BSessions.AuthParams()).apply {
-                        configurationManager.emitAnalyticsEvent(
-                            ConfigurationAnalyticsEvent(
-                                step = ConfigurationStep.SESSION_HYDRATION,
-                                duration = Date().time - start,
-                            ),
-                        )
-                    }
+                    sessions
+                        .authenticate(
+                            B2BSessions.AuthParams(configurationManager.options.sessionDurationMinutes),
+                        ).apply {
+                            configurationManager.emitAnalyticsEvent(
+                                ConfigurationAnalyticsEvent(
+                                    step = ConfigurationStep.SESSION_HYDRATION,
+                                    duration = Date().time - start,
+                                ),
+                            )
+                        }
                 } ?: configurationManager.emitAnalyticsEvent(
                     ConfigurationAnalyticsEvent(
                         step = ConfigurationStep.SESSION_HYDRATION,

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -684,7 +684,13 @@ public object StytchB2BClient {
                     // to validate it with the Stytch servers
                     sessions
                         .authenticate(
-                            B2BSessions.AuthParams(configurationManager.options.sessionDurationMinutes),
+                            B2BSessions.AuthParams(
+                                if (configurationManager.options.enableAutomaticSessionExtension) {
+                                    configurationManager.options.sessionDurationMinutes
+                                } else {
+                                    null
+                                },
+                            ),
                         ).apply {
                             configurationManager.emitAnalyticsEvent(
                                 ConfigurationAnalyticsEvent(

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
@@ -67,7 +67,11 @@ internal fun <T : CommonAuthenticationData> StytchResult<T>.launchSessionUpdater
             updateSession = {
                 withContext(dispatchers.io) {
                     StytchB2BApi.Sessions.authenticate(
-                        StytchB2BClient.configurationManager.options.sessionDurationMinutes,
+                        if (StytchB2BClient.configurationManager.options.enableAutomaticSessionExtension) {
+                            StytchB2BClient.configurationManager.options.sessionDurationMinutes
+                        } else {
+                            null
+                        },
                     )
                 }
             },

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/extensions/StytchResultExt.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.b2b.extensions
 
+import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IB2BAuthDataWithMFA
@@ -65,7 +66,9 @@ internal fun <T : CommonAuthenticationData> StytchResult<T>.launchSessionUpdater
             dispatchers = dispatchers,
             updateSession = {
                 withContext(dispatchers.io) {
-                    StytchB2BApi.Sessions.authenticate(null)
+                    StytchB2BApi.Sessions.authenticate(
+                        StytchB2BClient.configurationManager.options.sessionDurationMinutes,
+                    )
                 }
             },
             saveSession = { result ->

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientOptions.kt
@@ -9,6 +9,8 @@ import com.stytch.sdk.common.dfp.DFPType
  * @property dfpType Determines if the webview or native DFP implementation is used. Defaults to Native.
  * @property sessionDurationMinutes Determines the default session duration for all authentication requests.
  * Defaults to 5 minutes.
+ * @property enableAutomaticSessionExtension If true, the session heartbeat will attempt to extend the session duration,
+ * instead of only checking the validity.
  */
 @JacocoExcludeGenerated
 public data class StytchClientOptions
@@ -17,4 +19,5 @@ public data class StytchClientOptions
         val endpointOptions: EndpointOptions = EndpointOptions(),
         val dfpType: DFPType = DFPType.Native,
         val sessionDurationMinutes: Int = DEFAULT_SESSION_TIME_MINUTES,
+        val enableAutomaticSessionExtension: Boolean = false,
     )

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -586,7 +586,13 @@ public object StytchClient {
                     // to validate it with the Stytch servers
                     sessions
                         .authenticate(
-                            Sessions.AuthParams(configurationManager.options.sessionDurationMinutes),
+                            Sessions.AuthParams(
+                                if (configurationManager.options.enableAutomaticSessionExtension) {
+                                    configurationManager.options.sessionDurationMinutes
+                                } else {
+                                    null
+                                },
+                            ),
                         ).apply {
                             configurationManager.emitAnalyticsEvent(
                                 ConfigurationAnalyticsEvent(

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -584,14 +584,17 @@ public object StytchClient {
                 sessionStorage.session?.let {
                     // if we have a session, it's expiration date has already been validated, now attempt
                     // to validate it with the Stytch servers
-                    sessions.authenticate(Sessions.AuthParams()).apply {
-                        configurationManager.emitAnalyticsEvent(
-                            ConfigurationAnalyticsEvent(
-                                step = ConfigurationStep.SESSION_HYDRATION,
-                                duration = Date().time - start,
-                            ),
-                        )
-                    }
+                    sessions
+                        .authenticate(
+                            Sessions.AuthParams(configurationManager.options.sessionDurationMinutes),
+                        ).apply {
+                            configurationManager.emitAnalyticsEvent(
+                                ConfigurationAnalyticsEvent(
+                                    step = ConfigurationStep.SESSION_HYDRATION,
+                                    duration = Date().time - start,
+                                ),
+                            )
+                        }
                 } ?: configurationManager.emitAnalyticsEvent(
                     ConfigurationAnalyticsEvent(
                         step = ConfigurationStep.SESSION_HYDRATION,

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
@@ -40,7 +40,13 @@ internal fun <T : IAuthData> StytchResult<T>.launchSessionUpdater(
             dispatchers = dispatchers,
             updateSession = {
                 withContext(dispatchers.io) {
-                    StytchApi.Sessions.authenticate(StytchClient.configurationManager.options.sessionDurationMinutes)
+                    StytchApi.Sessions.authenticate(
+                        if (StytchClient.configurationManager.options.enableAutomaticSessionExtension) {
+                            StytchClient.configurationManager.options.sessionDurationMinutes
+                        } else {
+                            null
+                        },
+                    )
                 }
             },
             saveSession = { result ->

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/extensions/StytchResultExt.kt
@@ -6,6 +6,7 @@ package com.stytch.sdk.consumer.extensions
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.sessions.SessionAutoUpdater
+import com.stytch.sdk.consumer.StytchClient
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.network.models.IAuthData
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
@@ -39,7 +40,7 @@ internal fun <T : IAuthData> StytchResult<T>.launchSessionUpdater(
             dispatchers = dispatchers,
             updateSession = {
                 withContext(dispatchers.io) {
-                    StytchApi.Sessions.authenticate(null)
+                    StytchApi.Sessions.authenticate(StytchClient.configurationManager.options.sessionDurationMinutes)
                 }
             },
             saveSession = { result ->

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -224,7 +224,7 @@ internal class StytchB2BClientTest {
                     .toJson(mockValidSession)
             every { StorageHelper.loadValue(any()) } returns mockValidSessionJSON
             StytchB2BClient.configure(mContextMock, UUID.randomUUID().toString())
-            coVerify(exactly = 1) { StytchB2BApi.Sessions.authenticate() }
+            coVerify(exactly = 1) { StytchB2BApi.Sessions.authenticate(any()) }
         }
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -222,7 +222,7 @@ internal class StytchClientTest {
                     .toJson(mockValidSession)
             every { StorageHelper.loadValue(any()) } returns mockValidSessionJSON
             StytchClient.configure(mContextMock, UUID.randomUUID().toString())
-            coVerify(exactly = 1) { StytchApi.Sessions.authenticate() }
+            coVerify(exactly = 1) { StytchApi.Sessions.authenticate(any()) }
         }
     }
 


### PR DESCRIPTION
Linear Ticket: [SDK-2901](https://linear.app/stytch/issue/SDK-2901)

## Changes:

1. Instead of just validating a session during the heartbeat, also attempt to _extend_ the session duration by the default session length

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A