### PR TITLE
Configure reporting potential errors encountered during configuration call

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.63.0"
+val publishVersion = "0.64.0"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -39,6 +39,7 @@ import com.stytch.sdk.common.ConfigurationStep
 import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeeplinkResponse
 import com.stytch.sdk.common.DeeplinkTokenPair
+import com.stytch.sdk.common.InitializationStatus
 import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.QUERY_REDIRECT_TYPE
 import com.stytch.sdk.common.QUERY_TOKEN
@@ -48,6 +49,7 @@ import com.stytch.sdk.common.StytchClientCommon
 import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchLazyDelegate
 import com.stytch.sdk.common.StytchLog
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.DFP
 import com.stytch.sdk.common.dfp.DFPImpl
 import com.stytch.sdk.common.errors.StytchDeeplinkMissingTokenError
@@ -80,14 +82,13 @@ public object StytchB2BClient {
      * the `configure()` method, to know when the Stytch SDK has been fully initialized and is ready for use
      */
     @JvmStatic
-    public val isInitialized: StateFlow<Boolean> = configurationManager.isInitialized.asStateFlow()
+    public val isInitialized: StateFlow<InitializationStatus> = configurationManager.isInitialized.asStateFlow()
 
     /**
      * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
      * across app launches.
      * You must call this method before making any Stytch authentication requests.
      * @param context The applicationContext of your app
-     * @param callback An optional callback that is triggered after configuration and initialization has completed
      * @throws StytchInternalError - if we failed to initialize for any reason
      */
     @JvmStatic
@@ -109,7 +110,7 @@ public object StytchB2BClient {
     public fun configure(
         context: Context,
         options: StytchClientOptions = StytchClientOptions(),
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
         configure(context, publicToken, options, callback)
@@ -126,7 +127,7 @@ public object StytchB2BClient {
     @JvmStatic
     public fun configure(
         context: Context,
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
         configure(context, publicToken, StytchClientOptions(), callback)
@@ -162,7 +163,7 @@ public object StytchB2BClient {
     public fun configure(
         context: Context,
         publicToken: String,
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         configure(context, publicToken, StytchClientOptions(), callback)
     }
@@ -215,7 +216,7 @@ public object StytchB2BClient {
         context: Context,
         publicToken: String,
         options: StytchClientOptions = StytchClientOptions(),
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         // We must initialize the storagehelper/sessionstorage before configuration, because configuration kicks
         // off a task that relies on the storage being available (session hydration). HOWEVER, we don't want to handle
@@ -227,7 +228,6 @@ public object StytchB2BClient {
                 StytchLog.w(
                     "StytchB2BClient is already configured. You should only call configure once, at application start.",
                 )
-                return
             }
             val storageHelperInitializationJob = StorageHelper.initialize(context)
             sessionStorage = if (::sessionStorage.isInitialized) sessionStorage else B2BSessionStorage(StorageHelper)
@@ -235,7 +235,7 @@ public object StytchB2BClient {
                 client =
                     StytchB2BClientCommonConfiguration {
                         sessionStorage.emitCurrent()
-                        callback(true)
+                        callback(it)
                     },
                 context = context,
                 publicToken = publicToken,
@@ -541,6 +541,7 @@ public object StytchB2BClient {
                         ),
                     )
                 }
+
                 B2BTokenType.DISCOVERY -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     if (redirectType == B2BRedirectType.RESET_PASSWORD) {
@@ -556,10 +557,12 @@ public object StytchB2BClient {
                         ),
                     )
                 }
+
                 B2BTokenType.MULTI_TENANT_PASSWORDS -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.ManualHandlingRequired(type = tokenType, token = token)
                 }
+
                 B2BTokenType.SSO -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
@@ -573,6 +576,7 @@ public object StytchB2BClient {
                         ),
                     )
                 }
+
                 B2BTokenType.OAUTH -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
@@ -586,6 +590,7 @@ public object StytchB2BClient {
                         ),
                     )
                 }
+
                 B2BTokenType.DISCOVERY_OAUTH -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
