### PR TITLE
SDK-2903 Fix SimpleDateFormat crash

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.58.1"
+val publishVersion = "0.58.2"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
@@ -23,7 +23,6 @@ import com.stytch.sdk.common.utils.getDateOrMin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.Date
-import java.util.TimeZone
 
 internal class B2BSessionStorage(
     private val storageHelper: StorageHelper,
@@ -142,7 +141,7 @@ internal class B2BSessionStorage(
                     }
                 val expirationDate = memberSessionData?.expiresAt.getDateOrMin()
                 val formatter = SHORT_FORM_DATE_FORMATTER
-                val now = formatter.format(Date()).getDateOrMin()
+                val now = formatter?.format(Date()).getDateOrMin()
                 if (expirationDate.before(now)) {
                     revoke()
                     return null

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/sessions/B2BSessionStorage.kt
@@ -142,7 +142,6 @@ internal class B2BSessionStorage(
                     }
                 val expirationDate = memberSessionData?.expiresAt.getDateOrMin()
                 val formatter = SHORT_FORM_DATE_FORMATTER
-                formatter.timeZone = TimeZone.getTimeZone("UTC")
                 val now = formatter.format(Date()).getDateOrMin()
                 if (expirationDate.before(now)) {
                     revoke()

--- a/source/sdk/src/main/java/com/stytch/sdk/common/events/EventsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/events/EventsImpl.kt
@@ -29,7 +29,7 @@ internal class EventsImpl(
                 eventId = "event-id-${UUID.randomUUID()}",
                 appSessionId = appSessionId,
                 persistentId = "persistent-id-${UUID.randomUUID()}",
-                clientSentAt = ISO_DATE_FORMATTER.format(Date()),
+                clientSentAt = ISO_DATE_FORMATTER?.format(Date()) ?: "",
                 timezone = TimeZone.getDefault().id,
                 eventName = eventName,
                 infoHeaderModel = infoHeaderModel,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/utils/DateHelpers.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/utils/DateHelpers.kt
@@ -1,20 +1,66 @@
 package com.stytch.sdk.common.utils
 
+import java.lang.ThreadLocal
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.ConcurrentHashMap
 
-// Format a date as ISO-8601, using the appropriate date and time patterns. See: https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
-internal val ISO_DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
+private object SdfPool {
+    private data class Key(
+        val pattern: String,
+        val tzId: String,
+        val locale: Locale,
+    )
 
-internal val SHORT_FORM_DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+    private val cache = ConcurrentHashMap<Key, ThreadLocal<SimpleDateFormat>>()
+
+    private fun newThreadLocal(
+        pattern: String,
+        tz: TimeZone,
+        locale: Locale,
+    ): ThreadLocal<SimpleDateFormat> =
+        object : ThreadLocal<SimpleDateFormat>() {
+            override fun initialValue(): SimpleDateFormat =
+                SimpleDateFormat(pattern, locale).apply {
+                    isLenient = false
+                    timeZone = tz
+                }
+        }
+
+    fun get(
+        pattern: String,
+        tz: TimeZone = TimeZone.getTimeZone("UTC"),
+        locale: Locale = Locale.US,
+    ): SimpleDateFormat {
+        val key = Key(pattern, tz.id, locale)
+        var tl = cache[key]
+        if (tl == null) {
+            val created = newThreadLocal(pattern, tz, locale)
+            val prev = cache.putIfAbsent(key, created)
+            tl = prev ?: created
+        }
+        return tl.get()!!
+    }
+}
+
+private const val ISO_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+private const val SHORT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+
+internal val ISO_DATE_FORMATTER get() = SdfPool.get(ISO_PATTERN)
+internal val SHORT_FORM_DATE_FORMATTER get() = SdfPool.get(SHORT_PATTERN)
 
 internal fun String?.getDateOrMin(minimum: Date = Date(0L)): Date =
     this?.let { date ->
         try {
             ISO_DATE_FORMATTER.parse(date)
-        } catch (e: ParseException) {
-            SHORT_FORM_DATE_FORMATTER.parse(date)
+        } catch (_: ParseException) {
+            try {
+                SHORT_FORM_DATE_FORMATTER.parse(date)
+            } catch (_: ParseException) {
+                minimum
+            }
         }
     } ?: minimum

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
@@ -22,7 +22,6 @@ import com.stytch.sdk.consumer.network.models.UserData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.Date
-import java.util.TimeZone
 
 internal class ConsumerSessionStorage(
     private val storageHelper: StorageHelper,
@@ -105,7 +104,7 @@ internal class ConsumerSessionStorage(
                     }
                 val expirationDate = sessionData?.expiresAt.getDateOrMin()
                 val formatter = SHORT_FORM_DATE_FORMATTER
-                val now = formatter.format(Date()).getDateOrMin()
+                val now = formatter?.format(Date()).getDateOrMin()
                 if (expirationDate.before(now)) {
                     revoke()
                     return null

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/sessions/ConsumerSessionStorage.kt
@@ -105,7 +105,6 @@ internal class ConsumerSessionStorage(
                     }
                 val expirationDate = sessionData?.expiresAt.getDateOrMin()
                 val formatter = SHORT_FORM_DATE_FORMATTER
-                formatter.timeZone = TimeZone.getTimeZone("UTC")
                 val now = formatter.format(Date()).getDateOrMin()
                 if (expirationDate.before(now)) {
                     revoke()

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -197,7 +197,7 @@ internal class StytchB2BClientTest {
             // yes session data, but expired, no authentication/updater
             val mockExpiredSession =
                 mockk<B2BSessionData>(relaxed = true) {
-                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER.format(Date(0L))
+                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER!!.format(Date(0L))
                 }
             val mockExpiredSessionJSON =
                 Moshi
@@ -213,7 +213,7 @@ internal class StytchB2BClientTest {
             // yes session data, and valid, yes authentication/updater
             val mockValidSession =
                 mockk<B2BSessionData>(relaxed = true) {
-                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER.format(Date(Date().time + 1000))
+                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER!!.format(Date(Date().time + 1000))
                 }
             val mockValidSessionJSON =
                 Moshi

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -195,7 +195,7 @@ internal class StytchClientTest {
             // yes session data, but expired, no authentication/updater
             val mockExpiredSession =
                 mockk<SessionData>(relaxed = true) {
-                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER.format(Date(0L))
+                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER!!.format(Date(0L))
                 }
             val mockExpiredSessionJSON =
                 Moshi
@@ -211,7 +211,7 @@ internal class StytchClientTest {
             // yes session data, and valid, yes authentication/updater
             val mockValidSession =
                 mockk<SessionData>(relaxed = true) {
-                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER.format(Date(Date().time + 1000))
+                    every { expiresAt } returns SHORT_FORM_DATE_FORMATTER!!.format(Date(Date().time + 1000))
                 }
             val mockValidSessionJSON =
                 Moshi


### PR DESCRIPTION
Linear Ticket: [SDK-2903](https://linear.app/stytch/issue/SDK-2903)

## Changes:

1. Since `SimpleDateFormat` is not thread safe, introduce a hashmap of `ThreadLocal` instances. This ensures calls to format/parse dates are thread safe while also avoiding expensive reinitialization of everything that SDF implements under the hood for functionality (calendars and the like)

## Notes:
- Ideally, we would use `java.time.*` implementations and this would be a lot simpler, but those aren't available until SDK 26, and we support down to 23. We _could_ use core desugaring to get access to those in earlier SDKs, but it requires our customers to _also_ opt-in to that, and I'm trying to fix this with 0 customer effort
- Closes #374 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A