### PR TITLE
Add the ability to set preferImmediatelyAvailableCredentials on passkey requests

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.62.4"
+val publishVersion = "0.63.0"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/Passkeys.kt
@@ -15,14 +15,26 @@ import java.util.concurrent.CompletableFuture
 
 public interface Passkeys {
     /**
+     * Data class used for passing options to the Google Credential Manager
+     * @property preferImmediatelyAvailableCredentials set this to `true` if you prefer the operation to return
+     * immediately when there is no available passkey registration offering instead of falling back to discovering
+     * remote options, and false otherwise
+     */
+    public data class PasskeyCredentialOptions(
+        val preferImmediatelyAvailableCredentials: Boolean = false,
+    )
+
+    /**
      * Data class used for wrapping parameters used with Passkeys registration
      * @property activity an activity context for launching the native Passkeys UI
      * @property domain the domain of the Passkey registration. Do not include the protocol
+     * @property options options to pass to the credential creation request
      */
     @JacocoExcludeGenerated
     public data class RegisterParameters(
         val activity: Activity,
         val domain: String,
+        val options: PasskeyCredentialOptions = PasskeyCredentialOptions(true),
     )
 
     /**
@@ -30,6 +42,7 @@ public interface Passkeys {
      * @property activity an activity context for launching the native Passkeys UI
      * @property domain the domain of the Passkey registration. Do not include the protocol
      * @property sessionDurationMinutes indicates how long the session should last before it expires
+     * @property options options to pass to the credential retrieval request
      */
     @JacocoExcludeGenerated
     public data class AuthenticateParameters
@@ -38,6 +51,7 @@ public interface Passkeys {
             val activity: Activity,
             val domain: String,
             val sessionDurationMinutes: Int = StytchClient.configurationManager.options.defaultSessionDuration,
+            val options: PasskeyCredentialOptions = PasskeyCredentialOptions(false),
         )
 
     /**

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/passkeys/PasskeysImpl.kt
@@ -34,12 +34,14 @@ import java.util.concurrent.CompletableFuture
 internal interface PasskeysProvider {
     suspend fun createPublicKeyCredential(
         startResponse: WebAuthnRegisterStartData,
+        options: Passkeys.PasskeyCredentialOptions,
         activity: Activity,
         dispatchers: StytchDispatchers,
     ): CreatePublicKeyCredentialResponse
 
     suspend fun getPublicKeyCredential(
         startResponse: WebAuthnAuthenticateStartData,
+        options: Passkeys.PasskeyCredentialOptions,
         activity: Activity,
         dispatchers: StytchDispatchers,
     ): PublicKeyCredential
@@ -48,13 +50,14 @@ internal interface PasskeysProvider {
 private class PasskeysProviderImpl : PasskeysProvider {
     override suspend fun createPublicKeyCredential(
         startResponse: WebAuthnRegisterStartData,
+        options: Passkeys.PasskeyCredentialOptions,
         activity: Activity,
         dispatchers: StytchDispatchers,
     ): CreatePublicKeyCredentialResponse {
         val createPublicKeyCredentialRequest =
             CreatePublicKeyCredentialRequest(
                 requestJson = startResponse.publicKeyCredentialCreationOptions,
-                preferImmediatelyAvailableCredentials = true,
+                preferImmediatelyAvailableCredentials = options.preferImmediatelyAvailableCredentials,
             )
         val credentialManager = CredentialManager.create(activity)
         return withContext(dispatchers.ui) {
@@ -68,6 +71,7 @@ private class PasskeysProviderImpl : PasskeysProvider {
 
     override suspend fun getPublicKeyCredential(
         startResponse: WebAuthnAuthenticateStartData,
+        options: Passkeys.PasskeyCredentialOptions,
         activity: Activity,
         dispatchers: StytchDispatchers,
     ): PublicKeyCredential {
@@ -79,7 +83,11 @@ private class PasskeysProviderImpl : PasskeysProvider {
         return withContext(dispatchers.ui) {
             credentialManager.getCredential(
                 context = activity,
-                request = GetCredentialRequest(listOf(getPublicKeyCredentialOption)),
+                request =
+                    GetCredentialRequest(
+                        credentialOptions = listOf(getPublicKeyCredentialOption),
+                        preferImmediatelyAvailableCredentials = options.preferImmediatelyAvailableCredentials,
+                    ),
             )
         }.credential as PublicKeyCredential
         // if credential is not a PublicKeyCredential, it will error and be caught in the calling class
@@ -112,6 +120,7 @@ internal class PasskeysImpl internal constructor(
                 val credentialResponse =
                     provider.createPublicKeyCredential(
                         startResponse = startResponse,
+                        options = parameters.options,
                         activity = parameters.activity,
                         dispatchers = dispatchers,
                     )
@@ -167,6 +176,7 @@ internal class PasskeysImpl internal constructor(
                 val credentialResponse =
                     provider.getPublicKeyCredential(
                         startResponse = startResponse,
+                        options = parameters.options,
                         activity = parameters.activity,
                         dispatchers = dispatchers,
                     )

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysImplTest.kt
@@ -92,7 +92,7 @@ internal class PasskeysImplTest {
             val result = impl.register(mockk(relaxed = true))
             assert(result is StytchResult.Error)
             coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
-            coVerify(exactly = 0) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 0) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 0) { mockApi.register(any()) }
         }
 
@@ -103,11 +103,11 @@ internal class PasskeysImplTest {
             coEvery {
                 mockApi.registerStart(any(), any(), any(), any())
             } returns StytchResult.Success(mockk(relaxed = true))
-            coEvery { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) } throws Exception()
+            coEvery { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any(), any()) } throws Exception()
             val result = impl.register(mockk(relaxed = true))
             assert(result is StytchResult.Error)
             coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
-            coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 0) { mockApi.register(any()) }
         }
 
@@ -123,13 +123,14 @@ internal class PasskeysImplTest {
                     any(),
                     any(),
                     any(),
+                    any(),
                 )
             } returns mockk(relaxed = true)
             coEvery { mockApi.register(any()) } returns StytchResult.Error(mockk(relaxed = true))
             val result = impl.register(mockk(relaxed = true))
             assert(result is StytchResult.Error)
             coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
-            coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 1) { mockApi.register(any()) }
         }
 
@@ -145,6 +146,7 @@ internal class PasskeysImplTest {
                     any(),
                     any(),
                     any(),
+                    any(),
                 )
             } returns mockk(relaxed = true)
             val mockSuccessResponse = mockk<WebAuthnRegisterResponse>(relaxed = true)
@@ -152,7 +154,7 @@ internal class PasskeysImplTest {
             every { mockSuccessResponse.launchSessionUpdater(any(), any()) } just runs
             impl.register(mockk(relaxed = true))
             coVerify(exactly = 1) { mockApi.registerStart(any(), any(), any(), any()) }
-            coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 1) { mockPasskeysProvider.createPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 1) { mockApi.register(any()) }
             verify(exactly = 1) { mockSuccessResponse.launchSessionUpdater(any(), any()) }
         }
@@ -184,7 +186,7 @@ internal class PasskeysImplTest {
             assert(result is StytchResult.Error)
             coVerify(exactly = 1) { mockApi.authenticateStartSecondary(any(), any()) }
             coVerify(exactly = 0) { mockApi.authenticateStartPrimary(any(), any()) }
-            coVerify(exactly = 0) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 0) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 0) { mockApi.authenticate(any(), any()) }
         }
 
@@ -198,7 +200,7 @@ internal class PasskeysImplTest {
             assert(result is StytchResult.Error)
             coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
             coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
-            coVerify(exactly = 0) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 0) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 0) { mockApi.authenticate(any(), any()) }
         }
 
@@ -213,12 +215,12 @@ internal class PasskeysImplTest {
                     any(),
                 )
             } returns StytchResult.Success(mockk(relaxed = true))
-            coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } throws Exception()
+            coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) } throws Exception()
             val result = impl.authenticate(mockk(relaxed = true))
             assert(result is StytchResult.Error)
             coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
             coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
-            coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 0) { mockApi.authenticate(any(), any()) }
         }
 
@@ -233,13 +235,14 @@ internal class PasskeysImplTest {
                     any(),
                 )
             } returns StytchResult.Success(mockk(relaxed = true))
-            coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
+            coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) } returns
+                mockk(relaxed = true)
             coEvery { mockApi.authenticate(any(), any()) } returns StytchResult.Error(mockk(relaxed = true))
             val result = impl.authenticate(mockk(relaxed = true))
             assert(result is StytchResult.Error)
             coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
             coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
-            coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 1) { mockApi.authenticate(any(), any()) }
         }
 
@@ -254,14 +257,16 @@ internal class PasskeysImplTest {
                     any(),
                 )
             } returns StytchResult.Success(mockk(relaxed = true))
-            coEvery { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) } returns mockk(relaxed = true)
+            coEvery {
+                mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any())
+            } returns mockk(relaxed = true)
             val mockSuccessResponse = mockk<WebAuthnAuthenticateResponse>(relaxed = true)
             coEvery { mockApi.authenticate(any(), any()) } returns mockSuccessResponse
             every { mockSuccessResponse.launchSessionUpdater(any(), any()) } just runs
             impl.authenticate(mockk(relaxed = true))
             coVerify(exactly = 0) { mockApi.authenticateStartSecondary(any(), any()) }
             coVerify(exactly = 1) { mockApi.authenticateStartPrimary(any(), any()) }
-            coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any()) }
+            coVerify(exactly = 1) { mockPasskeysProvider.getPublicKeyCredential(any(), any(), any(), any()) }
             coVerify(exactly = 1) { mockApi.authenticate(any(), any()) }
             verify(exactly = 1) { mockSuccessResponse.launchSessionUpdater(any(), any()) }
         }

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/passkeys/PasskeysTest.kt
@@ -19,6 +19,7 @@ internal class PasskeysTest {
                 activity = mockActivity,
                 domain = "test.domain.com",
                 sessionDurationMinutes = DEFAULT_SESSION_TIME_MINUTES,
+                options = Passkeys.PasskeyCredentialOptions(false),
             )
         assert(params == expected)
     }


### PR DESCRIPTION
Linear Ticket: No ticket

## Changes:

1. Adds the ability to set `preferImmediatelyAvailableCredentials` on passkey requests
2. Bumps version for publishing

## Notes:

- Before, we were explicitly setting this to true on registration requests and not setting it (defaulting to false) on authentication requests. Now, it is configurable by the developer in both flows. Notice that the default values, however, are _different_ between register and authenticate. That is to preserve compatibility with the previous behavior.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A