@@ -598,6 +603,7 @@ public object StytchB2BClient {
                         ),
                     )
                 }
+
                 else -> {
                     events.logEvent("deeplink_handled_failure", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError())
@@ -671,7 +677,7 @@ public object StytchB2BClient {
         get() = sessionStorage.lastAuthMethodUsed
 
     private class StytchB2BClientCommonConfiguration(
-        override var onFinishedInitialization: () -> Unit,
+        override var onFinishedInitialization: (InitializationStatus) -> Unit,
     ) : StytchClientCommon {
         override val commonApi: CommonApi = StytchB2BApi
 
@@ -699,6 +705,11 @@ public object StytchB2BClient {
                                 },
                             ),
                         ).apply {
+                            if (this is StytchResult.Error) {
+                                configurationManager.sessionHydrationError = this.exception
+                            } else {
+                                configurationManager.sessionHydrationError = null
+                            }
                             configurationManager.emitAnalyticsEvent(
                                 ConfigurationAnalyticsEvent(
                                     step = ConfigurationStep.SESSION_HYDRATION,

--- a/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/ConfigurationManager.kt
@@ -38,9 +38,10 @@ internal class ConfigurationManager {
     internal var bootstrapData: BootstrapData = BootstrapData()
     internal lateinit var publicToken: String
     internal lateinit var smsRetriever: StytchSMSRetriever
-    internal var isInitialized: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    internal var isInitialized: MutableStateFlow<InitializationStatus> = MutableStateFlow(InitializationStatus.Loading)
     private var configurationStartTime = 0L
     private lateinit var client: StytchClientCommon
+    internal var sessionHydrationError: Exception? = null
 
     fun configure(
         client: StytchClientCommon,
@@ -49,74 +50,85 @@ internal class ConfigurationManager {
         options: StytchClientOptions = StytchClientOptions(),
         storageHelperInitializationJob: Job,
     ) {
-        configurationStartTime = Date().time
-        this.client = client
-        this.publicToken = publicToken
-        this.options = options
-        this.applicationContext = WeakReference(context.applicationContext)
-        this.deviceInfo = context.getDeviceInfo()
-        this.appSessionId = "app-session-id-${UUID.randomUUID()}"
-        val activityProvider =
-            if (options.dfpType == DFPType.Webview) {
-                WebviewActivityProvider(context.applicationContext as Application)
-            } else {
-                null
-            }
-        this.dfpProvider =
-            DFPProviderImpl(
-                scope = externalScope,
-                context = context.applicationContext,
-                publicToken = publicToken,
-                dfppaDomain = options.endpointOptions.dfppaDomain,
-                dfpType = options.dfpType,
-                activityProvider = activityProvider,
+        try {
+            configurationStartTime = Date().time
+            this.client = client
+            this.publicToken = publicToken
+            this.options = options
+            this.applicationContext = WeakReference(context.applicationContext)
+            this.deviceInfo = context.getDeviceInfo()
+            this.appSessionId = "app-session-id-${UUID.randomUUID()}"
+            val activityProvider =
+                if (options.dfpType == DFPType.Webview) {
+                    WebviewActivityProvider(context.applicationContext as Application)
+                } else {
+                    null
+                }
+            this.dfpProvider =
+                DFPProviderImpl(
+                    scope = externalScope,
+                    context = context.applicationContext,
+                    publicToken = publicToken,
+                    dfppaDomain = options.endpointOptions.dfppaDomain,
+                    dfpType = options.dfpType,
+                    activityProvider = activityProvider,
+                )
+            this.smsRetriever =
+                StytchSMSRetrieverImpl(context) { code, sessionDurationMinutes ->
+                    smsRetriever.finish()
+                    client.smsAutofillCallback(code, sessionDurationMinutes)
+                }
+            val dfpConfiguration =
+                DFPConfiguration(
+                    dfpProvider = dfpProvider,
+                    captchaProvider =
+                        CaptchaProviderImpl(
+                            context.applicationContext as Application,
+                            externalScope,
+                            bootstrapData.captchaSettings.siteKey,
+                        ),
+                    dfpProtectedAuthEnabled = bootstrapData.dfpProtectedAuthEnabled,
+                    dfpProtectedAuthMode = bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
+                )
+            client.commonApi.configure(
+                publicToken,
+                deviceInfo,
+                options.endpointOptions,
+                client::getSessionToken,
+                dfpConfiguration,
             )
-        this.smsRetriever =
-            StytchSMSRetrieverImpl(context) { code, sessionDurationMinutes ->
-                smsRetriever.finish()
-                client.smsAutofillCallback(code, sessionDurationMinutes)
-            }
-        val dfpConfiguration =
-            DFPConfiguration(
-                dfpProvider = dfpProvider,
-                captchaProvider =
-                    CaptchaProviderImpl(
-                        context.applicationContext as Application,
-                        externalScope,
-                        bootstrapData.captchaSettings.siteKey,
+            externalScope.launch(dispatchers.io) {
+                storageHelperInitializationJob.join()
+                val bootstrapJob = refreshBootstrapAndApi(true)
+                val sessionRehydrationJob = client.rehydrateSession()
+                listOf(bootstrapJob, sessionRehydrationJob).joinAll()
+                client.logEvent("client_initialization_success", null, null)
+
+                val potentialErrors = listOf(bootstrapError, sessionHydrationError).mapNotNull { it }
+                if (potentialErrors.isNotEmpty()) {
+                    isInitialized.value = InitializationStatus.Failure(potentialErrors)
+                } else {
+                    isInitialized.value = InitializationStatus.Success
+                }
+                emitAnalyticsEvent(
+                    ConfigurationAnalyticsEvent(
+                        step = ConfigurationStep.IS_INITIALIZED,
+                        duration = Date().time - configurationStartTime,
                     ),
-                dfpProtectedAuthEnabled = bootstrapData.dfpProtectedAuthEnabled,
-                dfpProtectedAuthMode = bootstrapData.dfpProtectedAuthMode ?: DFPProtectedAuthMode.OBSERVATION,
-            )
-        client.commonApi.configure(
-            publicToken,
-            deviceInfo,
-            options.endpointOptions,
-            client::getSessionToken,
-            dfpConfiguration,
-        )
-        externalScope.launch(dispatchers.io) {
-            storageHelperInitializationJob.join()
-            val bootstrapJob = refreshBootstrapAndApi(true)
-            val sessionRehydrationJob = client.rehydrateSession()
-            listOf(bootstrapJob, sessionRehydrationJob).joinAll()
-            client.logEvent("client_initialization_success", null, null)
-            isInitialized.value = true
-            emitAnalyticsEvent(
-                ConfigurationAnalyticsEvent(
-                    step = ConfigurationStep.IS_INITIALIZED,
-                    duration = Date().time - configurationStartTime,
-                ),
-            )
-            client.onFinishedInitialization()
-        }
-        NetworkChangeListener.configure(context.applicationContext) {
-            refreshBootstrapAndApi()
-            client.rehydrateSession()
-        }
-        AppLifecycleListener.configure {
-            refreshBootstrapAndApi()
-            client.rehydrateSession()
+                )
+                client.onFinishedInitialization(isInitialized.value)
+            }
+            NetworkChangeListener.configure(context.applicationContext) {
+                refreshBootstrapAndApi()
+                client.rehydrateSession()
+            }
+            AppLifecycleListener.configure {
+                refreshBootstrapAndApi()
+                client.rehydrateSession()
+            }
+        } catch (e: Exception) {
+            // if ANYTHING went wrong and is unaccounted for, report it
+            isInitialized.value = InitializationStatus.Failure(listOf(e))
         }
     }
 
@@ -161,14 +173,21 @@ internal class ConfigurationManager {
         }
 
     private var isRefreshingBootstrap = false
+    private var bootstrapError: Exception? = null
 
     suspend fun refreshBootstrapData() {
         if (isRefreshingBootstrap) return
         isRefreshingBootstrap = true
         bootstrapData =
             when (val res = client.commonApi.getBootstrapData()) {
-                is StytchResult.Success -> res.value
-                else -> bootstrapData
+                is StytchResult.Success -> {
+                    res.value
+                }
+
+                is StytchResult.Error -> {
+                    bootstrapError = res.exception
+                    bootstrapData
+                }
             }
         when {
             client.expectedVertical == Vertical.CONSUMER && bootstrapData.vertical == Vertical.B2B -> {
@@ -178,6 +197,7 @@ internal class ConfigurationManager {
                         "correct.",
                 )
             }
+
             client.expectedVertical == Vertical.B2B && bootstrapData.vertical == Vertical.CONSUMER -> {
                 StytchLog.e(
                     "This application is using a Stytch client for B2B projects, but the public token is for a " +

--- a/source/sdk/src/main/java/com/stytch/sdk/common/InitializationStatus.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/InitializationStatus.kt
@@ -1,0 +1,11 @@
+package com.stytch.sdk.common
+
+public sealed class InitializationStatus {
+    public data object Loading : InitializationStatus()
+
+    public data object Success : InitializationStatus()
+
+    public data class Failure(
+        val errors: List<Throwable>,
+    ) : InitializationStatus()
+}

--- a/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/common/StytchClientCommon.kt
@@ -22,7 +22,7 @@ internal interface StytchClientCommon {
         sessionDurationMinutes: Int?,
     )
 
-    var onFinishedInitialization: () -> Unit
+    var onFinishedInitialization: (InitializationStatus) -> Unit
 
     fun getSessionToken(): String?
 }

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -9,6 +9,7 @@ import com.stytch.sdk.common.ConfigurationStep
 import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeeplinkResponse
 import com.stytch.sdk.common.DeeplinkTokenPair
+import com.stytch.sdk.common.InitializationStatus
 import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.QUERY_TOKEN
 import com.stytch.sdk.common.QUERY_TOKEN_TYPE
@@ -17,6 +18,7 @@ import com.stytch.sdk.common.StytchClientCommon
 import com.stytch.sdk.common.StytchClientOptions
 import com.stytch.sdk.common.StytchLazyDelegate
 import com.stytch.sdk.common.StytchLog
+import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.dfp.DFP
 import com.stytch.sdk.common.dfp.DFPImpl
 import com.stytch.sdk.common.errors.StytchDeeplinkMissingTokenError
@@ -73,14 +75,13 @@ public object StytchClient {
      * the `configure()` method, to know when the Stytch SDK has been fully initialized and is ready for use
      */
     @JvmStatic
-    public val isInitialized: StateFlow<Boolean> = configurationManager.isInitialized.asStateFlow()
+    public val isInitialized: StateFlow<InitializationStatus> = configurationManager.isInitialized.asStateFlow()
 
     /**
      * This configures the API for authenticating requests and the encrypted storage helper for persisting session data
      * across app launches.
      * You must call this method before making any Stytch authentication requests.
      * @param context The applicationContext of your app
-     * @param callback An optional callback that is triggered after configuration and initialization has completed
      * @throws StytchInternalError - if we failed to initialize for any reason
      */
     @JvmStatic
@@ -102,7 +103,7 @@ public object StytchClient {
     public fun configure(
         context: Context,
         options: StytchClientOptions = StytchClientOptions(),
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
         configure(context, publicToken, options, callback)
@@ -119,7 +120,7 @@ public object StytchClient {
     @JvmStatic
     public fun configure(
         context: Context,
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         val publicToken = context.getString(R.string.STYTCH_PUBLIC_TOKEN)
         configure(context, publicToken, StytchClientOptions(), callback)
@@ -155,7 +156,7 @@ public object StytchClient {
     public fun configure(
         context: Context,
         publicToken: String,
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         configure(context, publicToken, StytchClientOptions(), callback)
     }
@@ -208,7 +209,7 @@ public object StytchClient {
         context: Context,
         publicToken: String,
         options: StytchClientOptions = StytchClientOptions(),
-        callback: ((Boolean) -> Unit) = {},
+        callback: ((InitializationStatus) -> Unit) = {},
     ) {
         // We must initialize the storagehelper/sessionstorage before configuration, because configuration kicks
         // off a task that relies on the storage being available (session hydration). HOWEVER, we don't want to handle
@@ -220,7 +221,6 @@ public object StytchClient {
                 StytchLog.w(
                     "StytchClient is already configured. You should only call configure once, at application start.",
                 )
-                return
             }
             val storageHelperInitializationJob = StorageHelper.initialize(context)
             sessionStorage =
@@ -229,7 +229,7 @@ public object StytchClient {
                 client =
                     StytchClientCommonConfiguration {
                         sessionStorage.emitCurrent()
-                        callback(true)
+                        callback(it)
                     },
                 context = context,
                 publicToken = publicToken,
@@ -486,6 +486,7 @@ public object StytchClient {
                         ),
                     )
                 }
+
                 ConsumerTokenType.OAUTH -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.Handled(
@@ -494,10 +495,12 @@ public object StytchClient {
                         ),
                     )
                 }
+
                 ConsumerTokenType.RESET_PASSWORD -> {
                     events.logEvent("deeplink_handled_success", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.ManualHandlingRequired(type = ConsumerTokenType.RESET_PASSWORD, token = token)
                 }
+
                 else -> {
                     events.logEvent("deeplink_handled_failure", details = mapOf("token_type" to tokenType))
                     DeeplinkHandledStatus.NotHandled(StytchDeeplinkUnkownTokenTypeError())
@@ -574,7 +577,7 @@ public object StytchClient {
         get() = sessionStorage.lastAuthMethodUsed
 
     private class StytchClientCommonConfiguration(
-        override var onFinishedInitialization: () -> Unit,
+        override var onFinishedInitialization: (InitializationStatus) -> Unit,
     ) : StytchClientCommon {
         override val commonApi: CommonApi = StytchApi
 
@@ -602,6 +605,11 @@ public object StytchClient {
                                 },
                             ),
                         ).apply {
+                            if (this is StytchResult.Error) {
+                                configurationManager.sessionHydrationError = this.exception
+                            } else {
+                                configurationManager.sessionHydrationError = null
+                            }
                             configurationManager.emitAnalyticsEvent(
                                 ConfigurationAnalyticsEvent(
                                     step = ConfigurationStep.SESSION_HYDRATION,

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationActivity.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2b/B2BAuthenticationActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import com.stytch.sdk.b2b.StytchB2BClient
+import com.stytch.sdk.common.InitializationStatus
 import com.stytch.sdk.common.errors.StytchUIInvalidConfiguration
 import com.stytch.sdk.ui.b2b.data.AuthFlowType
 import com.stytch.sdk.ui.b2b.data.AuthenticationResult
@@ -38,7 +39,7 @@ internal class B2BAuthenticationActivity : ComponentActivity() {
                 )
                 return@onCreate
             }
-        if (StytchB2BClient.isInitialized.value) {
+        if (StytchB2BClient.isInitialized.value == InitializationStatus.Success) {
             StytchB2BClient.events.logEvent(
                 eventName = "render_b2b_login_screen",
                 details =
@@ -110,15 +111,19 @@ internal class B2BAuthenticationActivity : ComponentActivity() {
     }
 
     private fun returnAuthenticationResult(result: AuthenticationResult) {
-        if (StytchB2BClient.isInitialized.value) {
+        if (StytchB2BClient.isInitialized.value == InitializationStatus.Success) {
             when (result) {
-                is AuthenticationResult.Authenticated -> StytchB2BClient.events.logEvent("ui_authentication_success")
-                is AuthenticationResult.Error ->
+                is AuthenticationResult.Authenticated -> {
+                    StytchB2BClient.events.logEvent("ui_authentication_success")
+                }
+
+                is AuthenticationResult.Error -> {
                     StytchB2BClient.events.logEvent(
                         eventName = "ui_authentication_failure",
                         details = null,
                         error = result.error,
                     )
+                }
             }
         }
         val data =

--- a/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationActivity.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/ui/b2c/AuthenticationActivity.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import cafe.adriel.voyager.androidx.AndroidScreen
+import com.stytch.sdk.common.InitializationStatus
 import com.stytch.sdk.common.StytchObjectInfo
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.errors.StytchUIInvalidConfiguration
@@ -42,7 +43,7 @@ internal class AuthenticationActivity : FragmentActivity() {
                 StytchClient.biometrics.areBiometricsAvailable(this) == AvailableNoRegistrations,
         )
         // log render_login_screen
-        if (StytchClient.isInitialized.value) {
+        if (StytchClient.isInitialized.value == InitializationStatus.Success) {
             StytchClient.events.logEvent(
                 eventName = "render_login_screen",
                 details =
@@ -113,15 +114,19 @@ internal class AuthenticationActivity : FragmentActivity() {
         ) {
             renderApplicationAtScreen(BiometricRegistrationScreen(result))
         } else {
-            if (StytchClient.isInitialized.value) {
+            if (StytchClient.isInitialized.value == InitializationStatus.Success) {
                 when (result) {
-                    is StytchResult.Success -> StytchClient.events.logEvent("ui_authentication_success")
-                    is StytchResult.Error ->
+                    is StytchResult.Success -> {
+                        StytchClient.events.logEvent("ui_authentication_success")
+                    }
+
+                    is StytchResult.Error -> {
                         StytchClient.events.logEvent(
                             eventName = "ui_authentication_failure",
                             details = null,
                             error = result.exception,
                         )
+                    }
                 }
             }
             val data =
@@ -145,10 +150,11 @@ internal class AuthenticationActivity : FragmentActivity() {
     ) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
-            STYTCH_THIRD_PARTY_OAUTH_REQUEST_ID ->
+            STYTCH_THIRD_PARTY_OAUTH_REQUEST_ID -> {
                 data?.let {
                     viewModel.authenticateThirdPartyOAuth(resultCode, it, uiConfig.productConfig.sessionOptions)
                 }
+            }
         }
     }
 

--- a/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -16,6 +16,7 @@ import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.EndpointOptions
+import com.stytch.sdk.common.InitializationStatus
 import com.stytch.sdk.common.NetworkChangeListener
 import com.stytch.sdk.common.PKCECodePair
 import com.stytch.sdk.common.StorageHelper
@@ -240,13 +241,13 @@ internal class StytchB2BClientTest {
                     every { launchSessionUpdater(any(), any()) } just runs
                 }
             coEvery { StytchB2BApi.Sessions.authenticate(any()) } returns mockResponse
-            val callback = spyk<(Boolean) -> Unit>()
+            val callback = spyk<(InitializationStatus) -> Unit>()
             StytchB2BClient.sessionStorage = B2BSessionStorage(StorageHelper)
             StytchB2BClient.configure(mContextMock, UUID.randomUUID().toString(), StytchClientOptions(), callback)
             // callback is called with expected value
-            verify(exactly = 1) { callback(true) }
+            verify(exactly = 1) { callback(any()) }
             // isInitialized has fired
-            assert(StytchB2BClient.isInitialized.value)
+            assert(StytchB2BClient.isInitialized.value != InitializationStatus.Loading)
         }
     }
 
@@ -260,17 +261,6 @@ internal class StytchB2BClientTest {
     }
 
     @Test
-    fun `calling StytchB2BClient configure with the same public token and no options short circuits`() {
-        val deviceInfo = DeviceInfo()
-        val stytchClientObject = spyk<StytchB2BClient>(recordPrivateCalls = true)
-        every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(mContextMock, "publicToken")
-        stytchClientObject.configure(mContextMock, "publicToken")
-        stytchClientObject.configure(mContextMock, "publicToken")
-        verify(exactly = 1) { mContextMock.getDeviceInfo() }
-    }
-
-    @Test
     fun `calling StytchB2BClient configure with different public tokens and no options doesn't short circuit`() {
         val deviceInfo = DeviceInfo()
         val stytchClientObject = spyk<StytchB2BClient>(recordPrivateCalls = true)
@@ -279,29 +269,6 @@ internal class StytchB2BClientTest {
         stytchClientObject.configure(mContextMock, "publicToken2")
         stytchClientObject.configure(mContextMock, "publicToken3")
         verify(exactly = 3) { mContextMock.getDeviceInfo() }
-    }
-
-    @Test
-    fun `calling StytchB2BClient configure with the same public token and the same options short circuits`() {
-        val deviceInfo = DeviceInfo()
-        val stytchClientObject = spyk<StytchB2BClient>(recordPrivateCalls = true)
-        every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(
-            mContextMock,
-            "publicToken",
-            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
-        )
-        stytchClientObject.configure(
-            mContextMock,
-            "publicToken",
-            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
-        )
-        stytchClientObject.configure(
-            mContextMock,
-            "publicToken",
-            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
-        )
-        verify(exactly = 1) { mContextMock.getDeviceInfo() }
     }
 
     @Test

--- a/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/source/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -11,6 +11,7 @@ import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.EndpointOptions
+import com.stytch.sdk.common.InitializationStatus
 import com.stytch.sdk.common.NetworkChangeListener
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchClientOptions
@@ -238,13 +239,13 @@ internal class StytchClientTest {
                     every { launchSessionUpdater(any(), any()) } just runs
                 }
             coEvery { StytchApi.Sessions.authenticate(any()) } returns mockResponse
-            val callback = spyk<(Boolean) -> Unit>()
+            val callback = spyk<(InitializationStatus) -> Unit>()
             StytchClient.sessionStorage = ConsumerSessionStorage(StorageHelper)
             StytchClient.configure(mContextMock, UUID.randomUUID().toString(), StytchClientOptions(), callback)
             // callback is called with expected value
-            verify(exactly = 1) { callback(true) }
+            verify(exactly = 1) { callback(any()) }
             // isInitialized has fired
-            assert(StytchClient.isInitialized.value)
+            assert(StytchClient.isInitialized.value != InitializationStatus.Loading)
         }
     }
 
@@ -258,17 +259,6 @@ internal class StytchClientTest {
     }
 
     @Test
-    fun `calling StytchClient configure with the same public token and no options short circuits`() {
-        val deviceInfo = DeviceInfo()
-        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
-        every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(mContextMock, "publicToken")
-        stytchClientObject.configure(mContextMock, "publicToken")
-        stytchClientObject.configure(mContextMock, "publicToken")
-        verify(exactly = 1) { mContextMock.getDeviceInfo() }
-    }
-
-    @Test
     fun `calling StytchClient configure with different public tokens and no options doesn't short circuit`() {
         val deviceInfo = DeviceInfo()
         val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
@@ -277,29 +267,6 @@ internal class StytchClientTest {
         stytchClientObject.configure(mContextMock, "publicToken2")
         stytchClientObject.configure(mContextMock, "publicToken3")
         verify(exactly = 3) { mContextMock.getDeviceInfo() }
-    }
-
-    @Test
-    fun `calling StytchClient configure with the same public token and the same options short circuits`() {
-        val deviceInfo = DeviceInfo()
-        val stytchClientObject = spyk<StytchClient>(recordPrivateCalls = true)
-        every { mContextMock.getDeviceInfo() } returns deviceInfo
-        stytchClientObject.configure(
-            mContextMock,
-            "publicToken",
-            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
-        )
-        stytchClientObject.configure(
-            mContextMock,
-            "publicToken",
-            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
-        )
-        stytchClientObject.configure(
-            mContextMock,
-            "publicToken",
-            StytchClientOptions(EndpointOptions("dfppa-domain.com")),
-        )
-        verify(exactly = 1) { mContextMock.getDeviceInfo() }
     }
 
     @Test


### PR DESCRIPTION
## Changes:

1. Instead of just reporting "true" when configuration has finished, return a new `InitializationStatus` class that gives visibility into if it was completely successful, or if there were any errors. In the case of errors, we silently allow them and fallback to default values. This way, developers _know_ if something went wrong.
2. Previously, we rejected multiple attempts to configure the Stytch client (because it's a heavy operation). However, if something went wrong, a developer might want to retry, so we let them. Keep the warning, though, because it's still true
3. Updates tests as appropriate (no more short circuit tests)

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A