### PR TITLE
chore: migrate GitHub runners to ubuntu-latest-public

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
     check:
         name: Check versions and tags
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-public
         outputs:
             tag_exists: ${{ steps.tags.outputs.tag_exists }}
             this_version: ${{ steps.version.outputs.this_version }}
@@ -43,7 +43,7 @@ jobs:
         name: Release build and publish
         needs: check
         if: needs.check.outputs.tag_exists == 'false'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-public
         steps:
           - uses: actions/checkout@v3
           - uses: actions/setup-java@v3
@@ -68,7 +68,7 @@ jobs:
               JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
     tag-and-release:
         name: Create tag and release
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-public
         needs: check
         if: needs.check.outputs.tag_exists == 'false'
         steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     timeout-minutes: 60
     permissions:
       actions: read

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-submission:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Release build and publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
 jobs:
   gradle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/uiTests.yml
+++ b/.github/workflows/uiTests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/versionedDocs.yml
+++ b/.github/workflows/versionedDocs.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
     - uses: actions/checkout@v3
       with:
@@ -40,7 +40,7 @@ jobs:
         path: Docs.zip
   publish:
     needs: [docs]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Migrates all `ubuntu-latest` runner references to `ubuntu-latest-public` (org-scoped GitHub-hosted runner group).