### PR TITLE
Bump SDK to include stytch android DFP v1.2.0 - (v0.66.0)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ ktlint = "13.1.0"
 detekt = "1.23.6"
 ksp = "2.1.0-1.0.29"
 kotlinCompilerExtension="1.5.15"
-stytchDfp="1.1.2"
+stytchDfp="1.2.0"
 leakCanary = "2.14"
 
 [libraries]

--- a/source/sdk/build.gradle.kts
+++ b/source/sdk/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 val publishGroupId = "com.stytch.sdk"
-val publishVersion = "0.65.1"
+val publishVersion = "0.66.0"
 val publishArtifactId = "sdk"
 
 android {


### PR DESCRIPTION
Linear Ticket: [WFP-185](ilio-engineering.atlassian.net/browse/WFP-185)

## Changes:

1. This PR bumps the Stytch SDK to include the latest Android DFP SDK (v1.2.0) which fixes some crash issues reported by SoLo funds

## Notes:

- 

## Checklist:
- [*] I have verified that this change works in the relevant demo app, or N/A