### PR TITLE
Ensure dependencies/dependabot is only looking at the core SDK dependencies

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -22,9 +22,8 @@ jobs:
     - name: Generate and submit dependency graph
       uses: gradle/actions/dependency-submission@v3
       with:
+        gradle-build-module: ":source:sdk"
+        sub-module-mode: IGNORE
         build-scan-publish: true
         build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
         build-scan-terms-of-use-agree: "yes"
-       
-        # Exclude all dependencies that originate solely in the following projects
-        DEPENDENCY_GRAPH_EXCLUDE_PROJECTS: ':workbench-apps:consumer-workbench|:workbench-apps:b2b-workbench|:workbench-apps:uiworkbench|:example-apps:stytchexampleapp'       


### PR DESCRIPTION
## Changes:

1. Updates dependency submission workflow to only look at SDK dependencies

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A