### PR TITLE
Handle UserNotAuthenticatedException

### DIFF
--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.64.0"
+val publishVersion = "0.65.0"
 val publishArtifactId = "sdk"
 
 android {

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricAvailability.kt
@@ -67,20 +67,33 @@ public sealed class BiometricAvailability {
             fun fromReason(reason: Int) =
                 Unavailable(
                     when (reason) {
-                        BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
+                        BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> {
                             Reason.BIOMETRIC_ERROR_NO_HARDWARE
-                        BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE ->
+                        }
+
+                        BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> {
                             Reason.BIOMETRIC_ERROR_HW_UNAVAILABLE
-                        BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+                        }
+
+                        BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
                             Reason.BIOMETRIC_ERROR_NONE_ENROLLED
-                        BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+                        }
+
+                        BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> {
                             Reason.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED
-                        BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED ->
+                        }
+
+                        BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> {
                             Reason.BIOMETRIC_ERROR_UNSUPPORTED
-                        BiometricManager.BIOMETRIC_STATUS_UNKNOWN ->
+                        }
+
+                        BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> {
                             Reason.BIOMETRIC_STATUS_UNKNOWN
-                        else ->
+                        }
+
+                        else -> {
                             Reason.BIOMETRIC_STATUS_UNKNOWN
+                        }
                     },
                 )
         }
@@ -92,6 +105,12 @@ public sealed class BiometricAvailability {
      */
 
     @JacocoExcludeGenerated public data object RegistrationRevoked : BiometricAvailability()
+
+    /**
+     * Indicates that a cryptographic operation could not be performed because the user has not been
+     * authenticated recently enough. Authenticating the user will resolve this issue.
+     */
+    @JacocoExcludeGenerated public data object UserAuthenticationRequired : BiometricAvailability()
 
     /**
      * Status indicating that biometrics are available, but no registrations have been made yet

--- a/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
+++ b/source/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/BiometricsImpl.kt
@@ -2,6 +2,7 @@ package com.stytch.sdk.consumer.biometrics
 
 import android.os.Build
 import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.UserNotAuthenticatedException
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
@@ -31,6 +32,7 @@ import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.security.InvalidAlgorithmParameterException
+import java.security.InvalidKeyException
 import java.util.concurrent.CompletableFuture
 
 internal const val LAST_USED_BIOMETRIC_REGISTRATION_ID = "last_used_biometric_registration_id"
@@ -78,7 +80,13 @@ internal class BiometricsImpl internal constructor(
         var errorEncounteredWhenGeneratingKey = false
         try {
             biometricsProvider.ensureSecretKeyIsAvailable(allowedAuthenticators)
-        } catch (_: KeyPermanentlyInvalidatedException) {
+        } catch (_: UserNotAuthenticatedException) {
+            // Indicates that a cryptographic operation could not be performed because the user has not been
+            // authenticated recently enough. Authenticating the user will resolve this issue.
+            return BiometricAvailability.UserAuthenticationRequired
+        } catch (_: InvalidKeyException) {
+            // This covers all other instances of invalid keys, where a registration WAS available
+            // but the key is not valid, so we should revoke the registration and have them re-register
             externalScope.launch(dispatchers.io) {
                 removeRegistration()
             }
@@ -104,7 +112,10 @@ internal class BiometricsImpl internal constructor(
                     false -> BiometricAvailability.AvailableNoRegistrations
                 }
             }
-            else -> BiometricAvailability.Unavailable.fromReason(result)
+
+            else -> {
+                BiometricAvailability.Unavailable.fromReason(result)
+            }
         }
     }
 
@@ -121,7 +132,10 @@ internal class BiometricsImpl internal constructor(
                     removeLocalRegistrationOnly()
                     true
                 }
-                else -> false
+
+                else -> {
+                    false
+                }
             }
         }
 


### PR DESCRIPTION
Linear Ticket: None

## Changes:

1. Handle `UserNotAuthenticatedException` explicitly by returning a new availability status
2. Handle all _other_ `InvalidKeyException` the way we have been

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A