### PR TITLE
Ensure keystore entry is deleted on KeyStoreException (instead of just the invalid preferences)

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.62.1"
+val publishVersion = "0.62.2"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StorageHelper.kt
@@ -36,8 +36,8 @@ internal object StorageHelper {
                 // `getOrGenerateNewAES256KeysetManager` method
                 context.clearPreferences(listOf(STYTCH_PREFERENCES_FILE_NAME, KEY_PREFERENCES_FILE_NAME))
             }
+            EncryptionManager.createNewKeys(context, keyStore)
             sharedPreferences = context.getSharedPreferences(STYTCH_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
-            EncryptionManager.createNewKeys(context)
         }
 
     /**

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -80,7 +80,7 @@ internal class StytchB2BClientTest {
             "com.stytch.sdk.b2b.extensions.StytchResultExtKt",
         )
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         mockkObject(NetworkChangeListener)
         every { NetworkChangeListener.configure(any(), any()) } just runs
         every { NetworkChangeListener.networkIsAvailable } returns true

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -62,7 +62,7 @@ internal class B2BMagicLinksImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/member/MemberImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/member/MemberImplTest.kt
@@ -57,7 +57,7 @@ internal class MemberImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { EncryptionManager.encryptString(any()) } returns ""
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -75,7 +75,7 @@ internal class StytchB2BApiTest {
         mockkObject(AppLifecycleListener)
         every { AppLifecycleListener.configure(any()) } just runs
         MockKAnnotations.init(this, true, true)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         StytchB2BApi.apiService = mockB2BApiService
         StytchB2BApi.publicToken = ""

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/oauth/OAuthImplTest.kt
@@ -54,7 +54,7 @@ internal class OAuthImplTest {
         mockkStatic(KeyStore::class)
         mockkStatic("com.stytch.sdk.common.extensions.StringExtKt", "com.stytch.sdk.common.extensions.ByteArrayExtKt")
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/organization/OrganizationImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/organization/OrganizationImplTest.kt
@@ -69,7 +69,7 @@ internal class OrganizationImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { EncryptionManager.encryptString(any()) } returns ""
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/passwords/PasswordsImplTest.kt
@@ -67,7 +67,7 @@ internal class PasswordsImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/rbac/RBACImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/rbac/RBACImplTest.kt
@@ -108,7 +108,7 @@ internal class RBACImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StytchB2BClient)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sessions/B2BSessionsImplTest.kt
@@ -60,7 +60,7 @@ internal class B2BSessionsImplTest {
         MockKAnnotations.init(this, true, true)
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.b2b.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/sso/SSOImplTest.kt
@@ -59,7 +59,7 @@ internal class SSOImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/common/pkcePairManager/PKCEPairManagerImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/common/pkcePairManager/PKCEPairManagerImplTest.kt
@@ -25,7 +25,7 @@ internal class PKCEPairManagerImplTest {
         mockkStatic(KeyStore::class)
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } just runs
+        every { EncryptionManager.createNewKeys(any(), any()) } just runs
         mockkObject(StorageHelper)
         every { StorageHelper.initialize(any()) } returns mockk()
 

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -78,7 +78,7 @@ internal class StytchClientTest {
             "com.stytch.sdk.consumer.extensions.StytchResultExtKt",
         )
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         mockkObject(NetworkChangeListener)
         every { NetworkChangeListener.configure(any(), any()) } just runs
         every { NetworkChangeListener.networkIsAvailable } returns true

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/biometrics/BiometricsImplTest.kt
@@ -82,7 +82,7 @@ internal class BiometricsImplTest {
             "com.stytch.sdk.consumer.extensions.StytchResultExtKt",
         )
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/magicLinks/MagicLinksImplTest.kt
@@ -58,7 +58,7 @@ internal class MagicLinksImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         MockKAnnotations.init(this, true, true)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/network/StytchApiTest.kt
@@ -61,7 +61,7 @@ internal class StytchApiTest {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
         MockKAnnotations.init(this, true, true)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         StytchApi.apiService = mockApiService

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/oauth/OAuthImplTest.kt
@@ -53,7 +53,7 @@ internal class OAuthImplTest {
         mockkStatic(KeyStore::class)
         mockkStatic("com.stytch.sdk.common.extensions.StringExtKt", "com.stytch.sdk.common.extensions.ByteArrayExtKt")
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         MockKAnnotations.init(this, true, true)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/otp/OTPImplTest.kt
@@ -51,7 +51,7 @@ internal class OTPImplTest {
         MockKAnnotations.init(this, true, true)
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passwords/PasswordsImplTest.kt
@@ -76,7 +76,7 @@ internal class PasswordsImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         mockkObject(SessionAutoUpdater)

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/SessionsImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/sessions/SessionsImplTest.kt
@@ -56,7 +56,7 @@ internal class SessionsImplTest {
         MockKAnnotations.init(this, true, true)
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(SessionAutoUpdater)
         mockkStatic("com.stytch.sdk.consumer.extensions.StytchResultExtKt")

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/userManagement/UserManagementImplTest.kt
@@ -49,7 +49,7 @@ internal class UserManagementImplTest {
     fun before() {
         mockkStatic(KeyStore::class)
         mockkObject(EncryptionManager)
-        every { EncryptionManager.createNewKeys(any()) } returns Unit
+        every { EncryptionManager.createNewKeys(any(), any()) } returns Unit
         every { KeyStore.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(StorageHelper)
         MockKAnnotations.init(this, true, true)


### PR DESCRIPTION
## Changes:

1. We were treating all keystore errors the same: delete the old/unusable preference files (good), but keep a potentially problematic master key (bad). This results in (if for some reason the master key becomes unusable), an unbreakable loop where no matter how many restarts you do, the app will never clear out the bad key (just the bad data). This will treat a keystore exception as truly exceptional, and ALSO nuke the master key. With the newly introduced "try three times" approach, this _should_ mean that a bad key is silently removed and a good key is added in it's place whenever this situation arises (which should be rarely!)
2. Bump the version for publishing
3. Update the tests to account for the method signature changing

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A